### PR TITLE
docs: clarify package-inferred-system test registration

### DIFF
--- a/contract.yml
+++ b/contract.yml
@@ -88,10 +88,28 @@ validation:
               (ok (stringp (version)))))
           ```
 
+          📦 Package-Inferred System Registration:
+          This project uses ASDF's `package-inferred-system`. To register new test files:
+
+          1. Add `:import-from` to `tests.lisp`:
+             ```lisp
+             (defpackage #:cl-mcp/tests
+               ...
+               (:import-from #:cl-mcp/tests/new-module-test))
+             ```
+          2. That's it! No changes to `.asd` files are required.
+
+          ASDF automatically infers dependencies from `:import-from` declarations.
+          The test system `cl-mcp/tests` loads all imported test packages.
+
+          ❌ WRONG: Editing cl-mcp.asd to add test dependencies manually
+          ✅ CORRECT: Adding `:import-from` to tests.lisp
+
           ⚠️ CRITICAL:
           - Do not use `cl-test` or `fiveam`; use `rove`.
           - Ensure tests do not leave background threads running (cleanup with `unwind-protect`).
           - Tests must be runnable via `(asdf:test-system "cl-mcp")`.
+          - Verify new test files are imported in `tests.lisp`.
 
       - name: security_and_safety
         prompt: |


### PR DESCRIPTION
## Summary
- Add package-inferred-system explanation to `testing_standards` rule in contract.yml
- Clarify that adding `:import-from` to `tests.lisp` is the correct way to register new test files
- Explicitly note that `.asd` file modifications are NOT required

## Background
PR #38 received a false positive from code-contractor-app claiming that new test files were not registered because the `.asd` file was not modified. However, this project uses ASDF's `package-inferred-system`, where dependencies are automatically inferred from `:import-from` declarations.

## Changes
| Before | After |
|--------|-------|
| No mention of package-inferred-system | Explains the system with examples |
| AI may expect `.asd` changes | Explicitly states `.asd` changes are WRONG |
| No guidance on `tests.lisp` | Shows correct `:import-from` pattern |

## Test plan
- [x] YAML syntax is valid
- [x] Rule is clear and unambiguous