### PR TITLE
Fix preview_max_depth nested expansion in inspect/repl preview

### DIFF
--- a/src/inspect.lisp
+++ b/src/inspect.lisp
@@ -74,10 +74,12 @@ VISITED-TABLE is used for circular reference detection."
   "Return representation of OBJECT, registering if inspectable.
 Returns either a primitive value representation or an object-ref."
   (if (inspectable-p object)
-      (if (and (> depth 0) (< depth max-depth))
-          ;; Recursively inspect nested objects
+      ;; DEPTH here is the parent depth. Expand nested objects only when the
+      ;; child depth (DEPTH + 1) is still below MAX-DEPTH and we have not
+      ;; already visited the object (to preserve circular-reference handling).
+      (if (and (< (1+ depth) max-depth)
+               (null (gethash object visited-table)))
           (%inspect-object-impl object visited-table (1+ depth) max-depth max-elements)
-          ;; Return object reference for deeper inspection
           (%make-object-ref object visited-table))
       (%primitive-value-repr object)))
 

--- a/tests/inspect-test.lisp
+++ b/tests/inspect-test.lisp
@@ -211,9 +211,9 @@
          (ok (string= "list" (ht-get result "kind")))
          ;; Inner list should be expanded at depth 2
          (let ((first-elem (first (ht-get result "elements"))))
-           ;; At depth 2, inner objects get expanded
-           (ok (or (string= "list" (ht-get first-elem "kind"))
-                   (string= "object-ref" (ht-get first-elem "kind"))))))))))
+           (ok (string= "list" (ht-get first-elem "kind"))
+               "max_depth=2 should expand first nested list")
+           (ok (= 2 (length (ht-get first-elem "elements"))))))))))
 
 (deftest inspect-multi-dimensional-array
   (testing "inspect 2D array"


### PR DESCRIPTION
## Summary
- Fix `%value-repr` depth handling so `preview_max_depth` actually changes nested preview expansion.
- Preserve circular reference behavior by avoiding recursive expansion for already-visited objects.
- Tighten `inspect-depth-expands-nested` to require actual expansion at `max-depth=2`.
- Add `tools-call-repl-eval-preview-max-depth` to verify MCP `tools/call repl-eval` depth=1 vs depth=2 behavior.

## Why
`preview_max_depth` did not produce visible differences for nested non-primitive values in `result_preview` (depth 1 and depth 3 both returned `object-ref`).

## Changes
- `src/inspect.lisp`
  - Update `%value-repr` recursion condition to use child depth and visited-state guard.
- `tests/inspect-test.lisp`
  - Make nested expansion assertion strict for `max-depth=2`.
- `tests/tools-test.lisp`
  - Add depth-difference integration test through `process-json-line` (`tools/call`).

## Validation
Executed in MCP REPL:
- `(rove:run-test 'cl-mcp/tests/inspect-test::inspect-depth-expands-nested)`
- `(rove:run-test 'cl-mcp/tests/inspect-test::inspect-self-referential-instance)`
- `(rove:run-test 'cl-mcp/tests/tools-test::tools-call-repl-eval-preview-max-depth)`
- `(rove:run 'cl-mcp/tests/inspect-test)`
- `(rove:run 'cl-mcp/tests/tools-test)`

Also verified runtime behavior via `tools/call repl-eval`:
- `preview_max_depth=1` => nested value is `object-ref`
- `preview_max_depth=2` => nested value is expanded `list`
