### PR TITLE
refactor: Extract fd-count and remove redundant normalize-path wrappers

### DIFF
--- a/src/code.lisp
+++ b/src/code.lisp
@@ -90,11 +90,6 @@ Returns NIL when the file cannot be read."
                    "error" (princ-to-string e))
         nil))))
 
-(defun %normalize-path (pathname)
-  "Return a namestring, relative to *project-root* when possible.
-Delegates to normalize-path-for-display from paths module."
-  (normalize-path-for-display pathname))
-
 (declaim (ftype (function (string &key (:package (or null package symbol string)))
                           (values (or null string) (or null integer) &optional))
                 code-find-definition))
@@ -117,7 +112,7 @@ Values are PATH (string) and LINE (integer), or NILs when not found."
         (let* ((pathname (funcall path-fn source))
                (char-offset (and offset (funcall offset source)))
                (line (%offset->line pathname char-offset))
-               (path (%normalize-path pathname)))
+               (path (normalize-path-for-display pathname)))
           (return-from code-find-definition (values path line))))
       (log-event :warn "code.find.not-found" "symbol" symbol-name)
       (values nil nil))
@@ -196,7 +191,7 @@ Returns T for any path when *project-root* is not set."
   (let* ((pathname (and path-fn (funcall path-fn source)))
          (char-offset (and offset-fn (funcall offset-fn source)))
          (line (%offset->line pathname char-offset))
-         (path (%normalize-path pathname)))
+         (path (normalize-path-for-display pathname)))
     (values pathname path (or line (and pathname char-offset 1)))))
 
 (defun %finder->type (name)

--- a/src/fs.lisp
+++ b/src/fs.lisp
@@ -13,6 +13,8 @@
                 #:ensure-project-root
                 #:allowed-read-path-p
                 #:ensure-write-path)
+  (:import-from #:cl-mcp/src/utils/system
+                #:fd-count)
   (:import-from #:uiop
                 #:ensure-directory-pathname
                 #:getenv
@@ -40,9 +42,6 @@
 (defparameter *skip-extensions* '("fasl" "ufasl" "x86f" "cfasl"))
 (defparameter *fs-read-max-bytes* 1048576
   "Maximum number of characters allowed for fs-read-file when LIMIT is provided.")
-
-(defun %fd-count ()
-  (ignore-errors (length (directory #P"/proc/self/fd/*"))))
 
 (defun %read-file-string (pn offset limit)
   "Read file PN honoring OFFSET and LIMIT (both may be NIL)."
@@ -81,11 +80,11 @@ Returns the content string."
                "path" (namestring pn)
                "offset" offset
                "limit" limit
-               "fd" (%fd-count))
+               "fd" (fd-count))
     (let ((text (%read-file-string pn offset limit)))
       (log-event :debug "fs.read.close"
                  "path" (namestring pn)
-                 "fd" (%fd-count))
+                 "fd" (fd-count))
       text)))
 
 (defun %write-string-to-file (pn content)
@@ -106,12 +105,12 @@ Returns T on success."
     (log-event :debug "fs.write.open"
                "path" (namestring pn)
                "bytes" (length content)
-               "fd" (%fd-count))
+               "fd" (fd-count))
     (unwind-protect
          (%write-string-to-file pn content)
       (log-event :debug "fs.write.close"
                  "path" (namestring pn)
-                 "fd" (%fd-count)))))
+                 "fd" (fd-count)))))
 
 (defun %entry-name (path)
   "Return display name for PATH, trimming trailing slash on directories."

--- a/src/lisp-read-file.lisp
+++ b/src/lisp-read-file.lisp
@@ -58,11 +58,6 @@
       (error "Pattern must be a string or NIL"))
     (create-scanner pattern)))
 
-(defun %normalize-path (pathname)
-  "Return a display-friendly path, relative to project root when possible."
-  (normalize-path-for-display pathname))
-
-
 (defun %docstring-first-line (string)
   (when (stringp string)
     (let* ((pos (or (position #\Newline string) (length string)))
@@ -375,7 +370,7 @@ Returns a hash-table payload with keys \"content\", \"path\", \"mode\", and \"me
                                  :readtable readtable)
       (let ((payload (make-hash-table :test #'equal)))
         (setf (gethash "content" payload) content
-              (gethash "path" payload) (%normalize-path resolved)
+              (gethash "path" payload) (normalize-path-for-display resolved)
               (gethash "mode" payload) mode
               (gethash "meta" payload) meta)
         payload))))

--- a/src/tcp.lisp
+++ b/src/tcp.lisp
@@ -4,6 +4,8 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:import-from #:cl-mcp/src/protocol #:make-state #:process-json-line)
+  (:import-from #:cl-mcp/src/utils/system
+                #:fd-count)
   (:import-from #:bordeaux-threads #:thread-alive-p #:make-thread #:destroy-thread #:join-thread)
   (:import-from #:usocket)
   (:export
@@ -40,9 +42,6 @@ Does not disconnect on timeout to allow idle clients (e.g. AI agents thinking)."
 
 (defparameter *tcp-conn-counter* 0
   "Monotonic counter used to tag connections in logs.")
-
-(defun %fd-count ()
-  (ignore-errors (length (directory #P"/proc/self/fd/*"))))
 
 (defun tcp-server-running-p ()
   "Return T when a background TCP server thread is alive."
@@ -196,7 +195,7 @@ successfully started, or NIL if the start attempt failed."
       (when client (ignore-errors (usocket:socket-close client)))
       (log-event :info "tcp.conn.closed"
                  "conn" conn-id
-                 "fd" (%fd-count)))))
+                 "fd" (fd-count)))))
 
 (defun %tcp-accept-loop (listener accept-once)
   (loop while (not *tcp-stop-flag*)

--- a/src/utils/system.lisp
+++ b/src/utils/system.lisp
@@ -1,0 +1,15 @@
+(defpackage #:cl-mcp/src/utils/system
+  (:use #:cl)
+  (:export #:fd-count))
+
+(in-package #:cl-mcp/src/utils/system)
+
+(declaim (ftype (function () (or null fixnum)) fd-count))
+
+(defun fd-count ()
+  "Return the count of open file descriptors for the current process.
+Returns NIL on non-Linux systems or when the count cannot be determined.
+
+This is a debugging utility useful for detecting file descriptor leaks.
+It works by counting entries in /proc/self/fd/ on Linux systems."
+  (ignore-errors (length (directory #P"/proc/self/fd/*"))))

--- a/tests.lisp
+++ b/tests.lisp
@@ -23,7 +23,8 @@
   (:import-from #:cl-mcp/tests/clgrep-test)
   (:import-from #:cl-mcp/tests/utils-strings-test)
   (:import-from #:cl-mcp/tests/utils-hash-test)
-  (:import-from #:cl-mcp/tests/utils-printing-test))
+  (:import-from #:cl-mcp/tests/utils-printing-test)
+  (:import-from #:cl-mcp/tests/utils-system-test))
 
 
 

--- a/tests/utils-system-test.lisp
+++ b/tests/utils-system-test.lisp
@@ -1,0 +1,29 @@
+(defpackage #:cl-mcp/tests/utils-system-test
+  (:use #:cl #:rove)
+  (:import-from #:cl-mcp/src/utils/system
+                #:fd-count))
+
+(in-package #:cl-mcp/tests/utils-system-test)
+
+(deftest fd-count-returns-nil-or-fixnum
+  (testing "fd-count returns NIL or a non-negative integer"
+    (let ((result (fd-count)))
+      (ok (or (null result)
+              (and (integerp result)
+                   (>= result 0)))))))
+
+(deftest fd-count-is-consistent
+  (testing "fd-count returns consistent results on consecutive calls"
+    (let ((first (fd-count))
+          (second (fd-count)))
+      ;; Both should have the same type (nil or integer)
+      (ok (eql (null first) (null second)))
+      ;; If both are integers, they should be close in value
+      (when (and first second)
+        (ok (<= (abs (- first second)) 5))))))
+
+(deftest fd-count-does-not-signal
+  (testing "fd-count never signals an error"
+    (ok (progn
+          (fd-count)
+          t))))


### PR DESCRIPTION
## Summary
- Create `src/utils/system.lisp` with `fd-count` utility
  - Extracted duplicate implementation from `fs.lisp` and `tcp.lisp`
  - Added type declaration for clear interface
- Remove redundant `%normalize-path` wrappers from `code.lisp` and `lisp-read-file.lisp`
  - These were just delegating to `normalize-path-for-display`
  - Callers now use `normalize-path-for-display` directly

## Test plan
- [x] New unit tests for `fd-count` (3 tests in utils-system-test.lisp)
- [x] fs-test passes (19 tests)
- [x] code-test passes (4 tests)
- [x] lisp-read-file-test passes (11 tests)
- [x] mallet lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)