### PR TITLE
frame-inspector: avoid locked SB-C intern on old SBCL

### DIFF
--- a/src/frame-inspector.lisp
+++ b/src/frame-inspector.lisp
@@ -74,6 +74,17 @@ When INCLUDE-PREVIEW is true, generates structural preview for non-primitive loc
     (nreverse locals)))
 
 #+sbcl
+(defun %debug-source-start-positions (debug-source)
+  "Return DEBUG-SOURCE start positions when this SBCL exposes the accessor.
+Older SBCL versions may not provide this internal accessor; avoid a read-time
+SB-C:: reference because package locks can reject interning missing symbols."
+  (let ((accessor
+          (or (find-symbol "DEBUG-SOURCE-START-POSITIONS" "SB-DI")
+              (find-symbol "DEBUG-SOURCE-START-POSITIONS" "SB-C"))))
+    (when (and accessor (fboundp accessor))
+      (funcall accessor debug-source))))
+
+#+sbcl
 (defun %frame-source-location (frame)
   "Extract source file and line from FRAME, or NIL if unavailable.
 Uses the code-location's TLF offset and the debug-source start-positions
@@ -98,8 +109,7 @@ point)."
                               code-location)))
                          (start-positions
                            (ignore-errors
-                             (sb-c::debug-source-start-positions
-                              debug-source)))
+                             (%debug-source-start-positions debug-source)))
                          (tlf-char
                            (when (and start-positions tlf-offset
                                       (< tlf-offset (length start-positions)))


### PR DESCRIPTION
## Summary
- Avoid read-time references to SB-C internal DEBUG-SOURCE-START-POSITIONS in frame inspector.
- Resolve the debug-source start-position accessor at runtime via FIND-SYMBOL.
- Fall back to omitting source line data when older SBCL versions do not expose the accessor.

## Tests
- cl-mcp/tests/frame-inspector-test

close #106