### PR TITLE
Improve Opencode support: fix array schema bug & fix readtable argument nuisance

### DIFF
--- a/src/lisp-edit-form-core.lisp
+++ b/src/lisp-edit-form-core.lisp
@@ -134,23 +134,26 @@ editor-hints.named-readtables package."
 Handles three forms:
   \"pkg:sym\"  or \"pkg::sym\" → interned symbol in PKG
   \":keyword\" or \"keyword\"  → keyword symbol
-Returns NIL if READTABLE-STRING is NIL."
-  (when readtable-string
-    (let ((colon-pos (position #\: readtable-string)))
-      (if (and colon-pos (plusp colon-pos))
-          (let* ((pkg-name (subseq readtable-string 0 colon-pos))
-                 (sym-start (if (and (< (1+ colon-pos) (length readtable-string))
-                                     (char= (char readtable-string (1+ colon-pos)) #\:))
-                                (+ colon-pos 2)
-                                (1+ colon-pos)))
-                 (sym-name (subseq readtable-string sym-start))
-                 (pkg (find-package (string-upcase pkg-name))))
-            (if pkg
-                (intern (string-upcase sym-name) pkg)
-                (error "Package ~A not found for readtable ~A"
-                       pkg-name readtable-string)))
-          (intern (string-upcase (string-left-trim ":" readtable-string))
-                  :keyword)))))
+Returns NIL if READTABLE-STRING is NIL or blank."
+  (let ((trimmed (and (stringp readtable-string)
+                      (string-trim '(#\Space #\Tab #\Newline #\Return)
+                                   readtable-string))))
+    (when (and trimmed (plusp (length trimmed)))
+      (let ((colon-pos (position #\: trimmed)))
+        (if (and colon-pos (plusp colon-pos))
+            (let* ((pkg-name (subseq trimmed 0 colon-pos))
+                   (sym-start (if (and (< (1+ colon-pos) (length trimmed))
+                                       (char= (char trimmed (1+ colon-pos)) #\:))
+                                  (+ colon-pos 2)
+                                  (1+ colon-pos)))
+                   (sym-name (subseq trimmed sym-start))
+                   (pkg (find-package (string-upcase pkg-name))))
+              (if pkg
+                  (intern (string-upcase sym-name) pkg)
+                  (error "Package ~A not found for readtable ~A"
+                         pkg-name readtable-string)))
+            (intern (string-upcase (string-left-trim ":" trimmed))
+                    :keyword))))))
 
 (defun %strip-name-prefix (name)
   "Strip reader macro prefixes (#: : \"...\") from NAME for form-name matching.

--- a/src/lisp-read-file.lisp
+++ b/src/lisp-read-file.lisp
@@ -23,6 +23,8 @@
                 #:normalize-path-for-display)
   (:import-from #:cl-mcp/src/utils/strings
                 #:ensure-trailing-newline)
+  (:import-from #:cl-mcp/src/lisp-edit-form-core
+                #:%parse-readtable-designator)
   (:import-from #:cl-ppcre
                 #:scan
                 #:create-scanner)
@@ -531,29 +533,13 @@ Supports both keyword style ('interpol-syntax') and package-qualified style
 is used instead of Eclector, which means comments are NOT preserved."))
   :body
   (let ((file-result
-         (lisp-read-file path
-                         :collapsed collapsed
-                         :name-pattern name_pattern
-                         :content-pattern content_pattern
-                         :offset offset
-                         :limit limit
-                         :readtable (when readtable
-                                      (let ((colon-pos (position #\: readtable)))
-                                        (if colon-pos
-                                            ;; Package-qualified: "pkg:sym" or "pkg::sym"
-                                            (let* ((pkg-name (subseq readtable 0 colon-pos))
-                                                   (sym-start (if (and (< (1+ colon-pos) (length readtable))
-                                                                       (char= (char readtable (1+ colon-pos)) #\:))
-                                                                  (+ colon-pos 2)
-                                                                  (1+ colon-pos)))
-                                                   (sym-name (subseq readtable sym-start))
-                                                   (pkg (find-package (string-upcase pkg-name))))
-                                              (if pkg
-                                                  (intern (string-upcase sym-name) pkg)
-                                                  (error "Package ~A not found for readtable ~A"
-                                                         pkg-name readtable)))
-                                            ;; Keyword symbol (no colon prefix)
-                                            (intern (string-upcase readtable) :keyword)))))))
+          (lisp-read-file path
+                          :collapsed collapsed
+                          :name-pattern name_pattern
+                          :content-pattern content_pattern
+                          :offset offset
+                          :limit limit
+                          :readtable (%parse-readtable-designator readtable))))
     (result id
             (make-ht "content" (text-content (gethash "content" file-result))
                      "text" (gethash "content" file-result)

--- a/src/tools/define-tool.lisp
+++ b/src/tools/define-tool.lisp
@@ -91,6 +91,8 @@
         (description (getf parsed-spec :description)))
     `(setf (gethash ,json-name properties)
            (make-ht "type" ,(%type-to-json-type type)
+                    ,@(when (eq type :array)
+                        '("items" (make-ht "type" "string")))
                     ,@(when enum
                         `("enum" (vector ,@enum)))
                     ,@(when description

--- a/tests/core-test.lisp
+++ b/tests/core-test.lisp
@@ -4,6 +4,8 @@
   (:use #:cl)
   (:import-from #:rove
                 #:deftest #:testing #:ok)
+  (:import-from #:cl-mcp/src/lisp-edit-form-core
+                #:%parse-readtable-designator)
   (:import-from #:cl-mcp/src/core #:version)
   (:import-from #:cl-mcp/src/run))
 
@@ -21,6 +23,12 @@
     (let ((in (make-string-input-stream ""))
           (out (make-string-output-stream)))
       (ok (eq t (cl-mcp/src/run:run :transport :stdio :in in :out out))))))
+
+(deftest parse-readtable-designator-blank
+  (testing "blank readtable arguments are ignored"
+    (ok (null (%parse-readtable-designator nil)))
+    (ok (null (%parse-readtable-designator "")))
+    (ok (null (%parse-readtable-designator "   ")))))
 
 (deftest stdio-one-message
   (testing "run processes one line from :in and writes to :out"

--- a/tests/define-tool-test.lisp
+++ b/tests/define-tool-test.lisp
@@ -47,6 +47,14 @@
             (make-ht "content" (text-content output)
                      "output" output))))
 
+(define-tool "test-array"
+  :description "Test array args."
+  :args ((tags :type :array :description "Tags"))
+  :body
+  (result id
+          (make-ht "content" (text-content "ok")
+                   "tags" tags)))
+
 ;;; Tests
 
 (deftest define-tool-creates-handler
@@ -70,6 +78,18 @@
         (ok (gethash "message" props))
         (ok (vectorp required))
         (ok (find "message" required :test #'string=))))))
+
+(deftest define-tool-array-schema
+  (testing "array args include items schema"
+    (let* ((desc (test-array-descriptor))
+           (schema (gethash "inputSchema" desc))
+           (props (gethash "properties" schema))
+           (array-prop (gethash "tags" props))
+           (items (gethash "items" array-prop)))
+      (ok (hash-table-p array-prop))
+      (ok (string= "array" (gethash "type" array-prop)))
+      (ok (hash-table-p items))
+      (ok (string= "string" (gethash "type" items))))))
 
 (deftest define-tool-registers-tool
   (testing "define-tool registers the tool in the registry"

--- a/tests/lisp-edit-form-test.lisp
+++ b/tests/lisp-edit-form-test.lisp
@@ -618,6 +618,24 @@ then clean up."
       (error ()
         (skip "cl-interpol not available")))))
 
+(deftest lisp-edit-form-ignores-blank-readtable
+  (testing "blank readtable arguments are treated as omitted"
+    (with-temp-file "tests/tmp/edit-form-blank-readtable.lisp"
+        (format nil "(defun greet ()~%  :hello)~%")
+      (lambda (path)
+        (let ((args (make-hash-table :test #'equal)))
+          (setf (gethash "file_path" args) path
+                (gethash "form_type" args) "defun"
+                (gethash "form_name" args) "greet"
+                (gethash "operation" args) "replace"
+                (gethash "content" args) (format nil "(defun greet ()~%  :hi)~%")
+                (gethash "readtable" args) "")
+          (cl-mcp/src/lisp-edit-form::lisp-edit-form-handler
+           (cl-mcp/src/state:make-state) 1 args))
+        (let ((updated (fs-read-file path)))
+          (ok (search ":hi" updated))
+          (ok (null (search ":hello" updated))))))))
+
 (deftest lisp-edit-form-auto-detects-in-readtable
   (testing "in-readtable form triggers automatic readtable switching"
     (handler-case

--- a/tests/lisp-read-file-test.lisp
+++ b/tests/lisp-read-file-test.lisp
@@ -233,6 +233,24 @@
       (error ()
         (skip "cl-interpol not available")))))
 
+(deftest lisp-read-file-ignores-blank-readtable
+  (testing "blank readtable arguments are treated as omitted"
+    (with-temp-lisp-file "tests/tmp/lisp-read-blank-readtable.lisp"
+        (format nil "(defun greet ()~%  :hello)~%")
+      (lambda (path)
+        (let ((args (make-hash-table :test #'equal)))
+          (setf (gethash "path" args) path
+                (gethash "readtable" args) "")
+          (let* ((response (cl-mcp/src/lisp-read-file::lisp-read-file-handler
+                            (cl-mcp/src/state:make-state) 1 args))
+                 (result (gethash "result" response))
+                 (content (and result (gethash "content" result)))
+                 (text (and (vectorp content)
+                            (> (length content) 0)
+                            (gethash "text" (aref content 0)))))
+            (ok (stringp text))
+            (ok (search "(defun greet" text))))))))
+
 (deftest lisp-read-file-auto-detects-in-readtable
   (testing "in-readtable form triggers automatic readtable switching"
     (handler-case


### PR DESCRIPTION
1. The `clgrep-search` could not be called because it expected an "items" for the "array" schema type. This is fixed now.
2. A `readtable` argument value in (e.g.) `lisp-read-file` was often still added with `""`, so I've increased leniency on supplied parameters.

