### PR TITLE
Fix eclector.parse-result system not found error

### DIFF
--- a/cl-mcp.asd
+++ b/cl-mcp.asd
@@ -1,5 +1,9 @@
 ;;;; cl-mcp.asd
 
+;; Tell ASDF that eclector.parse-result package is provided by eclector
+(asdf:register-system-packages "eclector"
+                               '(:eclector.parse-result))
+
 (asdf:defsystem "cl-mcp"
   :class :package-inferred-system
   :description "Model Context Protocol server for Common Lisp"


### PR DESCRIPTION
## Problem

cl-mcp fails to load with:
```
System "eclector.parse-result" not found
```

## Cause

`src/cst.lisp` imports from `#:eclector.parse-result`. ASDF's package-inferred-system sees this and looks for a system named `eclector.parse-result`, but no such system exists - the package is provided by the base `eclector` system.

## Fix

Register the package mapping before the defsystem:
```lisp
(asdf:register-system-packages "eclector"
                               '(:eclector.parse-result))
```

This tells ASDF which system provides the package.

## Testing

- System loads without error in SBCL
- Server starts successfully