### PR TITLE
fix: declare explicit sb-posix dependency

### DIFF
--- a/cl-mcp.asd
+++ b/cl-mcp.asd
@@ -1,5 +1,14 @@
 ;;;; cl-mcp.asd
 
+;; Pre-load SBCL contribs that source files reference via package-qualified
+;; symbols (sb-posix:getpid, sb-posix:sigterm, ...).  SBCL resolves package
+;; names embedded in FASLs at load time, before any top-level form in the
+;; FASL runs, so adding (require :sb-posix) inside a source file is too late.
+;; Putting it here guarantees the contrib is available before ASDF loads any
+;; cl-mcp FASL — including from the bare-SBCL worker, whose dep graph would
+;; not otherwise pull in sb-posix transitively (see %build-sbcl-args).
+#+sbcl (require :sb-posix)
+
 ;; Tell ASDF that eclector.parse-result package is provided by eclector
 (asdf:register-system-packages "eclector"
                                '(:eclector.parse-result

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -276,11 +276,19 @@ loaded in the current image, or NIL otherwise."
   "Build command-line arguments for spawning a worker via bare SBCL.
 Configures ASDF source registry to find cl-mcp, optionally loads
 Quicklisp setup.lisp if available, loads the worker system via ASDF,
-and calls the entry point."
+and calls the entry point.
+
+Pre-requires sb-posix because worker FASLs (log.fasl, worker/main.fasl)
+embed package-qualified references to sb-posix:getpid etc.  SBCL
+resolves those package names at FASL-load time, so the contrib must
+be present before any cl-mcp FASL is loaded.  cl-mcp.asd also issues
+this require, but doing it here guards against future changes that
+might bypass the .asd."
   (let ((source-dir (namestring (asdf:system-source-directory :cl-mcp)))
         (ql-setup (%quicklisp-setup-path)))
     (append
-     (list "--noinform" "--non-interactive")
+     (list "--noinform" "--non-interactive"
+           "--eval" "(require :sb-posix)")
      (when ql-setup
        (list "--load" ql-setup))
      (list
@@ -466,6 +474,50 @@ can clean it up."
   "Generate a random shared secret for worker TCP authentication."
   (generate-random-hex-string 32))
 
+(defparameter *spawn-failure-stderr-timeout* 2
+  "Seconds to wait while draining a failed worker's stderr before
+giving up.  The child is typically already dead (it closed stdout),
+so EOF arrives quickly; this bound only matters when the child is
+still alive but stuck pre-handshake.")
+
+(defparameter *spawn-failure-stderr-max-chars* 4096
+  "Cap on captured stderr bytes included in spawn-failure messages.
+Prevents a chatty child from blowing up log lines.")
+
+(defun %drain-stderr-for-failure (process)
+  "Read whatever the child has written to stderr without blocking
+indefinitely.  Returns a string (possibly empty).  Used only on
+the spawn-failure path; the normal-success path starts a long-running
+drain thread instead via %START-STDERR-DRAIN.
+
+Bounded by *SPAWN-FAILURE-STDERR-TIMEOUT* (wall clock) and
+*SPAWN-FAILURE-STDERR-MAX-CHARS* (output size)."
+  (let ((err (and process (ignore-errors (sb-ext:process-error process)))))
+    (unless (and err (open-stream-p err))
+      (return-from %drain-stderr-for-failure ""))
+    (let ((buf (make-array 1024 :element-type 'character
+                                :adjustable t :fill-pointer 0)))
+      (handler-case
+          (sb-ext:with-timeout *spawn-failure-stderr-timeout*
+            (loop for ch = (read-char err nil nil)
+                  while ch
+                  do (vector-push-extend ch buf)
+                  when (>= (length buf) *spawn-failure-stderr-max-chars*)
+                  do (return)))
+        (sb-ext:timeout () nil)
+        (error () nil))
+      (coerce buf 'simple-string))))
+
+(defun %trim-stderr-for-message (raw)
+  "Trim and shorten a stderr capture for inclusion in an error message.
+Strips trailing whitespace and truncates with an ellipsis if the
+content was capped at *SPAWN-FAILURE-STDERR-MAX-CHARS*."
+  (let* ((trimmed (string-right-trim '(#\Newline #\Return #\Space #\Tab) raw))
+         (truncated-p (>= (length raw) *spawn-failure-stderr-max-chars*)))
+    (if truncated-p
+        (concatenate 'string trimmed " [...truncated]")
+        trimmed)))
+
 (defun spawn-worker ()
   "Launch a worker child process and return a WORKER struct.
 The worker is launched via Roswell, reads its JSON handshake to
@@ -474,7 +526,9 @@ authenticates with a shared secret, and returns the worker in
 :standby state.
 
 Signals WORKER-SPAWN-FAILED if the process cannot be started,
-the handshake fails, or authentication is rejected."
+the handshake fails, or authentication is rejected.  On failure
+the child's stderr is drained (bounded) and appended to the error
+message so callers can see what actually went wrong in the child."
   (let ((id (%next-worker-id))
         (secret (%generate-worker-secret))
         (process nil)
@@ -523,24 +577,38 @@ the handshake fails, or authentication is rejected."
                          "pid" pid)
               worker)))
       (error (e)
-        ;; Clean up on failure
-        (when socket
-          (ignore-errors (usocket:socket-close socket)))
-        (when process
-          (ignore-errors
-            (when (sb-ext:process-alive-p process)
-              (sb-ext:process-kill process 15)
-              (sleep 0.5)
+        ;; Drain stderr BEFORE killing the process so we can report what
+        ;; the child actually printed (e.g. SBCL backtrace from a failed
+        ;; (asdf:load-system ...) eval).  Without this, callers only see
+        ;; the generic "Worker closed stdout before handshake".
+        (let* ((raw-stderr (%drain-stderr-for-failure process))
+               (child-stderr (%trim-stderr-for-message raw-stderr))
+               ;; Use the raw message (not princ-to-string) when E is
+               ;; already a worker-spawn-failed so we don't double-prefix
+               ;; "Failed to spawn worker: " when re-signaling below.
+               (base-message (if (typep e 'worker-spawn-failed)
+                                 (worker-spawn-failed-message e)
+                                 (princ-to-string e))))
+          (when socket
+            (ignore-errors (usocket:socket-close socket)))
+          (when process
+            (ignore-errors
               (when (sb-ext:process-alive-p process)
-                (sb-ext:process-kill process 9)))
-            (sb-ext:process-close process)))
-        (log-event :warn "worker.spawn.failed"
-                   "id" id
-                   "error" (princ-to-string e))
-        (if (typep e 'worker-spawn-failed)
-            (error e)
-            (error 'worker-spawn-failed
-                   :message (princ-to-string e)))))))
+                (sb-ext:process-kill process 15)
+                (sleep 0.5)
+                (when (sb-ext:process-alive-p process)
+                  (sb-ext:process-kill process 9)))
+              (sb-ext:process-close process)))
+          (apply #'log-event :warn "worker.spawn.failed"
+                 "id" id
+                 "error" base-message
+                 (when (plusp (length child-stderr))
+                   (list "child_stderr" child-stderr)))
+          (let ((enriched (if (plusp (length child-stderr))
+                              (format nil "~A; child stderr: ~A"
+                                      base-message child-stderr)
+                              base-message)))
+            (error 'worker-spawn-failed :message enriched)))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Public API — RPC

--- a/tests/worker-test.lisp
+++ b/tests/worker-test.lisp
@@ -936,3 +936,69 @@ Cleans up server and socket on exit."
                                 env))
                   "MCP_LOG_FILE is excluded (denylisted)")))
         (%restore-env "FAKE_API_KEY_FOR_TEST" prev-fake)))))
+
+;;; ---------------------------------------------------------------------------
+;;; Worker SBCL launch args — sb-posix preload (regression for issue where
+;;; bare-SBCL worker FASL load failed because nothing in the worker's ASDF
+;;; dep graph pulled in sb-posix transitively)
+;;; ---------------------------------------------------------------------------
+
+(deftest worker-build-sbcl-args-requires-sb-posix
+  (testing "%build-sbcl-args injects --eval (require :sb-posix) before loading cl-mcp"
+    (let* ((args (cl-mcp/src/worker-client::%build-sbcl-args))
+           (require-pos
+             (position-if
+              (lambda (s)
+                (and (stringp s) (search "(require :sb-posix)" s)))
+              args))
+           (load-pos
+             (position-if
+              (lambda (s)
+                (and (stringp s)
+                     (search "(asdf:load-system :cl-mcp/src/worker/main)" s)))
+              args)))
+      (ok require-pos
+          "(require :sb-posix) appears in args")
+      (ok load-pos
+          "asdf:load-system call appears in args")
+      (ok (and require-pos load-pos (< require-pos load-pos))
+          "(require :sb-posix) is positioned before asdf:load-system"))))
+
+;;; ---------------------------------------------------------------------------
+;;; Spawn failure stderr capture — without this, "Worker closed stdout before
+;;; handshake" failures arrive with no diagnostic context.
+;;; ---------------------------------------------------------------------------
+
+(defun %write-fake-sbcl (path stderr-message)
+  "Write an executable shell script to PATH that prints STDERR-MESSAGE on
+stderr and exits 1.  Used to simulate a child process that dies before
+emitting a handshake."
+  (with-open-file (out path :direction :output
+                            :if-exists :supersede
+                            :if-does-not-exist :create)
+    (format out "#!/bin/sh~%")
+    (format out "printf '%s' ~S 1>&2~%" stderr-message)
+    (format out "exit 1~%"))
+  (sb-posix:chmod path #o755)
+  path)
+
+(deftest spawn-worker-includes-child-stderr-in-error
+  (testing "spawn-worker surfaces child stderr in WORKER-SPAWN-FAILED message"
+    (let ((script-path (format nil "/tmp/cl-mcp-fake-sbcl-~A.sh"
+                               (sb-posix:getpid)))
+          (marker "FAKE-SBCL-DIED: simulated load failure here"))
+      (unwind-protect
+          (progn
+            (%write-fake-sbcl script-path marker)
+            (let ((cl-mcp/src/worker-client::*cached-sbcl-path* script-path)
+                  (cl-mcp/src/worker-client::*cached-ros-path* script-path)
+                  (caught-message nil))
+              (handler-case (cl-mcp/src/worker-client:spawn-worker)
+                (worker-spawn-failed (c)
+                  (setf caught-message
+                        (cl-mcp/src/worker-client::worker-spawn-failed-message c))))
+              (ok caught-message
+                  "spawn signals WORKER-SPAWN-FAILED")
+              (ok (and caught-message (search marker caught-message))
+                  "error message includes child stderr marker")))
+        (ignore-errors (delete-file script-path))))))

--- a/tests/worker-test.lisp
+++ b/tests/worker-test.lisp
@@ -17,7 +17,11 @@
                 #:register-all-handlers)
   (:import-from #:cl-mcp/src/worker/main)
   (:import-from #:cl-mcp/src/worker-client
-                #:worker-spawn-failed))
+                #:worker-spawn-failed)
+  (:import-from #:cl-mcp/src/fs
+                #:fs-write-file)
+  (:import-from #:cl-mcp/src/project-root
+                #:*project-root*))
 
 (in-package #:cl-mcp/tests/worker-test)
 
@@ -969,36 +973,37 @@ Cleans up server and socket on exit."
 ;;; handshake" failures arrive with no diagnostic context.
 ;;; ---------------------------------------------------------------------------
 
-(defun %write-fake-sbcl (path stderr-message)
-  "Write an executable shell script to PATH that prints STDERR-MESSAGE on
-stderr and exits 1.  Used to simulate a child process that dies before
-emitting a handshake."
-  (with-open-file (out path :direction :output
-                            :if-exists :supersede
-                            :if-does-not-exist :create)
-    (format out "#!/bin/sh~%")
-    (format out "printf '%s' ~S 1>&2~%" stderr-message)
-    (format out "exit 1~%"))
-  (sb-posix:chmod path #o755)
-  path)
+(defun %write-fake-sbcl (relative-path stderr-message)
+  "Write an executable shell script to RELATIVE-PATH (under project root)
+that prints STDERR-MESSAGE on stderr and exits 1.  Used to simulate a
+child process that dies before emitting a handshake.  Returns the
+absolute pathname namestring of the written script.
+
+Uses cl-mcp/src/fs:fs-write-file (required wrapper for filesystem
+writes) rather than raw with-open-file."
+  (let ((script (format nil "#!/bin/sh~%printf '%s' ~S 1>&2~%exit 1~%"
+                        stderr-message)))
+    (fs-write-file relative-path script)
+    (let ((abs (namestring (merge-pathnames relative-path *project-root*))))
+      (sb-posix:chmod abs #o755)
+      abs)))
 
 (deftest spawn-worker-includes-child-stderr-in-error
   (testing "spawn-worker surfaces child stderr in WORKER-SPAWN-FAILED message"
-    (let ((script-path (format nil "/tmp/cl-mcp-fake-sbcl-~A.sh"
-                               (sb-posix:getpid)))
+    (let ((rel-path (format nil "tests/tmp/cl-mcp-fake-sbcl-~A.sh"
+                            (sb-posix:getpid)))
           (marker "FAKE-SBCL-DIED: simulated load failure here"))
-      (unwind-protect
-          (progn
-            (%write-fake-sbcl script-path marker)
-            (let ((cl-mcp/src/worker-client::*cached-sbcl-path* script-path)
-                  (cl-mcp/src/worker-client::*cached-ros-path* script-path)
-                  (caught-message nil))
-              (handler-case (cl-mcp/src/worker-client:spawn-worker)
-                (worker-spawn-failed (c)
-                  (setf caught-message
-                        (cl-mcp/src/worker-client::worker-spawn-failed-message c))))
-              (ok caught-message
-                  "spawn signals WORKER-SPAWN-FAILED")
-              (ok (and caught-message (search marker caught-message))
-                  "error message includes child stderr marker")))
-        (ignore-errors (delete-file script-path))))))
+      (let ((script-path (%write-fake-sbcl rel-path marker)))
+        (unwind-protect
+             (let ((cl-mcp/src/worker-client::*cached-sbcl-path* script-path)
+                   (cl-mcp/src/worker-client::*cached-ros-path* script-path)
+                   (caught-message nil))
+               (handler-case (cl-mcp/src/worker-client:spawn-worker)
+                 (worker-spawn-failed (c)
+                   (setf caught-message
+                         (cl-mcp/src/worker-client::worker-spawn-failed-message c))))
+               (ok caught-message
+                   "spawn signals WORKER-SPAWN-FAILED")
+               (ok (and caught-message (search marker caught-message))
+                   "error message includes child stderr marker"))
+          (ignore-errors (delete-file script-path)))))))


### PR DESCRIPTION
Thanks for cl-mcp, it's really enjoyable to use with claude code. Worker pools
would sometime fail to spawn. Below is Claude Opus 4.7 xhigh's fix:

Root cause — Worker FASLs (log.fasl, worker/main.fasl,
worker-client.fasl) embed package-qualified references to
sb-posix:getpid, sb-posix:sigterm, etc. SBCL resolves package names
embedded in a FASL at load time, before any top-level form in the FASL
runs. The parent process happens to have sb-posix loaded
transitively (via hunchentoot, which is a top-level cl-mcp dep), but the
worker only loads cl-mcp/src/worker/main — a leaner dep graph that
doesn't pull in hunchentoot — so the bare-SBCL child crashes
during (asdf:load-system :cl-mcp/src/worker/main) with package SB-POSIX
did not get defined. The child closes stdout before sending its
handshake; parent reports the unhelpful "Worker closed stdout before
handshake". This is intermittent — only fires when the worker's dep
graph doesn't already include something that requires sb-posix.

Changes

- cl-mcp.asd — added #+sbcl (require :sb-posix) so the contrib is loaded
before any cl-mcp FASL:(the .asd is loaded before its FASLs).

- src/worker-client.lisp — %build-sbcl-args now prepends --eval
"(require :sb-posix)" as defense-in-depth for the worker spawn path.

- src/worker-client.lisp — spawn-worker's error handler now drains the
child's stderr (bounded by 2 s / 4 KB) before killing the process, and
includes it in both the WORKER-SPAWN-FAILED message and the
worker.spawn.failed log event (new child_stderr field). This turns the
next mystery spawn failure from "Worker closed stdout before handshake"
into a message that quotes the child's actual backtrace.

- tests/worker-test.lisp — two regression tests: one pins the (require
:sb-posix) injection in spawn args; the other uses a fake-sbcl shell
script to verify stderr capture lands in the error message.

Verified end-to-end by spawning a worker from
/home/ben/common-lisp/project-isidore (the directory that was failing in
the captured logs). Worker now spawns and exits cleanly.