### PR TITLE
fix(run-tests): surface system-load failures as structured test result

### DIFF
--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -280,7 +280,8 @@ opaque RPC-level error.  Mirrors the timeout pattern used by
      (format nil "~A~%~%Hint: the worker process may have a broken ~
                   package state. Use pool-kill-worker to get a fresh ~
                   worker, then retry run-tests."
-             condition)))))
+             (or (ignore-errors (princ-to-string condition))
+                 "unprintable condition"))))))
 
 (defun %extract-defpackage-names-from-file (pathname)
   "Return a list of package names mentioned in `(defpackage ...)' forms
@@ -849,8 +850,13 @@ error, the failure is converted via MAKE-LOAD-FAILURE-RESULT so callers
 always receive a structured hash.  Errors raised after the load step
 (e.g., framework-internal errors) still propagate normally."
   (when (and test tests) (error "Specify either TEST or TESTS, not both"))
+  ;; %ensure-system-loaded re-raises load failures via (error "~A" ...),
+  ;; so simple-error is the precise contract.  Catching plain ERROR would
+  ;; mask serious-condition subclasses or interactive-interrupt that
+  ;; should bubble up as bugs rather than be silently bucketed into a
+  ;; load-failure result.
   (handler-case (%ensure-system-loaded system-name)
-    (error (load-err)
+    (simple-error (load-err)
       (return-from run-tests
         (make-load-failure-result system-name load-err))))
   (let ((fw (%resolve-framework system-name framework))

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -10,6 +10,7 @@
                 #:make-ht)
   (:export #:run-tests
            #:detect-test-framework
+           #:make-load-failure-result
            #:*test-debug-output*
            #:*max-test-output-length*))
 
@@ -257,6 +258,29 @@ Shows the condition type explicitly to aid root-cause diagnosis."
                 system-name ctype cmsg tail)
         (format nil "Failed to load test system ~A:~%  [~A] ~A"
                 system-name ctype cmsg))))
+
+(defun make-load-failure-result (system-name condition)
+  "Convert a test-system load failure into a structured test-result so
+RUN-TESTS returns a normal MCP response (failed:1 with a synthetic
+SYSTEM-LOAD entry) instead of letting the condition propagate as an
+opaque RPC-level error.  Mirrors the timeout pattern used by
+%handle-run-tests in worker/handlers.lisp."
+  (make-test-result
+   :passed 0
+   :failed 1
+   :pending 0
+   :framework :load-error
+   :duration 0
+   :failed-tests
+   (vector
+    (make-failure-detail
+     :test-name "SYSTEM-LOAD"
+     :description (format nil "Could not load test system ~A" system-name)
+     :reason
+     (format nil "~A~%~%Hint: the worker process may have a broken ~
+                  package state. Use pool-kill-worker to get a fresh ~
+                  worker, then retry run-tests."
+             condition)))))
 
 (defun %extract-defpackage-names-from-file (pathname)
   "Return a list of package names mentioned in `(defpackage ...)' forms
@@ -818,31 +842,31 @@ the surrounding passed/failed/pending/failure-details bindings."
   "Run tests for SYSTEM-NAME using the specified or auto-detected FRAMEWORK.
 If TEST is provided, run only that specific test.
 If TESTS is provided, run those specific tests (array/list of fully qualified names).
-Returns a hash table with structured results."
-  (when (and test tests)
-    (error "Specify either TEST or TESTS, not both"))
-  ;; Load the test system before framework detection so that framework
-  ;; packages (e.g. :rove) are available for detect-test-framework.
-  ;; Without this, a freshly started process without Rove pre-loaded
-  ;; would fall back to the ASDF text-capture path that cannot report
-  ;; individual test counts (always returns passed=0, failed=0).
-  (%ensure-system-loaded system-name)
+Returns a hash table with structured results.
+
+If the implicit system-load step (%ENSURE-SYSTEM-LOADED) signals an
+error, the failure is converted via MAKE-LOAD-FAILURE-RESULT so callers
+always receive a structured hash.  Errors raised after the load step
+(e.g., framework-internal errors) still propagate normally."
+  (when (and test tests) (error "Specify either TEST or TESTS, not both"))
+  (handler-case (%ensure-system-loaded system-name)
+    (error (load-err)
+      (return-from run-tests
+        (make-load-failure-result system-name load-err))))
   (let ((fw (%resolve-framework system-name framework))
-         (selective-requested-p (or test tests)))
+        (selective-requested-p (or test tests)))
     (log-event :info "test-runner" "action" "run-tests" "system" system-name
-               "framework" (string-downcase (symbol-name fw))
-               "test" (cond
-                         (test (princ-to-string test))
-                         (tests "selected")
-                         (t "all")))
+               "framework" (string-downcase (symbol-name fw)) "test"
+               (cond (test (princ-to-string test)) (tests "selected")
+                     (t "all")))
     (case fw
       (:rove
-       ;; System already force-reloaded above; no second load needed.
        (if (find-package :rove)
            (if selective-requested-p
-               (let ((selected-tests (if test
-                                         (list (%coerce-test-symbol test))
-                                         (%normalize-tests-arg tests))))
+               (let ((selected-tests
+                      (if test
+                          (list (%coerce-test-symbol test))
+                          (%normalize-tests-arg tests))))
                  (run-rove-selected-tests selected-tests))
                (run-rove-tests system-name))
            (if selective-requested-p
@@ -850,22 +874,25 @@ Returns a hash table with structured results."
                 "Selective test execution with TEST/TESTS requires Rove for system ~A"
                 system-name)
                (progn
-                 (log-event :warn "test-runner" "message"
-                            "Rove not loaded, using ASDF fallback")
-                 (run-asdf-fallback system-name)))))
+                (log-event :warn "test-runner" "message"
+                           "Rove not loaded, using ASDF fallback")
+                (run-asdf-fallback system-name)))))
       (:fiveam
        (when selective-requested-p
-         (error "Selective test execution is currently supported only with Rove"))
+         (error
+          "Selective test execution is currently supported only with Rove"))
        (log-event :warn "test-runner" "message"
                   "FiveAM support not yet implemented")
        (run-asdf-fallback system-name))
       (:prove
        (when selective-requested-p
-         (error "Selective test execution is currently supported only with Rove"))
+         (error
+          "Selective test execution is currently supported only with Rove"))
        (log-event :warn "test-runner" "message"
                   "Prove support not yet implemented")
        (run-asdf-fallback system-name))
       (t
        (when selective-requested-p
-         (error "Selective test execution is currently supported only with Rove"))
+         (error
+          "Selective test execution is currently supported only with Rove"))
        (run-asdf-fallback system-name)))))

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -249,9 +249,10 @@ Raw stdout/stderr are kept in structured fields only (not in content text)."
          (summary
           (with-output-to-string (s)
             (format s "~A~%"
-                    (if (zerop failed)
-                        "✓ PASS"
-                        "✗ FAIL"))
+                    (cond ((string= framework-name "load-error") "✗ LOAD FAILED")
+                          ((string= framework-name "timeout") "✗ TIMEOUT")
+                          ((zerop failed) "✓ PASS")
+                          (t "✗ FAIL")))
             (format s "Passed: ~D, Failed: ~D~@[, Pending: ~D~]~%" passed
                     failed (when (plusp pending) pending))
             (format s "Duration: ~Dms~%" duration)

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -392,3 +392,65 @@
       (ok (search "line 59" msg))
       ;; Truncated: line 0 should be gone (*load-error-tail-max-lines* = 40)
       (ok (null (search "line 0 of" msg))))))
+
+(deftest run-tests-load-failure-returns-structured-result
+  (testing "compile error during system load surfaces as load-error result"
+    (let* ((tmp-dir
+            (uiop:ensure-directory-pathname
+             (uiop:merge-pathnames*
+              (format nil "cl-mcp-load-fail-~A/" (get-universal-time))
+              (uiop:temporary-directory))))
+           (asd-path (uiop:merge-pathnames* "broken-loadfail-sys.asd" tmp-dir))
+           (src-path (uiop:merge-pathnames* "broken-loadfail.lisp" tmp-dir))
+           (system-name "broken-loadfail-sys"))
+      (unwind-protect
+           (progn
+             (ensure-directories-exist tmp-dir)
+             (with-open-file (s asd-path :direction :output :if-exists :supersede)
+               (format s "(asdf:defsystem ~S~%  :components ((:file \"broken-loadfail\")))~%"
+                       system-name))
+             (with-open-file (s src-path :direction :output :if-exists :supersede)
+               (format s "(defpackage #:broken-loadfail (:use #:cl))~%")
+               (format s "(in-package #:broken-loadfail)~%")
+               (format s "(defun oops ("))
+             (asdf:load-asd asd-path)
+             (let ((result (run-tests system-name)))
+               (ok (= 0 (gethash "passed" result)))
+               (ok (= 1 (gethash "failed" result)))
+               (ok (string= "load-error" (gethash "framework" result))
+                   "framework field marks the failure category")
+               (let* ((fails (gethash "failed_tests" result))
+                      (first (and (vectorp fails)
+                                  (plusp (length fails))
+                                  (aref fails 0))))
+                 (ok first "failed_tests has at least one entry")
+                 (when first
+                   (ok (string= "SYSTEM-LOAD" (gethash "test_name" first))
+                       "synthetic test_name is SYSTEM-LOAD")
+                   (ok (search "pool-kill-worker" (gethash "reason" first))
+                       "reason carries the recovery hint")
+                   (ok (search system-name (gethash "description" first))
+                       "description names the offending system")))))
+        (ignore-errors (asdf:clear-system system-name))
+        (ignore-errors (uiop:delete-directory-tree tmp-dir :validate t))))))
+
+(deftest build-run-tests-response-uses-load-failed-banner
+  (testing "load-error framework renders as ✗ LOAD FAILED in summary"
+    (let* ((result
+            (cl-mcp/src/test-runner-core::make-load-failure-result
+             "some-system"
+             (make-condition 'simple-error
+                             :format-control "boom"
+                             :format-arguments nil)))
+           (response (build-run-tests-response result))
+           (content (gethash "content" response))
+           (text (when (and (vectorp content) (plusp (length content)))
+                   (gethash "text" (aref content 0)))))
+      (ok text "response has content text")
+      (when text
+        (ok (search "LOAD FAILED" text)
+            "summary uses LOAD FAILED banner instead of generic FAIL")
+        (ok (search "SYSTEM-LOAD" text)
+            "summary lists the synthetic SYSTEM-LOAD failure")
+        (ok (search "pool-kill-worker" text)
+            "recovery hint surfaces in the rendered text")))))

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -398,7 +398,8 @@
     (let* ((tmp-dir
             (uiop:ensure-directory-pathname
              (uiop:merge-pathnames*
-              (format nil "cl-mcp-load-fail-~A/" (get-universal-time))
+              (format nil "cl-mcp-load-fail-~A-~A/"
+                      (get-universal-time) (random 100000))
               (uiop:temporary-directory))))
            (asd-path (uiop:merge-pathnames* "broken-loadfail-sys.asd" tmp-dir))
            (src-path (uiop:merge-pathnames* "broken-loadfail.lisp" tmp-dir))


### PR DESCRIPTION
## Summary

- `run-tests` previously let `%ensure-system-loaded` errors propagate to the RPC dispatcher, surfacing as `JSON-RPC error -32603: Internal error: ...` with no structured `failed_tests` array, no recovery hint, and truncated compiler output.
- New `make-load-failure-result` helper converts load-phase errors into a normal hash with `framework: "load-error"`, `failed: 1`, and a synthetic `SYSTEM-LOAD` failure entry that carries the formatted message + `Use pool-kill-worker...` hint.
- `run-tests` wraps **only** `%ensure-system-loaded` in `handler-case` (post-load framework errors still propagate normally — scope is intentionally narrow).
- `build-run-tests-response` renders explicit `✗ LOAD FAILED` (and `✗ TIMEOUT`) banners so clients reading only `content[].text` can distinguish load failures from real test failures.
- Mirrors the existing timeout pattern in `%handle-run-tests` (`framework: "timeout"` + synthetic entry).

## Background

Discovered during a dogfooding cycle: a self-inflicted `NAME-CONFLICT` on a stale `:import-from` produced an opaque `Worker error: JSON-RPC error -32603: ... [NAME-CONFLICT] IMPORT (...) causes name-conflicts ...` with `Compiler output (most recent): ...` truncated mid-string. The same failure on the `load-system` path returns a clean structured response with the recovery hint — this PR brings `run-tests` to parity. Logged as P2-2 in `claudedocs/dogfooding-feedback.md` (2026-04-18 dice-engine session).

## Test plan

- [x] `mallet src/test-runner-core.lisp src/tools/response-builders.lisp tests/test-runner-test.lisp` → no problems
- [x] Full `rove cl-mcp.asd` suite green (no `✗` lines)
- [x] New `run-tests-load-failure-returns-structured-result` test verifies the path with a deliberately broken `defun oops (` source: `passed=0`, `failed=1`, `framework="load-error"`, `failed_tests[0]` carries the `pool-kill-worker` hint
- [x] New `build-run-tests-response-uses-load-failed-banner` test verifies `LOAD FAILED` text in the rendered summary
- [x] Existing `format-load-error-includes-compiler-output` and `run-tests-single-test-loads-target-system-package` unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)