### PR TITLE
test(pool): tighten startup-latency test isolation and pin on-demand spawn path

### DIFF
--- a/tests/pool-env-config-test.lisp
+++ b/tests/pool-env-config-test.lisp
@@ -75,15 +75,11 @@ is what %env-int observes."
 
 (deftest initialize-pool-rejects-warmup-above-max
   (testing "initialize-pool errors when *worker-pool-warmup* exceeds *max-pool-size*"
-    ;; Setf rather than let so the calling thread's binding is what
-    ;; the validation reads -- matches established style in pool-test.
-    (let ((saved-warmup cl-mcp/src/pool::*worker-pool-warmup*)
-          (saved-max cl-mcp/src/pool::*max-pool-size*))
-      (unwind-protect
-           (progn
-             (setf cl-mcp/src/pool::*worker-pool-warmup* 5
-                   cl-mcp/src/pool::*max-pool-size* 2)
-             (ok (signals (cl-mcp/src/pool:initialize-pool))
-                 "init signals when warmup > max"))
-        (setf cl-mcp/src/pool::*worker-pool-warmup* saved-warmup
-              cl-mcp/src/pool::*max-pool-size* saved-max)))))
+    ;; Plain dynamic binding works because the validation error is signaled
+    ;; on the calling thread before %schedule-replenish (which would spawn
+    ;; a background thread) runs.  No cross-thread binding propagation is
+    ;; needed for this path.
+    (let ((cl-mcp/src/pool::*worker-pool-warmup* 5)
+          (cl-mcp/src/pool::*max-pool-size* 2))
+      (ok (signals (cl-mcp/src/pool:initialize-pool))
+          "init signals when warmup > max"))))

--- a/tests/pool-startup-latency-test.lisp
+++ b/tests/pool-startup-latency-test.lisp
@@ -19,12 +19,18 @@
   (:use #:cl)
   (:import-from #:rove
                 #:deftest #:testing #:ok #:skip)
+  (:import-from #:bordeaux-threads
+                #:with-lock-held)
   (:import-from #:cl-mcp/src/pool
                 #:*worker-pool-warmup*
                 #:*health-check-interval-seconds*
                 #:*shutdown-replenish-wait-seconds*
                 #:initialize-pool
-                #:shutdown-pool)
+                #:shutdown-pool
+                #:get-or-assign-worker
+                #:release-session)
+  (:import-from #:cl-mcp/src/worker-client
+                #:worker)
   (:import-from #:cl-mcp/src/run
                 #:run)
   (:import-from #:cl-mcp/tests/test-helpers
@@ -78,10 +84,13 @@ a background replenish thread)"
 the warmup target within a generous bound"
     (unless (spawn-available-p)
       (skip "sbcl not available"))
-    ;; Bound is loose because cold-cache spawn is several seconds per
-    ;; worker and a prior test's in-flight replenish can still own
-    ;; *replenish-running* for one extra spawn after this test starts.
     (%with-fast-pool-defaults (:warmup 2)
+      ;; Defensive reset: if a prior test aborted before its replenish
+      ;; thread settled, *replenish-running* may still be t and
+      ;; %schedule-replenish would skip the spawn.  The pool is not
+      ;; running here so this cannot race a real replenish thread.
+      (with-lock-held (cl-mcp/src/pool::*pool-lock*)
+        (setf cl-mcp/src/pool::*replenish-running* nil))
       (unwind-protect
            (progn
              (initialize-pool)
@@ -114,14 +123,54 @@ the warmup target within a generous bound"
     (%with-fast-pool-defaults (:warmup 2)
       (let ((in (make-string-input-stream +initialize-line+))
             (out (make-string-output-stream)))
-        (let ((elapsed
-                (%elapsed-seconds
-                 (lambda ()
-                   (run :transport :stdio :in in :out out
-                        :worker-pool t)))))
-          (let ((response (get-output-stream-string out)))
-            (ok (search "\"protocolVersion\"" response)
-                "stdio response includes protocolVersion")
-            (ok (< elapsed 3.0)
-                (format nil "stdio initialize took ~,3F s (bound 3.0)"
-                        elapsed))))))))
+        (unwind-protect
+             (let ((elapsed
+                     (%elapsed-seconds
+                      (lambda ()
+                        (run :transport :stdio :in in :out out
+                             :worker-pool t)))))
+               (let ((response (get-output-stream-string out)))
+                 (ok (search "\"protocolVersion\"" response)
+                     "stdio response includes protocolVersion")
+                 (ok (< elapsed 3.0)
+                     (format nil "stdio initialize took ~,3F s (bound 3.0)"
+                             elapsed))))
+          ;; Drain any in-flight replenish so subsequent tests start clean.
+          ;; *shutdown-replenish-wait-seconds* is intentionally short here
+          ;; for the latency assertion, so spawn-worker may still be running
+          ;; in the background after run's shutdown-pool returns.  The
+          ;; replenish loop self-terminates once *pool-running* is nil.
+          (loop repeat 600  ; 60 s ceiling
+                while cl-mcp/src/pool::*replenish-running*
+                do (sleep 0.1)))))))
+
+(deftest first-tools-call-with-no-standby-completes-within-deadline
+  (testing "with warmup=0, the first get-or-assign-worker call must
+complete within *worker-startup-timeout* + buffer.  Pins the on-demand
+spawn path that PR #108's async warmup left as the load-bearing
+fallback when standbys are not yet ready."
+    (unless (spawn-available-p)
+      (skip "sbcl not available"))
+    (%with-fast-pool-defaults (:warmup 0)
+      (unwind-protect
+           (progn
+             (initialize-pool)
+             (let* ((deadline-s
+                      (+ cl-mcp/src/worker-client::*worker-startup-timeout* 5))
+                    (assigned nil)
+                    (elapsed
+                      (%elapsed-seconds
+                       (lambda ()
+                         (setf assigned
+                               (get-or-assign-worker "probe-session"))))))
+               (ok (typep assigned 'worker)
+                   "first call returns a worker instance")
+               (ok (< elapsed deadline-s)
+                   (format nil
+                           "first get-or-assign-worker took ~,3F s (bound ~D)"
+                           elapsed deadline-s))
+               (let ((again (get-or-assign-worker "probe-session")))
+                 (ok (eq again assigned)
+                     "second call for same session returns same worker"))))
+        (ignore-errors (release-session "probe-session"))
+        (shutdown-pool)))))


### PR DESCRIPTION
## Summary

Follow-up to #108. Closes three test isolation gaps called out in review and
adds the missing characterisation test for the on-demand spawn path.

- `stdio-handshake-responds-quickly-under-warmup` no longer leaks a background
  replenish thread past test teardown.
- `pool-eventually-reaches-warmup-target` defensively resets
  `*replenish-running*` rather than relying on prior-test cleanup.
- `initialize-pool-rejects-warmup-above-max` switches from
  `setf` + `unwind-protect` to plain dynamic `let` (the validation error path
  never crosses thread boundaries, so cross-thread binding propagation is
  irrelevant).
- Adds `first-tools-call-with-no-standby-completes-within-deadline`: with
  `warmup=0`, the first `get-or-assign-worker` call must complete within
  `*worker-startup-timeout* + 5 s` and return a real worker. Pins the
  spawn-and-bind latency contract that PR #108's async warmup made the
  load-bearing fallback when standbys are not yet ready.

## Motivation

PR #108 was merged with these isolation gaps known and explicitly deferred
("non-blocking but recommended" in review) so that PR could stay focused.
This PR closes the gaps before they cause flakes in CI, and adds the
characterisation test that pins the other side of #108's trade-off (fast
`initialize` response in exchange for first-`tools/call` latency exposure).

## Tests

| Suite | Result |
|---|---|
| `cl-mcp/tests/pool-env-config-test` (full) | 7/7 pass (27 ms) |
| `cl-mcp/tests/pool-startup-latency-test` (full, 5 tests) | 5/5 pass (5567 ms) |
| Each latency test individually | All pass (3 ms – 2719 ms) |
| `mallet` on both files | Clean |
| `asdf:compile-system :force t` (both) | T (cosmetic redefining-macro warnings only) |

## Out of scope

- `concurrent-first-calls-share-spawn-via-placeholder` (was "recommended" in
  the spec; deferred because `bt:join-thread` without timeout could mask a
  spawn-worker hang. Worth designing the timeout wrapper in a separate PR.)
- Auditing `pool-test.lisp` for the same `setf` + `unwind-protect` pattern.
- Telemetry / `notifications/tools/list_changed` follow-ups already on the
  roadmap from PR #108.

## Test plan

- [ ] CI green on Ubuntu (sbcl-bin/2.5.0)
- [ ] `mallet src/*.lisp tests/*.lisp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)