### PR TITLE
Temporarily disabled due to unresolved "Transport closed" errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ clients to drive Common Lisp development via MCP.
 - MCP initialize handshake with capability discovery
 - Tools API
   - `repl-eval` — evaluate forms
-  - `asdf-system-info` / `asdf-list-systems` — inspect registered ASDF systems and dependencies
   - `fs-read-file` / `fs-write-file` / `fs-list-directory` — project-scoped file access with allow‑list
   - `fs-get-project-info` — report project root and cwd info for path normalization
   - `fs-set-project-root` — set the server's project root and working directory
@@ -112,6 +111,10 @@ Response (excerpt):
 {"result":{"content":[{"type":"text","text":"3"}]}}
 ```
 
+### ASDF tools (disabled)
+`asdf-system-info` and `asdf-list-systems` are temporarily disabled.
+
+<!--
 ### `asdf-system-info`
 Return detailed information about an ASDF system, including dependencies and source locations.
 
@@ -138,6 +141,7 @@ List all registered ASDF systems (may be large).
 Input: none
 
 Output: array of lower-case system names.
+-->
 
 ### `fs-read-file`
 Read text from an allow‑listed path.

--- a/main.lisp
+++ b/main.lisp
@@ -14,9 +14,6 @@
                 #:fs-list-directory
                 #:fs-get-project-info
                 #:*project-root*)
-  (:import-from #:cl-mcp/src/asdf-tools
-                #:asdf-system-info
-                #:asdf-list-systems)
   (:import-from #:cl-mcp/src/lisp-edit-form
                 #:lisp-edit-form)
   (:import-from #:cl-mcp/src/lisp-read-file
@@ -54,9 +51,6 @@
            #:*project-root*
            #:lisp-edit-form
            #:lisp-check-parens
-           ;; ASDF tools
-           #:asdf-system-info
-           #:asdf-list-systems
            ;; Code intelligence
            #:code-find-definition
            #:code-describe-symbol

--- a/prompts/repl-driven-development.md
+++ b/prompts/repl-driven-development.md
@@ -145,15 +145,7 @@ Use `repl-eval` for:
   ```json
   {"code": "(ql:quickload :my-system)", "package": "CL-USER"}
   ```
-- **Inspect ASDF system metadata/dependencies:** Prefer the dedicated tool:
-  ```json
-  {"name": "asdf-system-info", "arguments": {"system_name": "my-system"}}
-  ```
-  This returns `depends_on`, `defsystem_depends_on`, `source_file`, `source_directory`, and `loaded`.
-- **List registered systems:** Prefer the dedicated tool (output may be large):
-  ```json
-  {"name": "asdf-list-systems", "arguments": {}}
-  ```
+- **Inspect ASDF system metadata/dependencies:** Use `repl-eval` (the dedicated ASDF tools are currently disabled):
 - **Fallback:** If you need raw ASDF state, use `repl-eval`:
   ```json
   {"code": "(asdf:registered-systems)", "package": "CL-USER"}

--- a/src/protocol.lisp
+++ b/src/protocol.lisp
@@ -12,9 +12,6 @@
                 #:lisp-edit-form)
   (:import-from #:cl-mcp/src/lisp-read-file
                 #:lisp-read-file)
-  (:import-from #:cl-mcp/src/asdf-tools
-                #:asdf-system-info
-                #:asdf-list-systems)
   (:shadowing-import-from #:cl-mcp/src/code
                           #:code-find-references)
   (:import-from #:cl-mcp/src/code
@@ -166,6 +163,8 @@ there"))
 
 
 
+;; Temporarily disabled: asdf-system-info
+#+nil
 (defun tools-descriptor-asdf-system-info ()
   (%make-ht
    "name" "asdf-system-info"
@@ -186,6 +185,8 @@ there"))
 
 
 
+;; Temporarily disabled: asdf-list-systems
+#+nil
 (defun tools-descriptor-asdf-list-systems ()
   (%make-ht
    "name" "asdf-list-systems"
@@ -444,8 +445,8 @@ ALWAYS use this tool instead of 'fs-write-file' when modifying Lisp forms to ens
 (defun handle-tools-list (id)
   (let* ((tools
           (vector (tools-descriptor-repl)
-                  (tools-descriptor-asdf-system-info)
-                  (tools-descriptor-asdf-list-systems)
+                  #+nil(tools-descriptor-asdf-system-info)
+                  #+nil(tools-descriptor-asdf-list-systems)
                   (tools-descriptor-fs-read)
                   (tools-descriptor-fs-write)
                   (tools-descriptor-fs-list)
@@ -468,11 +469,27 @@ Returns a downcased local tool name (string)."
          (idx (max (or dot -1) (or sl -1))))
     (subseq s (1+ idx))))
 
+(defun handle-asdf-tools-call (id params)
+  ;; TODO: Temporarily disabled due to unresolved "Transport closed" errors.
+  ;;
+  ;; Issue:
+  ;; Executing this tool causes the MCP client to disconnect with "Transport closed"
+  ;; or timeout, even though the server logs show immediate and successful JSON response
+  ;; transmission.
+  ;;
+  ;; Investigation Status:
+  ;; 1. ASDF Output: Stdout noise is already suppressed via `with-silenced-output`.
+  ;; 2. TCP Timeout: Keep-alive logic is implemented; server does not close the socket.
+  ;; 3. Server Logs: Show `rpc.result` and `tcp.flushed` occurring immediately.
+  "Handle ASDF-related tool calls.
+Returns a JSON-RPC response hash-table when handled, or NIL to defer."
+  (declare (ignore id params))
+  nil)
 
-
+#+nil
 (defun handle-asdf-tools-call (id params)
   "Handle ASDF-related tool calls.
-Returns a JSON-RPC response hash-table when handled, or NIL to defer." 
+Returns a JSON-RPC response hash-table when handled, or NIL to defer."
   (let* ((name (and params (gethash "name" params)))
          (args (and params (gethash "arguments" params)))
          (local (and name (%normalize-tool-name name))))

--- a/tests.lisp
+++ b/tests.lisp
@@ -2,7 +2,7 @@
   (:use #:cl)
   (:import-from #:rove)
   (:import-from #:cl-mcp/tests/bridge-test)
-  (:import-from #:cl-mcp/tests/asdf-tools-test)
+  #+nil(:import-from #:cl-mcp/tests/asdf-tools-test)
   (:import-from #:cl-mcp/tests/code-test)
   (:import-from #:cl-mcp/tests/core-test)
   (:import-from #:cl-mcp/tests/fs-test)


### PR DESCRIPTION
;; TODO: Temporarily disabled due to unresolved "Transport closed" errors.
;;
;; Issue:
;; Executing this tool causes the MCP client to disconnect with "Transport closed"
;; or timeout, even though the server logs show immediate and successful JSON response
;; transmission.
;;
;; Investigation Status:
;; 1. ASDF Output: Stdout noise is already suppressed via `with-silenced-output`.
;; 2. TCP Timeout: Keep-alive logic is implemented; server does not close the socket.
;; 3. Server Logs: Show `rpc.result` and `tcp.flushed` occurring immediately.