### PR TITLE
Fix protocolVersion 2025-11-25 degrade

### DIFF
--- a/src/protocol.lisp
+++ b/src/protocol.lisp
@@ -645,8 +645,8 @@ Returns a JSON-RPC response hash-table when handled, or NIL to defer."
       (%error id -32603
               (format nil "Internal error during lisp-read-file: ~A" e)))))
 
-(defun handle-tool-fs-get-project-info (state id)
-  (declare (ignore state))
+(defun handle-tool-fs-get-project-info (state id args)
+  (declare (ignore state args))
   (handler-case
       (let* ((info (fs-get-project-info))
              (summary (format nil "Project root: ~A~%CWD: ~A~%Source: ~A"


### PR DESCRIPTION
## Fix fs-get-project-info handler signature and add protocol-level test

  The handle-tool-fs-get-project-info function was missing the 'args'
  parameter in its signature. This regression was introduced in commit
  74c0461 when adding MCP protocol 2025-11-25 support - the dispatcher
  was changed to call handlers with (state id args), but this handler
  was only updated to (state id), causing a runtime error.

  Changes:
  - Add missing 'args' parameter to handle-tool-fs-get-project-info
  - Add protocol-level test for fs-get-project-info in tools-test.lisp
  - Add with-test-project-root macro to tools-test.lisp for proper
    project root setup in protocol-level FS tests