### PR TITLE
fix: address 7 P1/P2 issues surfaced by dogfooding cycle

### DIFF
--- a/.mallet.lisp
+++ b/.mallet.lisp
@@ -1,6 +1,6 @@
 (:mallet-config
  (:extends :default)
- (:disable :eval-usage)
- (:disable :ignore-errors-usage)
+ (:disable :no-eval)
+ (:disable :no-ignore-errors)
  (:for-paths ("src/utils/lenient-read.lisp")
    (:disable :double-colon-access)))

--- a/src/code-core.lisp
+++ b/src/code-core.lisp
@@ -72,14 +72,17 @@ appears in SYMBOL-NAME (e.g., \"pkg:sym\"), PACKAGE is ignored."
 
 (defun %offset->line (pathname offset)
   "Convert character OFFSET within PATHNAME to a 1-based line number.
-SBCL's DEFINITION-SOURCE-CHARACTER-OFFSET often points to a whitespace
-character (typically the newline right after the preceding form's closing
-paren) rather than to the `(' that starts the form itself.  To give the
-user a line number that matches what they see when they open the file,
-we walk forward from OFFSET to the next `(' (skipping whitespace and
-`;'-style comments) and count newlines up to that position.  Capped at
-1024 characters of look-ahead to stay safe if the offset is spurious.
-Returns NIL when the file cannot be read."
+SBCL's DEFINITION-SOURCE-CHARACTER-OFFSET typically points at a
+whitespace character or reader-conditional directive that precedes
+the actual `(def...)' form. Walk forward from OFFSET across:
+  - whitespace
+  - `;' line comments
+  - `#|...|#' block comments
+  - `#+feature' / `#-feature' reader conditionals (with atom or
+    list feature expressions)
+and stop at the first `(' that begins the next definition form.
+Scan is capped at 1024 characters of look-ahead to stay safe if
+the offset is spurious. Returns NIL when the file cannot be read."
   (when (and pathname offset)
     (handler-case
         (let* ((physical (translate-logical-pathname pathname))
@@ -89,18 +92,59 @@ Returns NIL when the file cannot be read."
                (limit (min len (+ start 1024))))
           (labels ((ws-p (ch)
                      (or (char= ch #\Space) (char= ch #\Tab)
-                         (char= ch #\Newline) (char= ch #\Return))))
+                         (char= ch #\Newline) (char= ch #\Return)))
+                   (skip-balanced-list (i)
+                     (let ((depth 0))
+                       (loop while (< i limit) do
+                         (let ((c (char content i)))
+                           (incf i)
+                           (cond
+                             ((char= c #\() (incf depth))
+                             ((char= c #\))
+                              (decf depth)
+                              (when (zerop depth) (return))))))
+                       i))
+                   (skip-atom (i)
+                     (loop while (< i limit) do
+                       (let ((c (char content i)))
+                         (when (or (ws-p c) (char= c #\() (char= c #\))
+                                   (char= c #\;))
+                           (return))
+                         (incf i)))
+                     i)
+                   (skip-conditional (i)
+                     (incf i 2)
+                     (loop while (and (< i limit) (ws-p (char content i)))
+                           do (incf i))
+                     (if (< i limit)
+                         (if (char= (char content i) #\()
+                             (skip-balanced-list i)
+                             (skip-atom i))
+                         i))
+                   (skip-block-comment (i)
+                     (let ((end (search "|#" content :start2 (+ i 2)
+                                        :end2 limit)))
+                       (if end (+ end 2) limit))))
             (let ((i start))
-              (loop
-               (when (>= i limit) (return))
-               (let ((ch (char content i)))
-                 (cond
-                   ((ws-p ch) (incf i))
-                   ((char= ch #\;)
-                    ;; Skip line comment.
-                    (let ((nl (position #\Newline content :start i :end limit)))
-                      (setf i (if nl (1+ nl) limit))))
-                   (t (return)))))
+              (loop while (< i limit) do
+                (let ((ch (char content i)))
+                  (cond
+                    ((ws-p ch) (incf i))
+                    ((char= ch #\;)
+                     (let ((nl (position #\Newline content :start i
+                                         :end limit)))
+                       (setf i (if nl (1+ nl) limit))))
+                    ((char= ch #\#)
+                     (cond
+                       ((and (< (1+ i) limit)
+                             (char= (char content (1+ i)) #\|))
+                        (setf i (skip-block-comment i)))
+                       ((and (< (1+ i) limit)
+                             (or (char= (char content (1+ i)) #\+)
+                                 (char= (char content (1+ i)) #\-)))
+                        (setf i (skip-conditional i)))
+                       (t (return))))
+                    (t (return)))))
               (1+ (count #\Newline content :end (min i len))))))
       (error (e)
         (log-event :warn "code.find.line-error"

--- a/src/code-core.lisp
+++ b/src/code-core.lisp
@@ -72,13 +72,36 @@ appears in SYMBOL-NAME (e.g., \"pkg:sym\"), PACKAGE is ignored."
 
 (defun %offset->line (pathname offset)
   "Convert character OFFSET within PATHNAME to a 1-based line number.
+SBCL's DEFINITION-SOURCE-CHARACTER-OFFSET often points to a whitespace
+character (typically the newline right after the preceding form's closing
+paren) rather than to the `(' that starts the form itself.  To give the
+user a line number that matches what they see when they open the file,
+we walk forward from OFFSET to the next `(' (skipping whitespace and
+`;'-style comments) and count newlines up to that position.  Capped at
+1024 characters of look-ahead to stay safe if the offset is spurious.
 Returns NIL when the file cannot be read."
   (when (and pathname offset)
     (handler-case
         (let* ((physical (translate-logical-pathname pathname))
                (content (uiop:read-file-string physical))
-               (end (min (max offset 0) (length content))))
-          (1+ (count #\Newline content :end end)))
+               (len (length content))
+               (start (min (max offset 0) len))
+               (limit (min len (+ start 1024))))
+          (labels ((ws-p (ch)
+                     (or (char= ch #\Space) (char= ch #\Tab)
+                         (char= ch #\Newline) (char= ch #\Return))))
+            (let ((i start))
+              (loop
+               (when (>= i limit) (return))
+               (let ((ch (char content i)))
+                 (cond
+                   ((ws-p ch) (incf i))
+                   ((char= ch #\;)
+                    ;; Skip line comment.
+                    (let ((nl (position #\Newline content :start i :end limit)))
+                      (setf i (if nl (1+ nl) limit))))
+                   (t (return)))))
+              (1+ (count #\Newline content :end (min i len))))))
       (error (e)
         (log-event :warn "code.find.line-error"
                    "path" (princ-to-string pathname)
@@ -88,9 +111,13 @@ Returns NIL when the file cannot be read."
 (declaim (ftype (function (string &key (:package (or null package symbol string)))
                           (values (or null string) (or null integer) &optional))
                 code-find-definition))
+
 (defun code-find-definition (symbol-name &key package)
   "Return the definition location for SYMBOL-NAME.
-Values are PATH (string) and LINE (integer), or NILs when not found."
+Values are PATH (string) and LINE (integer), or NILs when not found.
+Searches multiple SB-INTROSPECT definition kinds so that classes,
+structures, conditions, generic functions, macros, and variables are
+all locatable, not only ordinary functions."
   (let* ((qualified (position #\: symbol-name))
          (pkg (if qualified nil package))
          (sym (%parse-symbol symbol-name :package pkg)))
@@ -100,9 +127,16 @@ Values are PATH (string) and LINE (integer), or NILs when not found."
            (find (and pkg (find-symbol "FIND-DEFINITION-SOURCE" pkg)))
            (path-fn (and pkg (find-symbol "DEFINITION-SOURCE-PATHNAME" pkg)))
            (offset (and pkg (find-symbol "DEFINITION-SOURCE-CHARACTER-OFFSET" pkg)))
-           (source (or (and find-by-name
-                            (first (ignore-errors (funcall find-by-name sym :function))))
-                       (and find (ignore-errors (funcall find sym))))))
+           (kinds '(:function :generic-function :macro
+                    :class :condition :structure :type
+                    :variable :constant :method-combination :package))
+           (source
+            (or (loop for kind in kinds
+                      for src = (and find-by-name
+                                     (first (ignore-errors
+                                             (funcall find-by-name sym kind))))
+                      when src return src)
+                (and find (ignore-errors (funcall find sym))))))
       (when (and source path-fn)
         (let* ((pathname (funcall path-fn source))
                (char-offset (and offset (funcall offset source)))
@@ -118,41 +152,85 @@ Values are PATH (string) and LINE (integer), or NILs when not found."
                           (values string string (or null string) (or null string)
                                   (or null string) (or null integer) &optional))
                 code-describe-symbol))
+
 (defun code-describe-symbol (symbol-name &key package)
   "Return NAME, TYPE, ARGLIST, DOCUMENTATION, PATH, and LINE for SYMBOL-NAME.
-Signals an error when the symbol is unbound. PATH/LINE may be NIL when unknown."
+Handles functions, macros, generic functions, variables, classes,
+condition types, and structure types. Signals an error only when none
+of those bindings resolve. PATH/LINE may be NIL when unknown.
+
+TYPE is one of:
+  \"function\", \"generic-function\", \"macro\", \"variable\",
+  \"class\", \"condition\", \"structure\"."
   (let* ((sym (%parse-symbol symbol-name :package package))
          (name (princ-to-string sym))
-         (type (cond
-                 ((macro-function sym) "macro")
-                 ((fboundp sym) "function")
-                 ((boundp sym) "variable")
-                 (t "unbound"))))
+         (class (find-class sym nil))
+         (type
+          (cond
+            ((macro-function sym) "macro")
+            ((and (fboundp sym)
+                  (typep (symbol-function sym) 'generic-function))
+             "generic-function")
+            ((fboundp sym) "function")
+            ((boundp sym) "variable")
+            ((and class
+                  (subtypep (class-name class) 'condition))
+             "condition")
+            #+sbcl
+            ((and class
+                  (typep class (find-class 'structure-class)))
+             "structure")
+            (class "class")
+            (t "unbound"))))
     (when (string= type "unbound")
-      (error "Symbol ~A is not bound as a function or variable" sym))
+      (error "Symbol ~A is not bound as a function, variable, class, or condition"
+             sym))
     #+sbcl
     (%ensure-sb-introspect)
     (let* ((fn (cond
                  ((macro-function sym))
                  ((fboundp sym) (symbol-function sym))
                  (t nil)))
-           (arglist (when fn
-                      (handler-case
-                          (let* ((fn-ll (%sb-introspect-symbol "FUNCTION-LAMBDA-LIST"))
-                                 (args (and fn-ll (funcall fn-ll fn))))
-                            (cond
-                              ((null args) "()")
-                              ((listp args) (princ-to-string args))
-                              (t (princ-to-string args))))
-                        (error (e)
-                          (log-event :warn "code.describe.arglist-error" "symbol" symbol-name
-                                     "error" (princ-to-string e))
-                          "()"))))
-           (doc (cond
-                  ((or (macro-function sym) (fboundp sym))
-                   (documentation sym 'function))
-                  ((boundp sym) (documentation sym 'variable))
-                  (t nil))))
+           (arglist
+            (cond
+              (fn
+               (handler-case
+                   (let* ((fn-ll (%sb-introspect-symbol "FUNCTION-LAMBDA-LIST"))
+                          (args (and fn-ll (funcall fn-ll fn))))
+                     (cond
+                       ((null args) "()")
+                       ((listp args) (princ-to-string args))
+                       (t (princ-to-string args))))
+                 (error (e)
+                   (log-event :warn "code.describe.arglist-error"
+                              "symbol" symbol-name
+                              "error" (princ-to-string e))
+                   "()")))
+              (class
+               (handler-case
+                   (let* ((slots-fn
+                            #+sbcl (find-symbol "CLASS-DIRECT-SLOTS" "SB-MOP")
+                            #-sbcl nil)
+                          (slots (and slots-fn
+                                      (ignore-errors (funcall slots-fn class))))
+                          (slot-name-fn
+                            #+sbcl (find-symbol "SLOT-DEFINITION-NAME" "SB-MOP")
+                            #-sbcl nil))
+                     (if (and slots slot-name-fn)
+                         (format nil "(~{~(~A~)~^ ~})"
+                                 (mapcar (lambda (s)
+                                           (funcall slot-name-fn s))
+                                         slots))
+                         "()"))
+                 (error () "()")))
+              (t nil)))
+           (doc
+            (cond
+              ((or (macro-function sym) (fboundp sym))
+               (documentation sym 'function))
+              ((boundp sym) (documentation sym 'variable))
+              (class (documentation sym 'type))
+              (t nil))))
       (multiple-value-bind (path line)
           (code-find-definition symbol-name :package package)
         (values name type arglist doc path line)))))
@@ -188,6 +266,72 @@ Returns T for any path when *project-root* is not set."
          (line (%offset->line pathname char-offset))
          (path (normalize-path-for-display pathname)))
     (values pathname path (or line (and pathname char-offset 1)))))
+
+(defun %format-xref-caller (name)
+  "Render an SB-INTROSPECT xref caller NAME as a short human-readable string.
+
+Normalizes several SBCL-internal shapes into the form the user would
+type to locate the call site:
+
+  FOO                               -> \"foo\"
+  (PKG::FOO)                        -> \"pkg::foo\"
+  (SB-PCL::FAST-METHOD NAME ...)    -> \"(defmethod name ...)\"
+  (:METHOD NAME ...)                -> \"(defmethod name ...)\"
+  (METHOD NAME ...)                 -> \"(defmethod name ...)\"
+  (FLET INNER :IN OUTER)            -> \"flet inner :in outer\"
+  (LABELS INNER :IN OUTER)          -> \"labels inner :in outer\"
+  (LAMBDA () :IN /abs/path)         -> \"(lambda)\"
+  (:LAMBDA ...)                     -> \"(lambda)\"
+  (SOMETHING ...)                   -> downcased, absolute path stripped
+
+Returns NIL for NIL input."
+  (when name
+    (handler-case
+        (let ((*print-case* :downcase)
+              (*print-readably* nil)
+              (*print-gensym* nil))
+          (cond
+            ((symbolp name)
+             (princ-to-string name))
+            ((not (consp name))
+             (princ-to-string name))
+            ;; SBCL-specific fast method wrapper
+            ((and (symbolp (car name))
+                  (or (string= (symbol-name (car name)) "FAST-METHOD")
+                      (string= (symbol-name (car name)) "SLOW-METHOD")))
+             (format nil "(defmethod ~{~(~A~)~^ ~})" (cdr name)))
+            ;; Keyword :method / plain method
+            ((and (symbolp (car name))
+                  (or (string= (symbol-name (car name)) "METHOD")
+                      (eq (car name) :method)))
+             (format nil "(defmethod ~{~(~A~)~^ ~})" (cdr name)))
+            ;; (lambda ...) or (:lambda ...) — drop absolute file paths
+            ((and (symbolp (car name))
+                  (or (string= (symbol-name (car name)) "LAMBDA")
+                      (eq (car name) :lambda)))
+             "(lambda)")
+            ;; (flet name :in parent) / (labels name :in parent)
+            ((and (symbolp (car name))
+                  (or (string= (symbol-name (car name)) "FLET")
+                      (string= (symbol-name (car name)) "LABELS"))
+                  (consp (cdr name)))
+             (format nil "~(~A~) ~(~A~)~@[ :in ~(~A~)~]"
+                     (car name)
+                     (second name)
+                     (let ((in (member :in name))) (and in (second in)))))
+            (t
+             ;; Generic form: strip any absolute path strings from pieces.
+             (format nil "(~{~A~^ ~})"
+                     (mapcar
+                      (lambda (piece)
+                        (cond
+                          ((and (stringp piece)
+                                (or (uiop:string-prefix-p "/" piece)
+                                    (uiop:string-prefix-p "\\" piece)))
+                           "...")
+                          (t (format nil "~(~A~)" piece))))
+                      name)))))
+      (error () nil))))
 
 (defun %finder->type (name)
   "Map SB-INTROSPECT XREF function name to output type."
@@ -240,13 +384,7 @@ or grep the file starting from LINE to find the call site."
                              (or (not project-only)
                                  (%path-inside-project-p pathname)))
                     (let* ((type (%finder->type finder))
-                           (caller-str
-                            (and caller-name
-                                 (handler-case
-                                     (let ((*print-case* :downcase)
-                                           (*print-readably* nil))
-                                       (princ-to-string caller-name))
-                                   (error () nil))))
+                           (caller-str (%format-xref-caller caller-name))
                            (context (%line-snippet pathname line))
                            (key (format nil "~A:~A:~A:~A"
                                         path line type (or caller-str ""))))

--- a/src/lisp-edit-form.lisp
+++ b/src/lisp-edit-form.lisp
@@ -105,12 +105,32 @@ blank line. For EOF boundary use a single newline."
   "Ensure CONTENT is a single valid form. If parsing fails, attempt to repair
 using parinfer:apply-indent-mode. Returns the validated (possibly repaired) content.
 When READTABLE-DESIGNATOR is provided, use that named-readtable for parsing.
-Unknown package prefixes are handled leniently via stub packages."
+Unknown package prefixes are handled leniently via stub packages.
+
+As a convenience, CONTENT consisting entirely of comments (and whitespace)
+is accepted verbatim. This allows `replace' to delete a form by replacing
+it with a `;; removed' comment marker, and `insert_*' to place bare
+comments near a target form."
   (let* ((*read-eval* nil)
          (custom-rt (%resolve-named-readtable readtable-designator))
          (*readtable* (if custom-rt custom-rt (copy-readtable nil))))
     (labels ((whitespace-char-p (ch)
                (member ch '(#\Space #\Tab #\Newline #\Return)))
+             (comment-only-p (text)
+               ;; Return T when TEXT contains at least one `;' line comment
+               ;; or `#|...|#' block comment and NO readable forms.
+               (and (stringp text)
+                    (some (lambda (ch) (not (whitespace-char-p ch))) text)
+                    (handler-case
+                        (multiple-value-bind (form pos)
+                            (read-from-string text nil :eof)
+                          (declare (ignore pos))
+                          (eq form :eof))
+                      (error () nil))
+                    ;; Require that a `;' or `#|' token is actually present
+                    ;; so that mis-balanced junk doesn't accidentally pass.
+                    (or (find #\; text)
+                        (search "#|" text))))
              (rest-parses-as-complete-forms-p (text start)
                (let ((len (length text)))
                  (handler-case
@@ -138,7 +158,9 @@ Unknown package prefixes are handled leniently via stub packages."
                       (multiple-value-bind (form pos)
                           (read-from-string text nil :eof)
                         (when (eq form :eof)
-                          (error "content is empty"))
+                          (if (comment-only-p text)
+                              (return-from try-parse text)
+                              (error "content is empty")))
                         (let* ((len (length text))
                                (rest-start
                                  (or (position-if-not #'whitespace-char-p
@@ -153,6 +175,8 @@ Unknown package prefixes are handled leniently via stub packages."
                     :source-path source-path)
                  (error (e)
                    (values nil e)))))
+      (when (comment-only-p content)
+        (return-from %validate-and-repair-content (values content nil)))
       (multiple-value-bind (result err)
           (try-parse content)
         (if result

--- a/src/lisp-read-file.lisp
+++ b/src/lisp-read-file.lisp
@@ -17,6 +17,8 @@
                 #:make-ht #:result #:text-content #:arg-validation-error)
   (:import-from #:cl-mcp/src/tools/define-tool
                 #:define-tool)
+  (:import-from #:cl-mcp/src/utils/lenient-read
+                #:*homeless-due-to-teardown*)
   (:import-from #:cl-mcp/src/utils/paths
                 #:normalize-path-for-display)
   (:import-from #:cl-mcp/src/utils/strings
@@ -41,6 +43,49 @@
 
 (defparameter *text-context-lines* 5
   "Number of surrounding lines to include for text filtering with patterns.")
+
+(defun %print-homeless-symbol-name (stream name)
+  "Write NAME to STREAM with case conversion honoring *PRINT-CASE*."
+  (write-string (ecase *print-case*
+                  (:downcase (string-downcase name))
+                  (:upcase name)
+                  (:capitalize (string-capitalize name)))
+                stream))
+
+(defun %print-source-symbol (stream sym)
+  "Pprint-dispatch handler for symbols in lisp-read-file output.
+
+A symbol with no home package is either:
+  (a) genuinely uninterned in the source — e.g. written as `#:foo'.
+      In that case it is NOT in *HOMELESS-DUE-TO-TEARDOWN*, and we
+      preserve the `#:' prefix so the display remains a faithful
+      reproduction of the source.
+  (b) homeless only because a synthesized package was torn down
+      after reading. In that case it IS in the teardown set, and we
+      strip the `#:' so expanded views are readable.
+
+Interned symbols (keywords, ordinary package symbols) fall through
+to the default printer with *PRINT-CIRCLE* forced to NIL. Rebinding
+*PRINT-CIRCLE* avoids a subtle interaction with the pretty printer
+that would otherwise label shared symbol objects with `#1=#1#'
+self-references when the outer tree is walked under *PRINT-PRETTY*."
+  (cond
+    ((and (symbolp sym) (null (symbol-package sym)))
+     (unless (gethash sym *homeless-due-to-teardown*)
+       (write-string "#:" stream))
+     (%print-homeless-symbol-name stream (symbol-name sym)))
+    (t
+     (let ((*print-pprint-dispatch* (copy-pprint-dispatch nil))
+           (*print-circle* nil))
+       (prin1 sym stream)))))
+
+(defvar *source-pprint-dispatch*
+  (let ((table (copy-pprint-dispatch nil)))
+    (set-pprint-dispatch 'symbol #'%print-source-symbol 0 table)
+    table)
+  "Pprint dispatch used by %FORM->STRING and %COLLAPSE-DEF-FORM so
+homeless-due-to-teardown symbols render without `#:' while genuine
+uninterned symbols retain their prefix. See %PRINT-SOURCE-SYMBOL.")
 
 (defun lisp-source-path-p (path)
   "Return T when PATH designator refers to a Lisp source file by extension."
@@ -86,23 +131,36 @@ PATTERN is a non-empty string that is not valid regex syntax."
 
 (defun %form->string (form)
   "Return FORM printed as Lisp source text for display.
-Binds *PRINT-GENSYM* to NIL so that symbols that were interned into a
-synthesized package which has since been deleted (leaving them homeless)
-do not acquire a spurious `#:' prefix in the output."
+Uses *SOURCE-PPRINT-DISPATCH* so symbols made homeless by a
+synthesized package's teardown print without the `#:' prefix, while
+symbols that were genuinely uninterned in the source (e.g., `#:foo'
+inside a `defpackage') retain their prefix.
+
+Forces *PRINT-CIRCLE* to NIL because the CST reader may intern a
+single symbol object once and share it across multiple positions in
+the form tree. Under *PRINT-CIRCLE* T, that would cause the pretty
+printer to label the first occurrence with `#1=' and emit `#1#' on
+reuse — producing nonsense like `(in-package #1=#1#)' when the
+shared symbol is the sole argument of a form."
   (let ((*print-pretty* t)
         (*print-case* :downcase)
         (*print-right-margin* 80)
-        (*print-gensym* nil))
+        (*print-circle* nil)
+        (*print-pprint-dispatch* *source-pprint-dispatch*))
     (with-output-to-string (out)
       (write form :stream out :pretty t :right-margin 80))))
 
 (defun %collapse-def-form (form)
   "Collapse a definition form to a signature line.
 For defmethod, includes qualifiers like :before, :after, :around.
-Binds *PRINT-GENSYM* to NIL so symbols from synthesized-and-deleted
-packages print without a spurious `#:' prefix."
+Uses *SOURCE-PPRINT-DISPATCH* so homeless-due-to-teardown symbols
+print without a spurious `#:' prefix while genuinely uninterned
+source symbols keep theirs. Forces *PRINT-CIRCLE* to NIL to avoid
+spurious `#1=#1#' self-references when the CST reader shares a
+single symbol object across multiple positions in the form tree."
   (let* ((*print-case* :downcase)
-         (*print-gensym* nil)
+         (*print-circle* nil)
+         (*print-pprint-dispatch* *source-pprint-dispatch*)
          (head (car form))
          (name (second form))
          (qualifiers

--- a/src/lisp-read-file.lisp
+++ b/src/lisp-read-file.lisp
@@ -85,16 +85,24 @@ PATTERN is a non-empty string that is not valid regex syntax."
         (list (string-downcase (prin1-to-string name)))))))
 
 (defun %form->string (form)
+  "Return FORM printed as Lisp source text for display.
+Binds *PRINT-GENSYM* to NIL so that symbols that were interned into a
+synthesized package which has since been deleted (leaving them homeless)
+do not acquire a spurious `#:' prefix in the output."
   (let ((*print-pretty* t)
         (*print-case* :downcase)
-        (*print-right-margin* 80))
+        (*print-right-margin* 80)
+        (*print-gensym* nil))
     (with-output-to-string (out)
       (write form :stream out :pretty t :right-margin 80))))
 
 (defun %collapse-def-form (form)
   "Collapse a definition form to a signature line.
-For defmethod, includes qualifiers like :before, :after, :around."
+For defmethod, includes qualifiers like :before, :after, :around.
+Binds *PRINT-GENSYM* to NIL so symbols from synthesized-and-deleted
+packages print without a spurious `#:' prefix."
   (let* ((*print-case* :downcase)
+         (*print-gensym* nil)
          (head (car form))
          (name (second form))
          (qualifiers

--- a/src/package-context.lisp
+++ b/src/package-context.lisp
@@ -13,7 +13,8 @@
                 #:*project-root*)
   (:import-from #:cl-mcp/src/utils/lenient-read
                 #:call-with-lenient-packages
-                #:call-with-managed-packages)
+                #:call-with-managed-packages
+                #:record-homeless-on-teardown)
   (:import-from #:uiop
                 #:directory-files
                 #:ensure-directory-pathname
@@ -293,10 +294,14 @@ have begun, to avoid descending into the rest of the file."
        :created-packages (nreverse (car created-packages-cell))))))
 
 (defun %cleanup-synthesized-package-context (context)
-  "Delete temporary packages created for CONTEXT."
+  "Delete temporary packages created for CONTEXT. Before deletion, the
+symbols that each package currently owns are recorded as becoming
+homeless-due-to-teardown so downstream display code can normalize
+them without affecting genuinely uninterned symbols."
   (dolist (pkg (reverse (synthesized-package-context-created-packages context)))
     (let ((name (ignore-errors (package-name pkg))))
       (when (and name (find-package name))
+        (ignore-errors (record-homeless-on-teardown pkg))
         (ignore-errors (delete-package pkg))))))
 
 (defun call-with-package-context (package-name thunk &key source-path)

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -242,6 +242,99 @@ instead of just an opaque COMPILE-FILE-ERROR."
         (format nil "Failed to load test system ~A: ~A"
                 system-name condition))))
 
+(defun %extract-defpackage-names-from-file (pathname)
+  "Return a list of package names mentioned in `(defpackage ...)' forms
+of the Lisp source file at PATHNAME. Silently returns NIL on any error."
+  (handler-case
+      (with-open-file (stream pathname :direction :input)
+        (let ((*read-eval* nil)
+              (*package* (find-package :cl-user))
+              (names nil))
+          (loop
+           (let ((form (handler-case (read stream nil :eof)
+                         (error () :eof))))
+             (when (eq form :eof) (return))
+             (when (and (consp form)
+                        (symbolp (car form))
+                        (or (string= (symbol-name (car form)) "DEFPACKAGE")
+                            (string= (symbol-name (car form)) "DEFINE-PACKAGE"))
+                        (consp (cdr form)))
+               (let ((name-form (second form)))
+                 (push
+                  (cond
+                    ((stringp name-form) name-form)
+                    ((symbolp name-form) (symbol-name name-form))
+                    (t nil))
+                  names)))))
+          (remove-if-not #'stringp (nreverse names))))
+    (error () nil)))
+
+(defun %rove-purge-ghost-suites (system-name)
+  "Remove Rove suite entries for every test package associated with
+SYSTEM-NAME. This prevents `ghost deftests' — tests that were deleted
+from source on disk but are still remembered by Rove's in-image
+registry and therefore keep running (and possibly failing) after a
+reload.
+
+Rove stores its per-package suite in a hash-table keyed by package
+object: ROVE/CORE/SUITE/PACKAGE::*PACKAGE-SUITES*. Clearing the entry
+for a package makes Rove rebuild the suite from scratch on the next
+deftest load, so forms that no longer exist in source disappear.
+
+Two discovery strategies are combined to cover both
+package-inferred-system and classic ASDF layouts:
+
+  1. **Dependency names**: for package-inferred systems, every
+     sub-system name like `foo/tests/bar-test' is also the package
+     name it defines. Walk SYSTEM-NAME's transitive dependency list
+     and clear packages matching each string name.
+  2. **Component source files**: recursively walk the ASDF component
+     tree under SYSTEM-NAME, read each source file, and clear
+     packages named in its `(defpackage ...)' forms. Catches classic
+     defsystems where the package name does not match any ASDF
+     sub-system name."
+  (let ((pkgs-var (find-symbol "*PACKAGE-SUITES*" :rove/core/suite/package)))
+    (when (and pkgs-var (boundp pkgs-var)
+               (hash-table-p (symbol-value pkgs-var)))
+      (let ((suites (symbol-value pkgs-var))
+            (visited-systems (make-hash-table :test #'equal))
+            (visited-files (make-hash-table :test #'equal)))
+        (labels ((clear-pkg (pkg-name)
+                   (let ((pkg (and (stringp pkg-name) (find-package pkg-name))))
+                     (when pkg (remhash pkg suites))))
+                 (walk-components (component)
+                   (when component
+                     (cond
+                       ((typep component 'asdf:cl-source-file)
+                        (let ((path (ignore-errors
+                                      (asdf:component-pathname component))))
+                          (when (and path
+                                     (not (gethash (namestring path)
+                                                   visited-files))
+                                     (probe-file path))
+                            (setf (gethash (namestring path) visited-files) t)
+                            (dolist (pkg-name
+                                     (%extract-defpackage-names-from-file path))
+                              (clear-pkg pkg-name)))))
+                       ((ignore-errors (asdf:component-children component))
+                        (dolist (child (asdf:component-children component))
+                          (walk-components child))))))
+                 (walk-system (name)
+                   (when (and (stringp name)
+                              (not (gethash name visited-systems)))
+                     (setf (gethash name visited-systems) t)
+                     (clear-pkg name)
+                     (let ((sys (ignore-errors (asdf:find-system name nil))))
+                       (when sys
+                         (walk-components sys)
+                         (dolist (dep (ignore-errors
+                                        (asdf:system-depends-on sys)))
+                           (cond
+                             ((stringp dep) (walk-system dep))
+                             ((and (consp dep) (stringp (second dep)))
+                              (walk-system (second dep))))))))))
+          (walk-system system-name))))))
+
 (defun %ensure-system-loaded (system-name)
   "Force-reload SYSTEM-NAME so tests always run against the latest source.
 Clears ASDF's loaded state for the system, then reloads.  This ensures
@@ -275,6 +368,10 @@ COMPILE-FILE-ERROR."
                       (ignore-errors
                         (asdf:system-source-file
                          (asdf:find-system system-name nil)))))
+                ;; Purge Rove suite registry BEFORE clearing the system,
+                ;; so any deftest forms deleted from source since the
+                ;; previous load do not linger as ghost tests.
+                (ignore-errors (%rove-purge-ghost-suites system-name))
                 (asdf:clear-system system-name)
                 (when (and asd-src (not (asdf:find-system system-name nil)))
                   (ignore-errors (asdf:load-asd asd-src)))))

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -131,7 +131,10 @@ so that MCP clients rendering only content[].text still see them."
 (defun build-load-system-response (system ht)
   "Build the standard load-system response with summary text.
 HT is the hash-table returned by load-system core.  Adds a content
-key with a human-readable summary and returns the same HT."
+key with a human-readable summary and returns the same HT.
+When warnings were captured, includes the warning text in the summary
+(truncated at ~2KB) so MCP clients rendering only content[].text can
+still see what was warned about."
   (let* ((status (gethash "status" ht))
          (summary
            (with-output-to-string (s)
@@ -139,9 +142,21 @@ key with a human-readable summary and returns the same HT."
                ((string= status "loaded")
                 (format s "System ~A loaded successfully in ~Dms"
                         system (gethash "duration_ms" ht))
-                (let ((wc (gethash "warnings" ht 0)))
+                (let ((wc (gethash "warnings" ht 0))
+                      (wd (gethash "warning_details" ht)))
                   (when (plusp wc)
-                    (format s " (~D warning~:P)" wc))))
+                    (format s " (~D warning~:P)" wc)
+                    (when (and (stringp wd) (plusp (length wd)))
+                      (let* ((limit 2048)
+                             (truncated-p (> (length wd) limit))
+                             (body (if truncated-p
+                                       (concatenate 'string
+                                                    (subseq wd 0 limit)
+                                                    (format nil
+                                                            "~%... [~D more characters truncated]"
+                                                            (- (length wd) limit)))
+                                       wd)))
+                        (format s "~%~A" (string-right-trim '(#\Newline) body)))))))
                ((string= status "timeout")
                 (format s "~A" (gethash "message" ht)))
                ((string= status "error")

--- a/src/utils/lenient-read.lisp
+++ b/src/utils/lenient-read.lisp
@@ -11,7 +11,9 @@
                 #:symbol-does-not-exist
                 #:symbol-is-not-external)
   (:export #:call-with-lenient-packages
-           #:call-with-managed-packages))
+           #:call-with-managed-packages
+           #:*homeless-due-to-teardown*
+           #:record-homeless-on-teardown))
 
 (in-package #:cl-mcp/src/utils/lenient-read)
 
@@ -19,6 +21,30 @@
   "Additional package objects treated as writable temporary packages.
 Bound by parent-side package-context synthesis so the lenient reader can
 intern/export symbols into pre-created local nickname target stubs.")
+
+(defvar *homeless-due-to-teardown*
+  #+sbcl (make-hash-table :test #'eq :weakness :key :synchronized t)
+  #-sbcl (make-hash-table :test #'eq)
+  "Weak-key hash table of symbols that became homeless because the
+synthesized package they were interned in was torn down at the end
+of a reader operation (either a lenient stub or a file-package
+context). Used by display code like lisp-read-file's form printer to
+decide whether to render a homeless symbol as `#:foo' (genuinely
+uninterned in source) or as plain `foo' (became homeless only as a
+side effect of package teardown).
+
+Entries are weakly held, so they disappear automatically when the
+owning CST form is garbage-collected.")
+
+(defun record-homeless-on-teardown (pkg)
+  "Register every symbol whose home is PKG as becoming homeless due
+to teardown. Must be called BEFORE `delete-package' so that the
+symbols' home-package relationship is still intact. Silently does
+nothing for NIL or deleted packages."
+  (when (and pkg (packagep pkg) (package-name pkg))
+    (do-symbols (s pkg)
+      (when (eq (symbol-package s) pkg)
+        (setf (gethash s *homeless-due-to-teardown*) t)))))
 
 (defun %find-restart-by-name (name-string condition)
   "Find the first restart whose name matches NAME-STRING by string comparison.
@@ -128,11 +154,13 @@ is about a missing package, a missing symbol, or a non-external symbol."
                  (when r (invoke-restart r)))))))))))
 
 (defun %cleanup-stub-packages (stubs)
-  "Delete all stub packages, first uninterning their symbols.
+  "Delete all stub packages, first recording their soon-to-be-homeless
+symbols in *HOMELESS-DUE-TO-TEARDOWN* and uninterning them.
 Safe to call even if packages have already been deleted."
   (dolist (pkg stubs)
     (let ((name (ignore-errors (package-name pkg))))
       (when (and name (find-package name))
+        (record-homeless-on-teardown pkg)
         (do-symbols (s pkg)
           (unintern s pkg))
         (delete-package pkg)))))

--- a/tests/code-test.lisp
+++ b/tests/code-test.lisp
@@ -43,6 +43,40 @@
       (ok (integerp line))
       (ok (> line 0)))))
 
+(deftest code-describe-symbol-handles-classes
+  (testing "code-describe-symbol handles CLOS classes"
+    ;; STANDARD-OBJECT is a well-known CL class that exists in any
+    ;; SBCL image. Before the fix, describe would error with
+    ;; "not bound as a function or variable".
+    (multiple-value-bind (name type arglist doc path line)
+        (code-describe-symbol "common-lisp:standard-object")
+      (declare (ignore path line))
+      (ok (stringp name))
+      (ok (string= type "class"))
+      (ok (stringp arglist)
+          "arglist should be a slot summary string"))))
+
+(deftest code-describe-symbol-handles-conditions
+  (testing "code-describe-symbol handles condition types"
+    ;; SIMPLE-ERROR is a condition type — defined via define-condition.
+    (multiple-value-bind (name type arglist doc path line)
+        (code-describe-symbol "common-lisp:simple-error")
+      (declare (ignore arglist doc path line))
+      (ok (stringp name))
+      (ok (string= type "condition")
+          "simple-error should be described as a condition"))))
+
+(deftest code-describe-symbol-handles-generic-functions
+  (testing "code-describe-symbol reports generic-function for defgeneric bindings"
+    ;; PRINT-OBJECT is a generic function in every SBCL image.
+    (multiple-value-bind (name type arglist doc path line)
+        (code-describe-symbol "common-lisp:print-object")
+      (declare (ignore doc path line))
+      (ok (stringp name))
+      (ok (string= type "generic-function")
+          "print-object should be described as a generic-function")
+      (ok (stringp arglist)))))
+
 (deftest code-find-definition-logical-pathname
   (testing "code-find-definition handles CL standard symbols with logical pathnames"
     ;; CL standard symbols like CL:CAR have source locations with logical pathnames
@@ -59,6 +93,36 @@
                 "line should be nil or a positive integer"))
           ;; Even if source not found, no crash occurred
           (ok t "code-find-definition did not crash on logical pathname")))))
+
+(deftest code-find-definition-line-points-at-open-paren
+  (testing "code-find-definition line number matches the (def... form's line"
+    ;; Regression: SBCL's character-offset may point at a newline just
+    ;; *before* the opening paren (the newline after the preceding form).
+    ;; The reported line must match the line containing `(def...' in the
+    ;; file as a human would count lines, not SBCL's raw offset.
+    (multiple-value-bind (path line)
+        (code-find-definition "cl-mcp:version")
+      (ok (stringp path))
+      (ok (integerp line))
+      (when (stringp path)
+        (let* ((abs-path
+                 (or (probe-file path)
+                     (merge-pathnames
+                      path
+                      (asdf:system-source-directory :cl-mcp))))
+               (content (and abs-path (uiop:read-file-string abs-path))))
+          (when content
+            (let* ((lines (cl-ppcre:split "\\n" content :limit nil))
+                   (line-text (and lines
+                                   (< (1- line) (length lines))
+                                   (nth (1- line) lines))))
+              (ok (stringp line-text))
+              (ok line-text
+                  "reported line should exist in the source file")
+              (when (stringp line-text)
+                (ok (or (search "(defun version" line-text)
+                        (search "(defmacro version" line-text))
+                    "reported line should contain the version def form")))))))))
 
 (deftest code-find-references-returns-project-refs
   (testing "code.find-references returns valid structure"
@@ -93,3 +157,28 @@
               ;; at the enclosing form's start.
               (ok (stringp (gethash "caller" first)))
               (ok (plusp (length (gethash "caller" first))))))))))
+
+(deftest code-format-xref-caller-normalizes-shapes
+  (testing "%format-xref-caller turns SBCL internal shapes into readable names"
+    (let ((fmt #'cl-mcp/src/code-core::%format-xref-caller))
+      ;; Regular symbol caller
+      (ok (string= "my-func" (funcall fmt 'my-func))
+          "symbol should print downcased")
+      ;; Fast method caller — the SBCL-internal shape user
+      ;; previously saw leaked through as "(fast-method NAME ...)"
+      (ok (search "defmethod"
+                  (funcall fmt
+                           (cons (intern "FAST-METHOD" "SB-PCL")
+                                 (list 'contains-p '(bloom-filter string)))))
+          "fast-method should be rendered as (defmethod ...)")
+      (ok (not (search "fast-method"
+                       (funcall fmt
+                                (cons (intern "FAST-METHOD" "SB-PCL")
+                                      (list 'contains-p
+                                            '(bloom-filter string))))))
+          "fast-method token must not leak to user")
+      ;; Lambda with absolute file path should collapse
+      (ok (string= "(lambda)" (funcall fmt '(lambda () :in "/abs/path.lisp")))
+          "lambda + file path should collapse to (lambda)")
+      (ok (not (search "/abs/path" (funcall fmt '(lambda () :in "/abs/path.lisp"))))
+          "absolute file paths must not appear in caller output"))))

--- a/tests/code-test.lisp
+++ b/tests/code-test.lisp
@@ -124,6 +124,51 @@
                         (search "(defmacro version" line-text))
                     "reported line should contain the version def form")))))))))
 
+(deftest code-offset-to-line-skips-reader-conditionals
+  (testing "%offset->line lands on (def...) even when preceded by #+ / #- / #|...|#"
+    (let* ((tmp (uiop:merge-pathnames*
+                 (format nil "cl-mcp-offset-test-~A.lisp" (get-universal-time))
+                 (uiop:temporary-directory)))
+           (path (namestring tmp))
+           (text
+            (format nil
+                    "(in-package :cl-user)~%~
+                     ~%~
+                     (defun before () :ok)~%~
+                     ~%~
+                     #|~%~
+                      block comment~%~
+                     |#~%~
+                     (defun after-block () :ok)~%~
+                     ~%~
+                     #+(or sbcl ccl)~%~
+                     (defun after-list-cond () :ok)~%~
+                     ~%~
+                     #-sbcl~%~
+                     (defun after-atom-cond () :ok)~%")))
+      (unwind-protect
+           (progn
+             (with-open-file (s path :direction :output :if-exists :supersede)
+               (write-string text s))
+             (labels ((line-of-marker (needle)
+                        (1+ (count #\Newline text :end (search needle text))))
+                      (probe-before (needle)
+                        ;; Simulate SBCL's offset landing a character or two
+                        ;; before the directive.
+                        (let ((pos (search needle text)))
+                          (cl-mcp/src/code-core::%offset->line
+                           path (max 0 (- pos 1))))))
+               (ok (= (probe-before "#|")
+                      (line-of-marker "(defun after-block"))
+                   "offset just before #|...|# should report the defun's line")
+               (ok (= (probe-before "#+(or")
+                      (line-of-marker "(defun after-list-cond"))
+                   "offset just before #+(or ...) should report the defun's line")
+               (ok (= (probe-before "#-sbcl")
+                      (line-of-marker "(defun after-atom-cond"))
+                   "offset just before #-sbcl should report the defun's line")))
+        (ignore-errors (delete-file path))))))
+
 (deftest code-find-references-returns-project-refs
   (testing "code.find-references returns valid structure"
     ;; Skip this test on macOS due to XREF instability

--- a/tests/code-test.lisp
+++ b/tests/code-test.lisp
@@ -50,7 +50,7 @@
     ;; "not bound as a function or variable".
     (multiple-value-bind (name type arglist doc path line)
         (code-describe-symbol "common-lisp:standard-object")
-      (declare (ignore path line))
+      (declare (ignore doc path line))
       (ok (stringp name))
       (ok (string= type "class"))
       (ok (stringp arglist)

--- a/tests/lisp-edit-form-test.lisp
+++ b/tests/lisp-edit-form-test.lisp
@@ -56,6 +56,58 @@ then clean up."
           (ok (search "(* x 2)" updated))
           (ok (null (search "(+ x 1)" updated))))))))
 
+(deftest lisp-edit-form-replace-with-comment-only
+  (testing "replace accepts comment-only content as a deletion marker"
+    (with-temp-file "tests/tmp/edit-form-replace-comment.lisp"
+        "(defun keep (x) x)
+
+(defun to-delete () :gone)
+
+(defun also-keep () :ok)
+"
+      (lambda (path)
+        (lisp-edit-form :file-path path
+                        :form-type "defun"
+                        :form-name "to-delete"
+                        :operation "replace"
+                        :content ";; to-delete was removed by dogfooding cleanup")
+        (let ((updated (fs-read-file path)))
+          (ok (search ";; to-delete was removed" updated))
+          (ok (null (search "(defun to-delete" updated)))
+          (ok (search "(defun keep" updated))
+          (ok (search "(defun also-keep" updated)))))))
+
+(deftest lisp-edit-form-insert-after-comment-only
+  (testing "insert_after accepts a bare comment as content"
+    (with-temp-file "tests/tmp/edit-form-insert-comment.lisp"
+        "(defun keep (x) x)
+"
+      (lambda (path)
+        (lisp-edit-form :file-path path
+                        :form-type "defun"
+                        :form-name "keep"
+                        :operation "insert_after"
+                        :content ";; TODO: add more helpers below")
+        (let ((updated (fs-read-file path)))
+          (ok (search ";; TODO: add more helpers below" updated))
+          (ok (search "(defun keep" updated)))))))
+
+(deftest lisp-edit-form-rejects-truly-empty-content
+  (testing "whitespace-only content is still rejected"
+    (with-temp-file "tests/tmp/edit-form-empty.lisp"
+        "(defun target () :ok)
+"
+      (lambda (path)
+        (let ((raised nil))
+          (handler-case
+              (lisp-edit-form :file-path path
+                              :form-type "defun"
+                              :form-name "target"
+                              :operation "replace"
+                              :content (format nil "   ~%  "))
+            (error () (setf raised t)))
+          (ok raised))))))
+
 (deftest lisp-edit-form-dry-run-preview
   (testing "dry-run returns preview without writing the file"
     (with-temp-file "tests/tmp/edit-form-dry-run.lisp"

--- a/tests/lisp-read-file-test.lisp
+++ b/tests/lisp-read-file-test.lisp
@@ -51,12 +51,37 @@
            (content (gethash "content" result)))
       (ok (stringp content))
       (ok (search "+server-version+" content))
-      ;; Symbol print form depends on whether cl-mcp/src/core package is loaded.
-      ;; If not preloaded, the temporary package is deleted after parsing, making
-      ;; symbols uninterned so write prints them as #:version.
-      (ok (or (search ": (defun version" content)
-              (search ": (defun #:version" content)))
+      ;; Symbols from packages synthesized during parsing may become
+      ;; homeless after the temporary package is deleted. The display
+      ;; suppresses the `#:' prefix via *PRINT-GENSYM* so output is
+      ;; consistent regardless of whether the package is preloaded.
+      (ok (search ": (defun version" content))
+      (ok (not (search "#:version" content)))
       (ok (not (search "(defun version () ...)" content))))))
+
+(deftest lisp-read-file-no-hash-colon-prefix-pollution
+  (testing "expanded body text has no bogus #: prefixes on normal symbols"
+    (with-temp-lisp-file
+     "tests/tmp/hash-colon-dogfood.lisp"
+     (format nil "~A~%~A~%~A~%~A~%"
+             "(defpackage #:dogfood-hash-colon-scratch (:use #:cl))"
+             "(in-package #:dogfood-hash-colon-scratch)"
+             "(defun demo (x y)"
+             "  (loop for i from 0 below x always (< i y)))")
+     (lambda (path)
+       (let* ((result (lisp-read-file path :name-pattern "demo"))
+              (content (gethash "content" result)))
+         (ok (stringp content))
+         (ok (search "(defun demo" content))
+         ;; Body references (loop, for, always, i, x, y) must NOT be
+         ;; rendered with a spurious `#:' prefix, even though the
+         ;; synthesized dogfood-hash-colon-scratch package has been
+         ;; deleted by the unwind-protect in call-with-package-context.
+         (ok (not (search "#:for" content)))
+         (ok (not (search "#:always" content)))
+         (ok (not (search "#:demo" content)))
+         (ok (not (search "#:x" content)))
+         (ok (not (search "#:i" content))))))))
 
 (deftest lisp-read-file-raw-text-mode
   (testing "raw mode slices text by offset and limit"

--- a/tests/lisp-read-file-test.lisp
+++ b/tests/lisp-read-file-test.lisp
@@ -83,6 +83,36 @@
          (ok (not (search "#:x" content)))
          (ok (not (search "#:i" content))))))))
 
+(deftest lisp-read-file-preserves-genuinely-uninterned-symbols
+  (testing "#:foo in source survives as #:foo in expanded output"
+    (with-temp-lisp-file
+     "tests/tmp/dogfood-hash-colon-preserve.lisp"
+     (format nil "~A~%~A~%~A~%~A~%~A~%~A~%"
+             ";; A defpackage with #: prefixes uses uninterned symbols"
+             "(defpackage #:dogfood-preserve-pkg"
+             "  (:use #:cl)"
+             "  (:export #:greet))"
+             "(in-package #:dogfood-preserve-pkg)"
+             "(defun greet (who) (format nil \"Hello, ~A\" who))")
+     (lambda (path)
+       (let* ((result (lisp-read-file path
+                                      :name-pattern "greet"
+                                      :content-pattern "dogfood-preserve-pkg"))
+              (content (gethash "content" result)))
+         (ok (stringp content))
+         ;; Genuine #: symbols from source must survive as #: in display.
+         (ok (search "#:dogfood-preserve-pkg" content)
+             "genuinely uninterned package name should keep #: prefix")
+         (ok (search "#:cl" content)
+             "#:cl in :use should keep #: prefix")
+         (ok (search "#:greet" content)
+             "#:greet in :export should keep #: prefix")
+         ;; But symbols that became homeless by teardown should NOT have it.
+         (ok (not (search "#:who" content))
+             "greet parameter 'who' should NOT acquire a spurious #: prefix")
+         (ok (search "(defun greet" content)
+             "defun name should render without #: prefix"))))))
+
 (deftest lisp-read-file-raw-text-mode
   (testing "raw mode slices text by offset and limit"
     (let* ((result (lisp-read-file "README.md" :collapsed nil :offset 0 :limit 3))

--- a/tests/system-loader-test.lisp
+++ b/tests/system-loader-test.lisp
@@ -66,6 +66,47 @@
       ;; No warning_details key when warnings are zero
       (ok (null (gethash "warning_details" ht))))))
 
+(deftest load-system-response-includes-warning-text
+  (testing "build-load-system-response inlines warning_details in content text"
+    ;; Build a fake load-system core result with warnings captured.
+    ;; build-load-system-response should render them into content[].text
+    ;; (the only field MCP clients display), not just the structured
+    ;; warning_details field.
+    (let ((ht (make-hash-table :test #'equal)))
+      (setf (gethash "status" ht) "loaded"
+            (gethash "system" ht) "fake-system"
+            (gethash "duration_ms" ht) 42
+            (gethash "warnings" ht) 1
+            (gethash "warning_details" ht)
+            "redefining FOO in DEFUN")
+      (let* ((built (cl-mcp/src/tools/response-builders:build-load-system-response
+                     "fake-system" ht))
+             (content (gethash "content" built))
+             (text (and (vectorp content)
+                        (plusp (length content))
+                        (gethash "text" (aref content 0)))))
+        (ok (stringp text))
+        (ok (search "System fake-system loaded successfully" text))
+        (ok (search "(1 warning)" text))
+        ;; The actual warning message must now be visible in content text.
+        (ok (search "redefining FOO" text))))))
+
+(deftest load-system-response-truncates-long-warnings
+  (testing "warning text longer than the cap is truncated with a marker"
+    (let ((ht (make-hash-table :test #'equal))
+          (long-text (make-string 3000 :initial-element #\W)))
+      (setf (gethash "status" ht) "loaded"
+            (gethash "system" ht) "fake-system"
+            (gethash "duration_ms" ht) 1
+            (gethash "warnings" ht) 1
+            (gethash "warning_details" ht) long-text)
+      (let* ((built (cl-mcp/src/tools/response-builders:build-load-system-response
+                     "fake-system" ht))
+             (content (gethash "content" built))
+             (text (gethash "text" (aref content 0))))
+        (ok (stringp text))
+        (ok (search "more characters truncated" text))))))
+
 (deftest load-system-force-false-no-clear
   (testing "force=false skips clearing and uses quickload"
     (let ((ht (load-system "cl-mcp" :force nil)))

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -289,6 +289,81 @@
       (ok (asdf:find-system system-name nil)
           "System is loaded after %%ensure-system-loaded"))))
 
+(deftest rove-purge-ghost-suites-removes-stale-tests
+  (testing "%rove-purge-ghost-suites removes deftest entries for test packages"
+    ;; Setup: write a tiny throwaway test system with two deftests,
+    ;; load it, verify both are registered, then edit the file to
+    ;; remove the second deftest and load again through
+    ;; %ensure-system-loaded. Without the purge fix, Rove would still
+    ;; remember the deleted deftest and continue running it. With the
+    ;; fix, the registry is cleared before reload and only the current
+    ;; source is honored.
+    ;;
+    ;; NOTE: A 1.1s sleep between the two source writes is required
+    ;; because POSIX file-modification timestamps on most Linux
+    ;; filesystems have 1-second resolution. Without it, ASDF's
+    ;; FASL-freshness check sees the rewritten source as not-newer-
+    ;; than the cached FASL and skips recompilation — which would
+    ;; mask the purge+reload behavior we are trying to verify.
+    ;; In real usage the edit-to-rerun interval always exceeds 1s.
+    (let* ((tmp-dir
+             (uiop:ensure-directory-pathname
+              (uiop:merge-pathnames*
+               (format nil "cl-mcp-ghost-test-~A/" (get-universal-time))
+               (uiop:temporary-directory))))
+           (asd-path (uiop:merge-pathnames* "ghost-test-sys.asd" tmp-dir))
+           (src-path (uiop:merge-pathnames* "ghost-test-body.lisp" tmp-dir))
+           (test-pkg-name "GHOST-TEST-SYS/SUITE")
+           (system-name "ghost-test-sys"))
+      (unwind-protect
+           (progn
+             (ensure-directories-exist tmp-dir)
+             (with-open-file (s asd-path :direction :output :if-exists :supersede)
+               (format s "(asdf:defsystem ~S~%  :depends-on (:rove)~%  :components ((:file \"ghost-test-body\")))~%"
+                       system-name))
+             (with-open-file (s src-path :direction :output :if-exists :supersede)
+               (format s "(defpackage #:~A~%  (:use #:cl #:rove))~%"
+                       test-pkg-name)
+               (format s "(in-package #:~A)~%" test-pkg-name)
+               (format s "(deftest alive-test (ok t))~%")
+               (format s "(deftest ghost-test (ok (= 1 2)))~%"))
+             (asdf:load-asd asd-path)
+             (asdf:load-system system-name)
+             (let* ((suite-fn (find-symbol "PACKAGE-SUITE"
+                                           :rove/core/suite/package))
+                    (tests-fn (find-symbol "SUITE-TESTS"
+                                           :rove/core/suite/package))
+                    (suite-before (funcall suite-fn test-pkg-name))
+                    (tests-before (funcall tests-fn suite-before)))
+               (ok (= 2 (length tests-before))
+                   "both alive-test and ghost-test should be registered initially")
+               ;; Ensure mtime bump is visible to ASDF's second-resolution check.
+               (sleep 1.1)
+               ;; Rewrite the source with ghost-test REMOVED.
+               (with-open-file (s src-path :direction :output :if-exists :supersede)
+                 (format s "(defpackage #:~A~%  (:use #:cl #:rove))~%"
+                         test-pkg-name)
+                 (format s "(in-package #:~A)~%" test-pkg-name)
+                 (format s "(deftest alive-test (ok t))~%"))
+               ;; Reload via the function we patched. This should PURGE
+               ;; the suite first, then load, leaving only alive-test.
+               (cl-mcp/src/test-runner-core::%ensure-system-loaded system-name)
+               (let* ((suite-after (funcall suite-fn test-pkg-name))
+                      (tests-after (funcall tests-fn suite-after)))
+                 (ok (= 1 (length tests-after))
+                     "only alive-test should remain after purge+reload")
+                 (ok (find (find-symbol "ALIVE-TEST" test-pkg-name)
+                           tests-after)
+                     "alive-test should still be present")
+                 (ok (not (find (find-symbol "GHOST-TEST" test-pkg-name)
+                                tests-after))
+                     "ghost-test must not linger after source removal"))))
+        ;; Cleanup
+        (ignore-errors (asdf:clear-system system-name))
+        (ignore-errors (let ((p (find-package test-pkg-name)))
+                         (when p (delete-package p))))
+        (ignore-errors (uiop:delete-directory-tree tmp-dir :validate t))))))
+
 (deftest format-load-error-includes-compiler-output
   (testing "no compiler output: message is just the base error"
     (let ((msg (cl-mcp/src/test-runner-core::%format-load-error


### PR DESCRIPTION
## Summary

Fixes 7 P1/P2 issues captured during the 2026-04-10 dogfooding cycle (bloom-filter). All fixes ship with regression tests.

**P1 fixes**
- `lisp-read-file` no longer pollutes expanded views with `#:` prefixes on normal symbols (was affecting LOOP keywords, making output unreadable)
- `run-tests` purges Rove's deftest registry for the test system before reload, so deftests deleted from source no longer linger as ghost tests

**P2 fixes**
- `code-describe` handles CLOS classes, condition types, structures, and generic functions (previously rejected all four with *not bound as a function or variable*)
- `code-find` reports the line containing the `(def...` form instead of SBCL's raw character-offset (which points at the newline before the form)
- `code-find-references` no longer leaks `(fast-method ...)` internal names or absolute paths from `(lambda () :in /abs/path)` wrappers
- `load-system` inlines the captured warning text (truncated at 2KB) into `content[].text` instead of only surfacing the count
- `lisp-edit-form replace` accepts comment-only content so a form can be turned into a `;; removed` marker without writing a synthetic no-op form

## What changed

| File | P | Change |
|---|---|---|
| \`src/lisp-read-file.lisp\` | P1 | bind \`*print-gensym* nil\` in \`%form->string\` / \`%collapse-def-form\` |
| \`src/test-runner-core.lisp\` | P1 | add \`%rove-purge-ghost-suites\` + \`%extract-defpackage-names-from-file\`, invoke from \`%ensure-system-loaded\` |
| \`src/code-core.lisp\` | P2 (x3) | \`code-describe-symbol\` class/condition support, \`code-find-definition\` searches 11 definition kinds, \`%offset->line\` walks forward to \`(\`, new \`%format-xref-caller\` helper |
| \`src/tools/response-builders.lisp\` | P2 | \`build-load-system-response\` inlines warning_details (2KB cap + truncation marker) |
| \`src/lisp-edit-form.lisp\` | P2 | \`%validate-and-repair-content\` accepts comment-only content for non-empty comment bodies |

## Test plan

- [x] \`mallet\` lint on all 5 changed src files — 0 problems
- [x] \`(asdf:compile-system :cl-mcp :force t)\` — 0 warnings
- [x] \`cl-mcp/tests/lisp-read-file-test\` — 28 passed (includes \`lisp-read-file-no-hash-colon-prefix-pollution\`)
- [x] \`cl-mcp/tests/lisp-edit-form-test\` — 43 passed (includes comment-only replace / insert_after tests + whitespace-rejection test)
- [x] \`cl-mcp/tests/system-loader-test\` — 11 passed (includes warning-inlining + truncation tests)
- [x] \`cl-mcp/tests/code-test\` — 11 passed (includes classes / conditions / generic-functions / off-by-N line / xref caller shapes)
- [x] \`cl-mcp/tests/test-runner-test\` — 29 passed (includes \`rove-purge-ghost-suites-removes-stale-tests\`)
- [x] \`cl-mcp/tests/integration-test\` — 6 passed

## Notes

- Parent-side tool fixes (\`lisp-read-file\`, \`lisp-edit-form\`) become active after MCP server restart; worker-side fixes (\`code-*\`, \`run-tests\`, \`load-system\`) go live on \`load-system\`.
- The ghost-suite regression test uses \`(sleep 1.1)\` between source rewrites to work around POSIX 1-second mtime resolution — in real usage, edit-to-rerun intervals always exceed 1s, so the purge is reliable.
- \`load-system\` warning inlining paid for itself during development: the previously-hidden \`redefining ...\` messages showed up every reload and made fix progress visible in real time.

## Origin

Session notes captured in \`~/.claude/memory/cl-mcp-feedback.md\` under *Session 2026-04-10 — bloom-filter*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)