### PR TITLE
fix: address P1/P2 issues from dogfooding cycle 9

### DIFF
--- a/src/clgrep.lisp
+++ b/src/clgrep.lisp
@@ -14,8 +14,6 @@
                 #:make-ht #:result #:text-content)
   (:import-from #:cl-mcp/src/tools/define-tool
                 #:define-tool)
-  (:import-from #:yason
-                #:encode)
   (:export
    #:clgrep-search))
 
@@ -157,8 +155,17 @@ Recommended workflow:
                          :include-form include-form))
          (formatted (%format-clgrep-results results)))
     (result id
-            (make-ht "content" (text-content (with-output-to-string (s)
-                                               (encode formatted s)))
+            (make-ht "content" (text-content
+                       (with-output-to-string (s)
+                         (format s "~D match~:P for ~S~@[ in ~A~]:~%"
+                                 (length formatted) pattern path)
+                         (loop for match across formatted
+                               do (format s "  ~A:~A [~A] ~A~%"
+                                          (gethash "file" match)
+                                          (gethash "line" match)
+                                          (gethash "form-type" match)
+                                          (or (gethash "signature" match)
+                                              (gethash "form-name" match))))))
                      "matches" formatted
                      "count" (length formatted)
                      "limited" (<= effective-limit (length results))))))

--- a/src/frame-inspector.lisp
+++ b/src/frame-inspector.lisp
@@ -11,7 +11,8 @@
                 #:safe-prin1)
   (:import-from #:cl-mcp/src/inspect
                 #:generate-result-preview)
-  (:export #:capture-error-context))
+  (:export #:capture-error-context
+           #:%internal-frame-p))
 
 
 (in-package #:cl-mcp/src/frame-inspector)
@@ -206,7 +207,7 @@ PREVIEW-MAX-DEPTH and PREVIEW-MAX-ELEMENTS control preview generation."
      &key (max-frames 20) (print-level 3) (print-length 10)
      (locals-preview-frames 0) (preview-max-depth 1)
      (preview-max-elements 5) (locals-preview-skip-internal t)
-     (filter-internal t))
+     (filter-internal nil))
   "Capture structured error context including frames and locals.
 
 LOCALS-PREVIEW-FRAMES: Number of top frames to include local variable previews (default: 0).

--- a/src/frame-inspector.lisp
+++ b/src/frame-inspector.lisp
@@ -136,56 +136,53 @@ Internal frames include:
                            "INVOKE-DEBUGGER" "BREAK" "EVAL")
            :test #'string-equal)))
 
-#+sbcl
-(defun %collect-frames (max-frames print-level print-length
-                        &key locals-preview-frames preview-max-depth
-                             preview-max-elements locals-preview-skip-internal)
+(defun %collect-frames
+    (max-frames print-level print-length
+     &key locals-preview-frames preview-max-depth preview-max-elements
+     locals-preview-skip-internal filter-internal)
   "Walk stack and collect frame information using SBCL backtrace API.
 LOCALS-PREVIEW-FRAMES controls how many top frames get local variable previews.
 When LOCALS-PREVIEW-SKIP-INTERNAL is true, only USER frames are counted and
 receive previews; internal frames are skipped entirely for preview purposes.
+When FILTER-INTERNAL is true, internal frames are excluded from the result
+entirely, keeping backtraces focused on user code.
 PREVIEW-MAX-DEPTH and PREVIEW-MAX-ELEMENTS control preview generation."
-  (let ((frames '())
+  (let ((frames 'nil)
         (index 0)
         (user-frame-index 0)
         (preview-frames (or locals-preview-frames 0))
         (skip-internal (and locals-preview-skip-internal t)))
     (handler-case
-        (let ((map-fn (ignore-errors
-                        (fdefinition
-                         (find-symbol "MAP-BACKTRACE" "SB-DEBUG")))))
-          (when map-fn
-            (funcall map-fn
-                     (lambda (frame)
-                       (when (< index max-frames)
-                         (let* ((function-name (%frame-function-name frame))
-                                (source-loc (%frame-source-location frame))
-                                (is-internal (%internal-frame-p function-name))
-                                ;; When skip-internal: only user frames get preview
-                                ;; When not skip-internal: count all frames
-                                (include-preview
+     (let ((map-fn
+            (ignore-errors
+             (fdefinition (find-symbol "MAP-BACKTRACE" "SB-DEBUG")))))
+       (when map-fn
+         (funcall map-fn
+                  (lambda (frame)
+                    (when (< index max-frames)
+                      (let* ((function-name (%frame-function-name frame))
+                             (source-loc (%frame-source-location frame))
+                             (is-internal (%internal-frame-p function-name)))
+                        (unless (and filter-internal is-internal)
+                          (let ((include-preview
                                  (if skip-internal
                                      (and (not is-internal)
                                           (< user-frame-index preview-frames))
                                      (< index preview-frames))))
-                           (push (list :index index
-                                       :function function-name
-                                       :source-file (getf source-loc :file)
-                                       :source-line (getf source-loc :line)
-                                       :locals
-                                       (%frame-locals frame print-level
-                                                      print-length
-                                                      :include-preview
-                                                      include-preview
-                                                      :preview-max-depth
-                                                      preview-max-depth
-                                                      :preview-max-elements
-                                                      preview-max-elements))
-                                 frames)
-                           (unless is-internal
-                             (incf user-frame-index)))
-                         (incf index))))))
-      (error () nil))
+                            (push
+                             (list :index index :function function-name
+                                   :source-file (getf source-loc :file)
+                                   :source-line (getf source-loc :line) :locals
+                                   (%frame-locals frame print-level print-length
+                                                  :include-preview include-preview
+                                                  :preview-max-depth
+                                                  preview-max-depth
+                                                  :preview-max-elements
+                                                  preview-max-elements))
+                             frames))
+                          (unless is-internal (incf user-frame-index))
+                          (incf index))))))))
+     (error nil nil))
     (nreverse frames)))
 
 #-sbcl
@@ -198,13 +195,12 @@ PREVIEW-MAX-DEPTH and PREVIEW-MAX-ELEMENTS control preview generation."
                    locals-preview-skip-internal))
   nil)
 
-(defun capture-error-context (condition &key (max-frames 20)
-                                             (print-level 3)
-                                             (print-length 10)
-                                             (locals-preview-frames 0)
-                                             (preview-max-depth 1)
-                                             (preview-max-elements 5)
-                                             (locals-preview-skip-internal t))
+(defun capture-error-context
+    (condition
+     &key (max-frames 20) (print-level 3) (print-length 10)
+     (locals-preview-frames 0) (preview-max-depth 1)
+     (preview-max-elements 5) (locals-preview-skip-internal t)
+     (filter-internal t))
   "Capture structured error context including frames and locals.
 
 LOCALS-PREVIEW-FRAMES: Number of top frames to include local variable previews (default: 0).
@@ -213,6 +209,9 @@ LOCALS-PREVIEW-FRAMES: Number of top frames to include local variable previews (
 LOCALS-PREVIEW-SKIP-INTERNAL: When true (default), skip internal frames when counting for preview.
   Internal frames include CL-MCP, SBCL internals (SB-KERNEL, etc.), ASDF, UIOP, anonymous functions.
   This ensures user code frames get previews even when buried under infrastructure frames.
+FILTER-INTERNAL: When true (default), exclude internal frames from the result entirely.
+  This keeps backtraces focused on user code by omitting CL-MCP, SBCL, and other
+  infrastructure frames.
 PREVIEW-MAX-DEPTH: Max nesting depth for local previews (default: 1).
 PREVIEW-MAX-ELEMENTS: Max elements per collection in local previews (default: 5).
 
@@ -223,14 +222,14 @@ Returns a plist with:
   :restarts - list of (:name STRING :description STRING)
   :frames - list of frame plists (SBCL only, NIL on other implementations)
             When LOCALS-PREVIEW-FRAMES > 0, locals in top frames include :preview field."
-  (list :error t
-        :condition-type (prin1-to-string (type-of condition))
-        :message (handler-case
-                     (princ-to-string condition)
-                   (error () "<error formatting condition>"))
-        :restarts (%collect-restarts)
-        :frames (%collect-frames max-frames print-level print-length
-                                 :locals-preview-frames locals-preview-frames
-                                 :preview-max-depth preview-max-depth
-                                 :preview-max-elements preview-max-elements
-                                 :locals-preview-skip-internal locals-preview-skip-internal)))
+  (list :error t :condition-type (prin1-to-string (type-of condition)) :message
+        (handler-case (princ-to-string condition)
+                      (error nil "<error formatting condition>"))
+        :restarts (%collect-restarts) :frames
+        (%collect-frames max-frames print-level print-length
+                         :locals-preview-frames locals-preview-frames
+                         :preview-max-depth preview-max-depth
+                         :preview-max-elements preview-max-elements
+                         :locals-preview-skip-internal
+                         locals-preview-skip-internal
+                         :filter-internal filter-internal)))

--- a/src/frame-inspector.lisp
+++ b/src/frame-inspector.lisp
@@ -136,10 +136,11 @@ Internal frames include:
                            "INVOKE-DEBUGGER" "BREAK" "EVAL")
            :test #'string-equal)))
 
-(defun %collect-frames
-    (max-frames print-level print-length
-     &key locals-preview-frames preview-max-depth preview-max-elements
-     locals-preview-skip-internal filter-internal)
+#+sbcl
+(defun %collect-frames (max-frames print-level print-length
+                        &key locals-preview-frames preview-max-depth
+                             preview-max-elements locals-preview-skip-internal
+                             filter-internal)
   "Walk stack and collect frame information using SBCL backtrace API.
 LOCALS-PREVIEW-FRAMES controls how many top frames get local variable previews.
 When LOCALS-PREVIEW-SKIP-INTERNAL is true, only USER frames are counted and
@@ -147,52 +148,57 @@ receive previews; internal frames are skipped entirely for preview purposes.
 When FILTER-INTERNAL is true, internal frames are excluded from the result
 entirely, keeping backtraces focused on user code.
 PREVIEW-MAX-DEPTH and PREVIEW-MAX-ELEMENTS control preview generation."
-  (let ((frames 'nil)
+  (let ((frames '())
         (index 0)
         (user-frame-index 0)
         (preview-frames (or locals-preview-frames 0))
         (skip-internal (and locals-preview-skip-internal t)))
     (handler-case
-     (let ((map-fn
-            (ignore-errors
-             (fdefinition (find-symbol "MAP-BACKTRACE" "SB-DEBUG")))))
-       (when map-fn
-         (funcall map-fn
-                  (lambda (frame)
-                    (when (< index max-frames)
-                      (let* ((function-name (%frame-function-name frame))
-                             (source-loc (%frame-source-location frame))
-                             (is-internal (%internal-frame-p function-name)))
-                        (unless (and filter-internal is-internal)
-                          (let ((include-preview
-                                 (if skip-internal
-                                     (and (not is-internal)
-                                          (< user-frame-index preview-frames))
-                                     (< index preview-frames))))
-                            (push
-                             (list :index index :function function-name
-                                   :source-file (getf source-loc :file)
-                                   :source-line (getf source-loc :line) :locals
-                                   (%frame-locals frame print-level print-length
-                                                  :include-preview include-preview
-                                                  :preview-max-depth
-                                                  preview-max-depth
-                                                  :preview-max-elements
-                                                  preview-max-elements))
-                             frames))
-                          (unless is-internal (incf user-frame-index))
-                          (incf index))))))))
-     (error nil nil))
+        (let ((map-fn (ignore-errors
+                        (fdefinition
+                         (find-symbol "MAP-BACKTRACE" "SB-DEBUG")))))
+          (when map-fn
+            (funcall map-fn
+                     (lambda (frame)
+                       (when (< index max-frames)
+                         (let* ((function-name (%frame-function-name frame))
+                                (source-loc (%frame-source-location frame))
+                                (is-internal (%internal-frame-p function-name)))
+                           (unless (and filter-internal is-internal)
+                             (let ((include-preview
+                                     (if skip-internal
+                                         (and (not is-internal)
+                                              (< user-frame-index preview-frames))
+                                         (< index preview-frames))))
+                               (push (list :index index
+                                           :function function-name
+                                           :source-file (getf source-loc :file)
+                                           :source-line (getf source-loc :line)
+                                           :locals
+                                           (%frame-locals frame print-level
+                                                          print-length
+                                                          :include-preview
+                                                          include-preview
+                                                          :preview-max-depth
+                                                          preview-max-depth
+                                                          :preview-max-elements
+                                                          preview-max-elements))
+                                     frames))
+                             (unless is-internal
+                               (incf user-frame-index))
+                             (incf index))))))))
+      (error () nil))
     (nreverse frames)))
 
 #-sbcl
 (defun %collect-frames (max-frames print-level print-length
-                        &key locals-preview-frames preview-max-depth preview-max-elements
-                             locals-preview-skip-internal)
+                        &key locals-preview-frames preview-max-depth
+                             preview-max-elements locals-preview-skip-internal
+                             filter-internal)
   "Fallback for non-SBCL: return empty frame list."
   (declare (ignore max-frames print-level print-length
                    locals-preview-frames preview-max-depth preview-max-elements
-                   locals-preview-skip-internal))
+                   locals-preview-skip-internal filter-internal))
   nil)
 
 (defun capture-error-context

--- a/src/project-scaffold.lisp
+++ b/src/project-scaffold.lisp
@@ -125,13 +125,11 @@ underlying error after cleaning up the temp directory."
       (%absolute-scaffold-paths *project-root* destination name)
     (%assert-within-project-root target-dir)
     (%assert-within-project-root temp-dir)
-    (when (uiop:directory-exists-p target-dir)
-      (if overwrite
-          (uiop:delete-directory-tree target-dir :validate t)
-          (error 'invalid-argument-error
-                 :field "name" :value name
-                 :reason (format nil "target directory already exists: ~A"
-                                 (namestring target-dir)))))
+    (when (and (uiop:directory-exists-p target-dir) (not overwrite))
+      (error 'invalid-argument-error
+             :field "name" :value name
+             :reason (format nil "target directory already exists: ~A"
+                             (namestring target-dir))))
     (let ((plan (plan-scaffold :name name
                                :description (or description "")
                                :author (or author "")
@@ -141,6 +139,11 @@ underlying error after cleaning up the temp directory."
       (unwind-protect
            (progn
              (%write-files-to-temp temp-dir plan)
+             ;; Delete existing target AFTER temp is ready, preserving
+             ;; atomicity: if %write-files-to-temp fails, the original
+             ;; scaffold survives.
+             (when (and overwrite (uiop:directory-exists-p target-dir))
+               (uiop:delete-directory-tree target-dir :validate t))
              (rename-file temp-dir target-dir)
              (setf committed t)
              (list :target-dir target-dir

--- a/src/project-scaffold.lisp
+++ b/src/project-scaffold.lisp
@@ -107,7 +107,7 @@ TEMP-DIR if any intermediate write fails."
             (content (cdr entry)))
         (fs-write-file (concatenate 'string temp-relative rel) content)))))
 
-(defun write-scaffold (&key name description author license destination)
+(defun write-scaffold (&key name description author license destination overwrite)
   "Generate the scaffold project atomically. Returns a plist with:
   :target-dir (absolute pathname)
   :relative-path (namestring relative to *project-root*)
@@ -126,10 +126,12 @@ underlying error after cleaning up the temp directory."
     (%assert-within-project-root target-dir)
     (%assert-within-project-root temp-dir)
     (when (uiop:directory-exists-p target-dir)
-      (error 'invalid-argument-error
-             :field "name" :value name
-             :reason (format nil "target directory already exists: ~A"
-                             (namestring target-dir))))
+      (if overwrite
+          (uiop:delete-directory-tree target-dir :validate t)
+          (error 'invalid-argument-error
+                 :field "name" :value name
+                 :reason (format nil "target directory already exists: ~A"
+                                 (namestring target-dir)))))
     (let ((plan (plan-scaffold :name name
                                :description (or description "")
                                :author (or author "")
@@ -172,7 +174,9 @@ cl-mcp's tool surface."
    (license :type :string :description
             "License string for .asd :license. No newlines.")
    (destination :type :string :description
-                "Relative parent directory under project root where <name>/ is created. Default: scaffolds."))
+                "Relative parent directory under project root where <name>/ is created. Default: scaffolds.")
+   (overwrite :type :boolean :description
+              "When true, replace an existing scaffold directory instead of failing."))
   :body
   (handler-case
       (let* ((result-plist
@@ -181,7 +185,8 @@ cl-mcp's tool surface."
                :description (or description "A Common Lisp project scaffolded by cl-mcp.")
                :author (or author "Unknown")
                :license (or license "MIT")
-               :destination (or destination "scaffolds")))
+               :destination (or destination "scaffolds")
+               :overwrite overwrite))
              (target-dir (getf result-plist :target-dir))
              (relative (getf result-plist :relative-path))
              (files (getf result-plist :files))
@@ -190,7 +195,7 @@ cl-mcp's tool surface."
              (next-steps
               (vector
                (format nil
-                       "To register with ASDF: run repl-eval with (asdf:load-asd ~S)"
+                       "Auto-registered with ASDF. To re-register: (asdf:load-asd ~S)"
                        abs-asd)
                (format nil
                        "To load: run load-system with {\"system\": ~S}"
@@ -201,6 +206,8 @@ cl-mcp's tool surface."
                (format nil
                        "To edit: use lisp-edit-form with paths under ~A"
                        relative))))
+        ;; Auto-register with ASDF
+        (ignore-errors (asdf/find-system:load-asd abs-asd))
         (result id
                 (make-ht
                  "created" t

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -15,7 +15,8 @@
                 #:make-ht)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-for-json)
-  (:export #:load-system))
+  (:export #:load-system
+           #:*last-compiler-stderr*))
 
 (in-package #:cl-mcp/src/system-loader-core)
 
@@ -67,12 +68,23 @@ returned as a success -- completed work is never discarded as a timeout."
         (error (c)
           (values (list c) nil t)))))
 
+(defvar *last-compiler-stderr* nil
+  "Captured compiler stderr from the most recent %call-with-suppressed-output call.
+Always set via unwind-protect so it survives error unwinds.  When the call
+completes normally this is set to NIL; on error it holds the stderr string
+accumulated up to the point of failure.")
+
 (defun %call-with-suppressed-output (thunk)
   "Call THUNK with compilation and load output suppressed.
-Returns (values thunk-result warning-count warning-details)."
+Returns (values thunk-result warning-count warning-details compiler-stderr).
+The stderr string is also saved to *last-compiler-stderr* via unwind-protect
+so it survives error unwinds and can be retrieved by callers that catch the error."
   (let ((warning-count 0)
         (warning-details (make-string-output-stream))
         (stderr (make-string-output-stream)))
+    ;; Reset before each call so stale data from a previous run is not
+    ;; mistakenly attributed to this invocation.
+    (setf *last-compiler-stderr* nil)
     #+sbcl
     (let ((err-sym (find-symbol "*COMPILER-ERROR-OUTPUT*" "SB-C"))
           (note-sym (find-symbol "*COMPILER-NOTE-STREAM*" "SB-C"))
@@ -82,48 +94,68 @@ Returns (values thunk-result warning-count warning-details)."
       (when err-sym (push err-sym syms) (push stderr vals))
       (when note-sym (push note-sym syms) (push stderr vals))
       (when trace-sym (push trace-sym syms) (push nil vals))
-      (let ((result
-              (handler-bind
-                  ((warning
-                     (lambda (w)
-                       (incf warning-count)
-                       (format warning-details "~A~%" w)
-                       (when (find-restart 'muffle-warning)
-                         (invoke-restart 'muffle-warning)))))
-                (let ((*compile-verbose* nil)
-                      (*compile-print* nil)
-                      (*load-verbose* nil)
-                      (*load-print* nil)
-                      (*standard-output* (make-string-output-stream))
-                      (*trace-output* (make-string-output-stream))
-                      (*error-output* stderr))
-                  (if syms
-                      (progv (nreverse syms) (nreverse vals)
-                        (with-compilation-unit (:override t)
-                          (funcall thunk)))
-                      (with-compilation-unit (:override t)
-                        (funcall thunk)))))))
-        (values result warning-count
-                (get-output-stream-string warning-details))))
+      (let ((result nil)
+            (completed-p nil))
+        (unwind-protect
+            (progn
+              (setf result
+                    (handler-bind
+                        ((warning
+                           (lambda (w)
+                             (incf warning-count)
+                             (format warning-details "~A~%" w)
+                             (when (find-restart 'muffle-warning)
+                               (invoke-restart 'muffle-warning)))))
+                      (let ((*compile-verbose* nil)
+                            (*compile-print* nil)
+                            (*load-verbose* nil)
+                            (*load-print* nil)
+                            (*standard-output* (make-string-output-stream))
+                            (*trace-output* (make-string-output-stream))
+                            (*error-output* stderr))
+                        (if syms
+                            (progv (nreverse syms) (nreverse vals)
+                              (with-compilation-unit (:override t)
+                                (funcall thunk)))
+                            (with-compilation-unit (:override t)
+                              (funcall thunk))))))
+              (setf completed-p t)
+              (values result warning-count
+                      (get-output-stream-string warning-details)
+                      (get-output-stream-string stderr)))
+          ;; Always capture stderr so it survives error unwind.
+          (unless completed-p
+            (setf *last-compiler-stderr*
+                  (ignore-errors (get-output-stream-string stderr)))))))
     #-sbcl
-    (let ((result
-            (handler-bind
-                ((warning
-                   (lambda (w)
-                     (incf warning-count)
-                     (format warning-details "~A~%" w)
-                     (when (find-restart 'muffle-warning)
-                       (invoke-restart 'muffle-warning)))))
-              (let ((*compile-verbose* nil)
-                    (*compile-print* nil)
-                    (*load-verbose* nil)
-                    (*load-print* nil)
-                    (*standard-output* (make-string-output-stream))
-                    (*trace-output* (make-string-output-stream))
-                    (*error-output* stderr))
-                (funcall thunk)))))
-      (values result warning-count
-              (get-output-stream-string warning-details)))))
+    (let ((result nil)
+          (completed-p nil))
+      (unwind-protect
+          (progn
+            (setf result
+                  (handler-bind
+                      ((warning
+                         (lambda (w)
+                           (incf warning-count)
+                           (format warning-details "~A~%" w)
+                           (when (find-restart 'muffle-warning)
+                             (invoke-restart 'muffle-warning)))))
+                    (let ((*compile-verbose* nil)
+                          (*compile-print* nil)
+                          (*load-verbose* nil)
+                          (*load-print* nil)
+                          (*standard-output* (make-string-output-stream))
+                          (*trace-output* (make-string-output-stream))
+                          (*error-output* stderr))
+                      (funcall thunk))))
+            (setf completed-p t)
+            (values result warning-count
+                    (get-output-stream-string warning-details)
+                    (get-output-stream-string stderr)))
+        ;; Always capture stderr so it survives error unwind.
+        (unless completed-p
+          (setf *last-compiler-stderr*
+                (ignore-errors (get-output-stream-string stderr))))))))
 
 (declaim (ftype (function (string &key (:force boolean)
                                        (:clear-fasls boolean)
@@ -182,21 +214,28 @@ or NIL (no timeout). Default is 120 seconds."
                       "system" system-name
                       "timeout" timeout-seconds))
           (errored-p
-           (let ((err (first result-list)))
+           (let ((err (first result-list))
+                 (compiler-stderr *last-compiler-stderr*))
              (setf (gethash "status" ht) "error")
              (setf (gethash "duration_ms" ht) elapsed-ms)
              (setf (gethash "message" ht)
                    (sanitize-for-json
                     (or (ignore-errors (princ-to-string err))
                         (format nil "~A" (type-of err)))))
+             (when (and (stringp compiler-stderr)
+                        (plusp (length compiler-stderr)))
+               (setf (gethash "compiler_output" ht)
+                     (sanitize-for-json compiler-stderr)))
              (log-event :error "load-system-error"
                         "system" system-name
                         "error" (or (ignore-errors (princ-to-string err))
                                     "unprintable error"))))
           (t
-           (destructuring-bind (load-result warning-count warning-details)
+           (destructuring-bind
+                 (load-result warning-count warning-details
+                  &optional compiler-stderr)
                result-list
-             (declare (ignore load-result))
+             (declare (ignore load-result compiler-stderr))
              (setf (gethash "status" ht) "loaded")
              (setf (gethash "duration_ms" ht) elapsed-ms)
              (setf (gethash "forced" ht) force)

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -538,6 +538,8 @@ detects test sub-systems from ASDF dependencies and runs each individually."
          (test-name-fn (fdefinition (find-symbol "TEST-NAME" result-pkg)))
          (report-stream-sym (find-symbol "*REPORT-STREAM*" reporter-pkg))
          (last-report-sym (find-symbol "*LAST-SUITE-REPORT*" rove-pkg))
+         (pkgs-var (find-symbol "*PACKAGE-SUITES*"
+                                :rove/core/suite/package))
          (_ (unless (and report-stream-sym last-report-sym)
               (error "Rove internal symbols not found (~A ~A); incompatible Rove version?"
                      report-stream-sym last-report-sym)))
@@ -645,6 +647,18 @@ the surrounding passed/failed/pending/failure-details bindings."
                       (let ((run-ok nil))
                         (handler-case
                             (progn
+                              ;; Purge Rove suite for this sub-system so
+                              ;; rove:run rebuilds from fresh deftests,
+                              ;; producing a full 3-level result structure.
+                              (when (and pkgs-var (boundp pkgs-var)
+                                         (hash-table-p (symbol-value pkgs-var)))
+                                (let ((pkg (find-package (string-upcase sub-sys))))
+                                  (when pkg
+                                    (remhash pkg (symbol-value pkgs-var)))))
+                              ;; Clear ASDF loaded state so rove:run
+                              ;; triggers a real reload of deftest forms.
+                              (ignore-errors
+                                (asdf/system-registry:clear-system sub-sys))
                               ;; progv: bind late-resolved Rove special
                               ;; (see M1 guard above for nil safety)
                               (progv (list report-stream-sym)

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -17,6 +17,8 @@
                 #:sanitize-for-json)
   (:import-from #:cl-mcp/src/repl-core
                 #:*default-max-output-length*)
+  (:import-from #:cl-mcp/src/frame-inspector
+                #:%internal-frame-p)
   (:export #:build-eval-response
            #:build-load-system-response
            #:build-run-tests-response
@@ -30,34 +32,41 @@
 (defun %build-error-context-ht (error-context)
   "Build a hash-table from an error-context plist for JSON serialization.
 ERROR-CONTEXT is a plist with keys :condition-type, :message, :restarts,
-and :frames as returned by repl-eval."
-  (make-ht
-   "condition_type" (sanitize-for-json (getf error-context :condition-type))
-   "message" (sanitize-for-json (getf error-context :message))
-   "restarts"
-   (mapcar (lambda (r)
-             (make-ht "name" (sanitize-for-json (getf r :name))
-                      "description" (sanitize-for-json (getf r :description))))
-           (getf error-context :restarts))
-   "frames"
-   (mapcar (lambda (f)
-             (make-ht
-              "index" (getf f :index)
-              "function" (sanitize-for-json (getf f :function))
-              "source_file" (getf f :source-file)
-              "source_line" (getf f :source-line)
-              "locals"
-              (mapcar (lambda (l)
-                        (let ((lht (make-ht
-                                    "name" (sanitize-for-json (getf l :name))
-                                    "value" (sanitize-for-json (getf l :value)))))
-                          (when (getf l :object-id)
-                            (setf (gethash "object_id" lht) (getf l :object-id)))
-                          (when (getf l :preview)
-                            (setf (gethash "preview" lht) (getf l :preview)))
-                          lht))
-                      (getf f :locals))))
-           (getf error-context :frames))))
+and :frames as returned by repl-eval.
+Internal/infrastructure frames (CL-MCP, SBCL internals, ASDF, etc.) are
+filtered out so that the user-visible backtrace focuses on application code."
+  (let ((user-frames
+          (remove-if (lambda (f)
+                       (%internal-frame-p
+                        (or (getf f :function) "")))
+                     (getf error-context :frames))))
+    (make-ht
+     "condition_type" (sanitize-for-json (getf error-context :condition-type))
+     "message" (sanitize-for-json (getf error-context :message))
+     "restarts"
+     (mapcar (lambda (r)
+               (make-ht "name" (sanitize-for-json (getf r :name))
+                        "description" (sanitize-for-json (getf r :description))))
+             (getf error-context :restarts))
+     "frames"
+     (mapcar (lambda (f)
+               (make-ht
+                "index" (getf f :index)
+                "function" (sanitize-for-json (getf f :function))
+                "source_file" (getf f :source-file)
+                "source_line" (getf f :source-line)
+                "locals"
+                (mapcar (lambda (l)
+                          (let ((lht (make-ht
+                                      "name" (sanitize-for-json (getf l :name))
+                                      "value" (sanitize-for-json (getf l :value)))))
+                            (when (getf l :object-id)
+                              (setf (gethash "object_id" lht) (getf l :object-id)))
+                            (when (getf l :preview)
+                              (setf (gethash "preview" lht) (getf l :preview)))
+                            lht))
+                        (getf f :locals))))
+             user-frames))))
 
 (defun build-eval-response (printed raw-value stdout stderr error-context
                             &key include-result-preview
@@ -122,19 +131,18 @@ so that MCP clients rendering only content[].text still see them."
                                     restarts)))
                   (when frames
                     (format s "~&Backtrace:")
-                    ;; Show at most 5 frames in content text;
-                    ;; full backtrace is in structured error_context.
-                    (loop for frame in frames
-                          for i below 5
-                          for fn = (sanitize-for-json
-                                    (getf frame :function))
-                          for src = (sanitize-for-json
-                                     (getf frame :source-file))
-                          for line = (getf frame :source-line)
+                    ;; Filter internal frames; show at most 5 user frames.
+                    (loop with shown = 0
+                          for frame in frames
+                          for fn = (or (getf frame :function) "")
+                          unless (%internal-frame-p fn)
                           do (format s "~&  ~A: ~A~@[ (~A~@[:~A~])~]"
                                      (or (getf frame :index) "?")
-                                     (or fn "?")
-                                     src line))))))))
+                                     (sanitize-for-json fn)
+                                     (sanitize-for-json (getf frame :source-file))
+                                     (getf frame :source-line))
+                             (incf shown)
+                          until (>= shown 5))))))))
       (setf (gethash "content" ht)
             (text-content
              (if (> (length enriched) effective-limit)

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -34,12 +34,16 @@
 ERROR-CONTEXT is a plist with keys :condition-type, :message, :restarts,
 and :frames as returned by repl-eval.
 Internal/infrastructure frames (CL-MCP, SBCL internals, ASDF, etc.) are
-filtered out so that the user-visible backtrace focuses on application code."
-  (let ((user-frames
-          (remove-if (lambda (f)
-                       (%internal-frame-p
-                        (or (getf f :function) "")))
-                     (getf error-context :frames))))
+filtered out so that the user-visible backtrace focuses on application code.
+If filtering would remove ALL frames, the filter is skipped to preserve
+useful debug information."
+  (let* ((all-frames (getf error-context :frames))
+         (user-frames
+           (remove-if (lambda (f)
+                        (%internal-frame-p (or (getf f :function) "")))
+                      all-frames))
+         ;; Fall back to all frames when filtering removes everything
+         (display-frames (if user-frames user-frames all-frames)))
     (make-ht
      "condition_type" (sanitize-for-json (getf error-context :condition-type))
      "message" (sanitize-for-json (getf error-context :message))
@@ -49,24 +53,26 @@ filtered out so that the user-visible backtrace focuses on application code."
                         "description" (sanitize-for-json (getf r :description))))
              (getf error-context :restarts))
      "frames"
-     (mapcar (lambda (f)
-               (make-ht
-                "index" (getf f :index)
-                "function" (sanitize-for-json (getf f :function))
-                "source_file" (getf f :source-file)
-                "source_line" (getf f :source-line)
-                "locals"
-                (mapcar (lambda (l)
-                          (let ((lht (make-ht
-                                      "name" (sanitize-for-json (getf l :name))
-                                      "value" (sanitize-for-json (getf l :value)))))
-                            (when (getf l :object-id)
-                              (setf (gethash "object_id" lht) (getf l :object-id)))
-                            (when (getf l :preview)
-                              (setf (gethash "preview" lht) (getf l :preview)))
-                            lht))
-                        (getf f :locals))))
-             user-frames))))
+     (coerce
+      (mapcar (lambda (f)
+                (make-ht
+                 "index" (getf f :index)
+                 "function" (sanitize-for-json (getf f :function))
+                 "source_file" (getf f :source-file)
+                 "source_line" (getf f :source-line)
+                 "locals"
+                 (mapcar (lambda (l)
+                           (let ((lht (make-ht
+                                       "name" (sanitize-for-json (getf l :name))
+                                       "value" (sanitize-for-json (getf l :value)))))
+                             (when (getf l :object-id)
+                               (setf (gethash "object_id" lht) (getf l :object-id)))
+                             (when (getf l :preview)
+                               (setf (gethash "preview" lht) (getf l :preview)))
+                             lht))
+                         (getf f :locals))))
+              display-frames)
+      'vector))))
 
 (defun build-eval-response (printed raw-value stdout stderr error-context
                             &key include-result-preview

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -180,7 +180,22 @@ Use pool-kill-worker to get a fresh worker, then re-run load-system.")))))))
                 (format s "~A" (gethash "message" ht)))
                ((string= status "error")
                 (format s "Error loading ~A: ~A"
-                        system (gethash "message" ht)))))))
+                        system (gethash "message" ht))
+                (let ((co (gethash "compiler_output" ht)))
+                  (when (and (stringp co) (plusp (length co)))
+                    (let* ((limit 2048)
+                           (truncated-p (> (length co) limit))
+                           (body (if truncated-p
+                                     (concatenate
+                                      'string (subseq co 0 limit)
+                                      (format nil
+                                              "~%... [~D more characters truncated]"
+                                              (- (length co) limit)))
+                                     co)))
+                      (format s "~%~%Compiler output:~%~A"
+                              (string-right-trim '(#\Newline) body)))))
+                (format s "~%~%Hint: the worker process may now have a broken package state. ~
+Use pool-kill-worker to get a fresh worker, then retry load-system."))))))
     (setf (gethash "content" ht) (text-content summary))
     ht))
 


### PR DESCRIPTION
## Summary

- **P1**: `run-tests` aggregate test systems (e.g., `my-proj/tests`) now report correct pass/fail counts instead of `Passed: 0, Failed: 0`. Root cause: fallback sub-system runs reused stale Rove suite state, producing a shallow result structure. Fix purges each sub-system's Rove `*PACKAGE-SUITES*` entry and clears its ASDF loaded state before `rove:run`.
- **P2**: `load-system` compile errors now include compiler stderr diagnostics (via `*last-compiler-stderr*` surviving error unwind) and a `pool-kill-worker` hint
- **P2**: `project-scaffold` gains `overwrite` parameter and auto-registers `.asd` with ASDF
- **P2**: `error_context` backtraces filter CL-MCP/SBCL internal frames by default (`filter-internal` parameter)
- **P2**: `clgrep-search` content text changed from raw JSON to human-readable `file:line [type] name` format

## Test plan

- [x] All existing cl-mcp test suites pass (integration, protocol, validate, lisp-edit-form, lisp-read-file, lisp-patch-form, parinfer, clhs)
- [x] P1 verified: `run-tests system=event-bus/tests` correctly reports `Passed: 21` (was `Passed: 0`)
- [x] `mallet` lint clean on all 6 modified files
- [x] Full `compile-system :force t` with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)