### PR TITLE
docs: ship dogfooding-cl-mcp skill as project-local .claude/skills/

### DIFF
--- a/.claude/skills/dogfooding-cl-mcp/SKILL.md
+++ b/.claude/skills/dogfooding-cl-mcp/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: dogfooding-cl-mcp
+description: Use when you want to stress-test cl-mcp tools against a realistic Common Lisp development workflow and collect concrete improvement feedback by building a throwaway medium-size project end-to-end.
+---
+
+# Dogfooding cl-mcp
+
+## Overview
+
+Build a real mid-size Common Lisp project with cl-mcp's own tools, watching for every rough edge along the way. The point is not the project — it is the feedback. Every retry, every confusing error, every tool that surprises you goes into the feedback file.
+
+**Core principle:** Cheap, disposable projects that exercise the full cl-mcp tool surface produce better feedback than abstract review. Build, notice friction, record it, throw it away.
+
+## When to Use
+
+- User asks for dogfooding, feedback collection, or "try cl-mcp on a real project"
+- You want to verify a recent cl-mcp change works in practice, not just in unit tests
+- You are looking for P1/P2/P3-level improvement candidates to feed into the next PR cycle
+
+**Do NOT use** for: scaffolding a project the user actually wants to keep, or for unrelated CL work.
+
+## Workflow
+
+### 1. Workspace setup (isolate the throwaway project)
+
+**Never scaffold inside cl-mcp's own git tree.** The generated files would show up in `git status` and could be committed by accident.
+
+```
+mkdir -p ~/cl-mcp-experiments          # one-time; outside cl-mcp checkout
+fs-set-project-root path=~/cl-mcp-experiments
+fs-get-project-info                    # confirm
+```
+
+Note the original cl-mcp project root before switching. You will restore it at the end.
+
+### 2. Scaffold with `project-scaffold`
+
+Call `project-scaffold` once. Pick a `name` that does not exist yet under `scaffolds/`. Save the response — note the `absolute_path` and `files` list.
+
+⚠️ **The text summary returned by `project-scaffold` currently omits the `next_steps` array** (the field exists in the structured response but is not rendered in the visible content). Do not wait for it. Go straight to step 3.
+
+### 3. Register the scaffold with ASDF (before first load-system)
+
+ASDF does not auto-discover projects under `~/cl-mcp-experiments/`. The `load-system` tool will fail with `Component "<name>" not found` unless you prime ASDF first:
+
+```
+repl-eval code='(asdf:load-asd "<absolute-path-from-step-2>/<name>.asd")'
+```
+
+Only AFTER that call does `load-system system=<name>` work. This is a one-time prime per scaffold.
+
+### 4. Build out medium complexity
+
+Target shape (medium = 15-30 minutes of work):
+
+- 3-5 source files under `src/`
+- 2-4 test files under `tests/`
+- ~10 Rove tests across all test files
+- At least one of: `defclass` + `defmethod`, `defstruct`, `define-condition`, a small `defmacro`, multi-file inter-package `:import-from`
+
+Use `fs-write-file` for **new** files, `lisp-edit-form` / `lisp-patch-form` for **existing** files (parinfer-safe). Register extra test packages in the scaffold's `.asd` `:depends-on` list and re-`load-system` after each new file.
+
+**Tool parameter gotchas** (easy to trip on):
+- `lisp-edit-form` / `lisp-patch-form` use `file_path`, NOT `path`. Reading tools (`lisp-read-file`, `fs-read-file`) use `path`.
+- `lisp-edit-form content` must contain **exactly one top-level form**. To insert multiple forms, chain `insert_after` calls.
+- `code-find` requires `symbol`, NOT `name`. When the symbol is not in `CL-USER`, also pass `package`.
+- `lisp-edit-form` / `lisp-patch-form` accept `form_type: "defsystem"` for `.asd` files, NOT `"asdf:defsystem"`.
+
+### 5. Exercise the full tool surface
+
+Deliberately try each tool at least once so friction surfaces:
+
+`clgrep-search`, `code-find`, `code-describe`, `code-find-references`, `inspect-object` on a non-primitive result, `lisp-read-file` with `name_pattern`, `repl-eval` with an intentional error to see `error_context`, `run-tests` on both a passing and a deliberately-failing assertion.
+
+### 6. Record feedback as you go
+
+Keep a running list. Append to the feedback file at the end of the cycle, not at the end of the session.
+
+**Feedback file location** — pick the variant that matches how you work:
+
+- **Solo / private notes** (default for most contributors): `~/.claude/memory/cl-mcp-feedback.md`. Contains your personal observations; never committed to cl-mcp's git tree.
+- **Team-shared** (if the project has agreed on a shared file): e.g. `<cl-mcp-repo>/claudedocs/dogfooding-feedback.md`. Visible to other contributors; avoid sensitive material and un-redacted paths.
+- **Project-specific override** — if the user of this skill has said "record feedback to X", use X and skip the defaults.
+
+In all cases: **append, never overwrite**. Create the file with `fs-write-file` if it does not exist; afterwards append via shell heredoc or `repl-eval`.
+
+**Format:** add a new dated section (`## Session YYYY-MM-DD — <project-name>`). Categorize every item as P1/P2/P3:
+- **P1** — real bugs, silent wrong results, data-loss risk, or features that block the workflow
+- **P2** — rough edges, token waste, confusing error messages, docs mismatches
+- **P3** — nits, scaffold template polish, nice-to-haves
+
+For each item: Problem (one line), Reproduction or symptom, Suggested fix.
+
+### 7. Cleanup
+
+At the end of the cycle:
+
+1. `fs-set-project-root path=<original-cl-mcp-path>` to restore the working context
+2. Report generation stats (project name, location, test count, feedback items count)
+3. Leave the throwaway project on disk — it is cheap storage and the next cycle can reuse `~/cl-mcp-experiments/` as the parent
+
+Do **not** `git add` anything in cl-mcp's checkout.
+
+## Known pitfalls (check before recording as new bugs)
+
+These are documented pitfalls that have tripped previous dogfooding runs. If you hit them, you can cite the existing feedback instead of opening duplicates.
+
+| Symptom | Cause | Workaround |
+|---|---|---|
+| `run-tests` on aggregate `<name>/tests` reports `Passed: 0, Failed: 0` with `✓ PASS` despite tests actually running | `run-tests` result extractor does not handle the scaffold's `:perform (test-op ...)` rove:run shape | Run each sub-package individually (`run-tests system=<name>/tests/foo-test`) OR verify via `(asdf:test-system :<name>)` in repl-eval |
+| `run-tests` fails with opaque `COMPILE-FILE-ERROR while compiling ...` after you edited a `defpackage` | SBCL package-variance warning escalated to error; cached worker state | `pool-kill-worker` then `load-system` to get a fresh image |
+| `lisp-edit-form` or `lisp-patch-form` on a `.asd` file rejects `form_type: "asdf:defsystem"` | Tool matches on unqualified symbol name | Use `form_type: "defsystem"` |
+| `code-find` returns `symbol is required` when you pass `name:` | Parameter name is `symbol`, not `name` | Check the tool schema: the required key is `symbol` |
+| `fs-list-directory` hides `.gitignore` and other dotfiles | Default behavior filters `*hidden-prefixes*` | Pass `show_hidden: true` (added in PR #94) |
+| `lisp-edit-form` on a defmethod with `#:` specializers says "not found" with plain `form_name` | Was a bug before PR #94; fixed by `%strip-hash-colon` normalization | Should work now; if it still fails, file a new issue |
+| `load-system system=<name>` fails with `Component "<name>" not found` immediately after `project-scaffold` | ASDF has not loaded the scaffold's `.asd` yet | `repl-eval '(asdf:load-asd "<absolute-path>/<name>.asd")'` once, then `load-system` works — see step 3 |
+| `project-scaffold` text response does not contain the `next_steps` array | Response builder does not render `next_steps` in `content[].text` | Use the `absolute_path` from the structured response and prime ASDF manually per step 3 |
+| `inspect-object id=<N>` returns `id must be an integer` even when N is clearly an integer | Known broken in the MCP JSON layer (may be intermittent) | Fall back to `repl-eval '(inspect <N>)'` or re-reference the raw value via a `defparameter` and print slots directly |
+| `lisp-edit-form content=<multi-form>` rejects with `content must contain exactly one top-level form` | Tool only accepts one form per call | Chain multiple `insert_after` calls, one form each |
+| `clgrep-search form_types=[...]` filter returns `[]` even when matches exist in the un-filtered query | Filter is currently unreliable | Omit `form_types` and post-filter client-side, OR prefer `code-find` / `code-describe` for exact lookups |
+| `clgrep-search` signature field is a 4KB blob with the whole form body | Known token waste (see cl-mcp-feedback.md P2) | Use `head_limit` aggressively, or do targeted `lisp-read-file name_pattern=...` instead |
+
+## Success criteria
+
+You are done with one cycle when:
+
+- [ ] The throwaway project has all its generated Rove tests green (verified per-package OR via `asdf:test-system`, **not** just via the buggy aggregate `run-tests` path)
+- [ ] At least one edited Lisp file was sanity-checked with `lisp-check-parens` (cheap and catches `lisp-patch-form` drift early)
+- [ ] At least **5 feedback items** were **actually appended** to the chosen feedback file (verify with a `fs-read-file` or shell `tail` — the "I'll record it later" trap is real)
+- [ ] Feedback is categorized P1/P2/P3 under a dated section heading
+- [ ] Project root is restored to cl-mcp's original location
+- [ ] Nothing in `git status` under cl-mcp references the throwaway project
+
+## Anti-patterns
+
+- **Scaffolding inside cl-mcp's checkout.** The generated files will taint `git status`. Always set project root to an outside directory first.
+- **Building a project you intend to keep.** This is a feedback-gathering exercise; grab shallow breadth (lots of tool calls) over deep polish.
+- **Trusting `✓ PASS / Passed: 0, Failed: 0` on the aggregate test system.** See the pitfalls table — this is a known silent bug.
+- **Recording only tool bugs.** Capture UX friction too: confusing errors, missing defaults, unnecessary retries. Those become P2/P3 items.
+- **Skipping the "try every tool" step.** If you only use `lisp-edit-form` and `run-tests`, you only produce feedback on those two tools.
+
+## Output when asked to run a cycle
+
+When a cycle completes, summarize:
+
+1. **Project:** name + absolute path
+2. **Size:** N src files, N test files, N Rove tests, what CL features exercised (defclass, defmethod, etc.)
+3. **Test status:** per-package counts (avoid the aggregate trap)
+4. **Feedback recorded:** total count, P1/P2/P3 breakdown
+5. **Procedural pitfalls:** anything that took more than one try (these are usually the best P1/P2 candidates)
+6. **Cleanup:** project root restored ✓, cl-mcp `git status` clean ✓

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,19 @@ mallet src/*.lisp
 ## Repository Structure
 
 ```
-src/          Core implementation (protocol, tools, transports)
-tests/        Rove test suites (mirrored naming: *-test.lisp)
-scripts/      Helper clients and stdio<->TCP bridge
-prompts/      System prompts for AI agents
+src/              Core implementation (protocol, tools, transports)
+tests/            Rove test suites (mirrored naming: *-test.lisp)
+scripts/          Helper clients and stdio<->TCP bridge
+prompts/          System prompts for AI agents
+.claude/skills/   Project-local Claude Code skills (auto-discovered)
 ```
+
+## Dogfooding
+
+For structured feedback-collection cycles ("build a throwaway project with
+cl-mcp's own tools and record every rough edge"), use the `dogfooding-cl-mcp`
+skill shipped in `.claude/skills/dogfooding-cl-mcp/SKILL.md`. Claude Code
+auto-discovers project-local skills on session start, so invoking `/dogfooding-cl-mcp`
+(or the `Skill` tool with `skill: "dogfooding-cl-mcp"`) loads the workflow.
+The skill includes a pitfalls table of known issues and a P1/P2/P3 feedback
+format; contributing new pitfalls back to the skill is welcomed via normal PRs.


### PR DESCRIPTION
## Summary

Move the `dogfooding-cl-mcp` skill from the author's personal `~/.claude/skills/` directory into the cl-mcp repo at `.claude/skills/dogfooding-cl-mcp/SKILL.md`. Claude Code auto-discovers project-local skills at `<project-root>/.claude/skills/` on session start, so contributors get the workflow without any manual setup.

## Motivation

The skill was originally written as a personal tool but had two problems as a solo artifact:

1. **Version drift:** the skill's "Known pitfalls" table references specific cl-mcp PRs (#94 et al.). When a PR fixes one of those pitfalls, the table needs to be updated in the same commit — that only works naturally if the skill is in the same git tree.
2. **Discoverability:** other contributors and future maintainers cannot invoke the skill without copying files out of someone else's home directory.

Committing the skill to the repo solves both. Review of any future skill updates happens via normal PR flow.

## Changes

1. **New file:** `.claude/skills/dogfooding-cl-mcp/SKILL.md` (151 lines)
   - 7-step workflow: workspace isolation → scaffold → ASDF prime → build medium complexity → exercise tool surface → record feedback → cleanup
   - 12-row Known Pitfalls table covering `run-tests` aggregate-zero bug, SBCL package-variance compile errors, `project-scaffold` next_steps not rendered in content text, `inspect-object` JSON-layer issue, `lisp-edit-form` single-form requirement, `clgrep-search form_types` filter unreliability, and others.
   - 6-item Success Criteria checklist (per-package test counts, `lisp-check-parens` gate, feedback-file append verification, project-root restoration, clean `git status`)
   - 5 Anti-patterns, plus the output format for cycle reports.

2. **Feedback-file path is no longer hardcoded.** The skill lists three variants (solo-private at `~/.claude/memory/cl-mcp-feedback.md`, team-shared at `<cl-mcp-repo>/claudedocs/dogfooding-feedback.md`, or a user override) so contributors with different privacy preferences can all use the same skill.

3. **CLAUDE.md updates:**
   - Repository Structure block now lists `.claude/skills/` as an auto-discovered location
   - New "Dogfooding" section documents the skill's location and invocation

4. **Personal symlink (author's machine only, not part of this PR):** `~/.claude/skills/dogfooding-cl-mcp` now points at the in-repo file so local edits and PR edits stay in lockstep for the author. Other contributors do not need to do anything — project-local auto-discovery handles it.

## Verification

- **Auto-discovery confirmed in-session:** after placing the skill at `.claude/skills/dogfooding-cl-mcp/SKILL.md`, the Claude Code skill list enumerated `dogfooding-cl-mcp` alongside personal and plugin skills, with the description read from the YAML frontmatter.
- **TDD cycle for the skill itself:**
  - RED: dispatched a subagent without the skill, documented 3 procedural pitfalls (`asdf:defsystem` form-type rejection, `code-find` parameter name, silent `run-tests` aggregate zeros)
  - GREEN: wrote the skill addressing those gaps, dispatched a fresh subagent with the skill available
  - REFACTOR: subagent identified 7 additional gaps; all folded back into the skill (ASDF priming step, tool parameter gotchas subsection, 6 new Pitfalls rows, success-criteria checkboxes)
  - Final verification subagent produced 15 new feedback items in one cycle, confirming the skill successfully guides a fresh agent through the workflow.

## Non-goals

- This PR does not change the `feedback.md` file itself (it's personal and stays under `~/.claude/memory/`).
- This PR does not add a CI step for the skill; it's reference material, not code.
- This PR does not make any cl-mcp tool changes. The pitfalls documented in the skill are tracked separately in the feedback file for future fix PRs (several are already queued as P1/P2 candidates).

## Test plan

- [x] `git diff` shows only 2 files changed (`CLAUDE.md`, new `.claude/skills/dogfooding-cl-mcp/SKILL.md`)
- [x] Skill description conforms to YAML frontmatter limits
- [x] Auto-discovery verified in the same session
- [x] No cl-mcp source code touched; no tests need to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)