### PR TITLE
refactor: Consolidate make-ht and make-string-hash-table

### DIFF
--- a/src/tools/helpers.lisp
+++ b/src/tools/helpers.lisp
@@ -5,6 +5,8 @@
 
 (defpackage #:cl-mcp/src/tools/helpers
   (:use #:cl)
+  (:import-from #:cl-mcp/src/utils/hash
+                #:make-string-hash-table)
   (:export #:make-ht
            #:result
            #:rpc-error
@@ -20,11 +22,9 @@
 
 (defun make-ht (&rest kvs)
   "Create a hash-table from alternating key-value pairs.
+This is an alias for make-string-hash-table from utils/hash.
 Example: (make-ht \"name\" \"foo\" \"type\" \"string\")"
-  (let ((h (make-hash-table :test #'equal)))
-    (loop for (k v) on kvs by #'cddr
-          do (setf (gethash k h) v))
-    h))
+  (apply #'make-string-hash-table kvs))
 
 (defun result (id payload)
   "Create a JSON-RPC 2.0 result response."


### PR DESCRIPTION
## Summary
- `make-ht` in `tools/helpers.lisp` now delegates to `make-string-hash-table` from `utils/hash.lisp`
- `utils/hash.lisp` is now the canonical implementation (lower-level utility layer)
- Eliminates duplicate identical implementations
- All 30+ existing usages of `make-ht` continue to work unchanged

## Test plan
- [x] utils-hash-test passes (9 tests)
- [x] tools-test passes (26 tests)
- [x] protocol-test passes (14 tests)
- [x] inspect-test passes (21 tests)
- [x] mallet lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)