### PR TITLE
fix: clear_fasls never rebuilt package-inferred dependency subsystems

### DIFF
--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -224,6 +224,28 @@ DEFUN' lines are noise that drown real warnings."
             (setf *last-compiler-stderr*
                   (ignore-errors (get-output-stream-string stderr)))))))))
 
+(defun %delete-system-fasls (system-name)
+  "Delete the cached fasls under SYSTEM-NAME's output-translation
+directory.  ASDF's :FORCE T only forces the named system, not its
+dependencies — for package-inferred systems the actual code lives in
+dependency subsystems, so forcing the top system alone recompiles
+nothing, and a source edit landing in the same second as the previous
+compile is masked by second-granularity FILE-WRITE-DATE.  Deleting the
+fasls makes recompilation unconditional.  Returns the number of files
+deleted (0 when the system or its cache directory is absent)."
+  (let* ((system (asdf:find-system system-name nil))
+         (source-dir (and system (asdf:system-source-directory system))))
+    (if (null source-dir)
+        0
+        (let ((deleted 0))
+          (dolist (fasl (directory
+                         (merge-pathnames
+                          "**/*.fasl"
+                          (asdf:apply-output-translations source-dir)))
+                  deleted)
+            (when (ignore-errors (delete-file fasl) t)
+              (incf deleted)))))))
+
 (declaim (ftype (function (string &key (:force boolean)
                                        (:clear-fasls boolean)
                                        (:timeout-seconds (or null (real (0))))
@@ -237,8 +259,11 @@ DEFUN' lines are noise that drown real warnings."
   "Load ASDF system SYSTEM-NAME with structured result.
 
 When FORCE is true (default), clears loaded state before loading so
-changed files are picked up. When CLEAR-FASLS is true, forces full
-recompilation from source. TIMEOUT-SECONDS must be a positive number
+changed files are picked up. When CLEAR-FASLS is true, deletes the
+system's cached fasls (its output-translation directory) before
+loading, guaranteeing recompilation from source — including
+package-inferred dependency subsystems that :FORCE T alone would not
+rebuild. TIMEOUT-SECONDS must be a positive number
 or NIL (no timeout). Default is 120 seconds.
 
 SUPPRESS-REDEFINITION-WARNINGS controls whether SBCL
@@ -267,6 +292,8 @@ registering it."
         (%load-with-timeout
          (lambda ()
            (flet ((%do-load ()
+                    (when clear-fasls
+                      (%delete-system-fasls system-name))
                     (let ((cleared-prior-p
                             (when (and force
                                        (member system-name

--- a/tests/system-loader-test.lisp
+++ b/tests/system-loader-test.lisp
@@ -260,3 +260,55 @@
                            :suppress-redefinition-warnings nil)))
       (ok (hash-table-p ht))
       (ok (string= "loaded" (gethash "status" ht))))))
+
+(deftest load-system-clear-fasls-recompiles-package-inferred
+  (testing "clear_fasls recompiles dependency subsystems regardless of timestamps"
+    ;; ASDF's :FORCE T only forces the NAMED system, not its
+    ;; dependencies.  For package-inferred systems the actual code
+    ;; lives in dependency subsystems (\"fixture/src/main\"), so a
+    ;; source rewrite landing in the same second as the previous
+    ;; compile is masked by second-granularity FILE-WRITE-DATE and
+    ;; the stale fasl gets reloaded.  clear_fasls must delete the
+    ;; cached fasls so recompilation happens unconditionally.
+    (let* ((dir (merge-pathnames "clmcp-clear-fasls-fixture/"
+                                 (uiop:temporary-directory)))
+           (src-dir (merge-pathnames "src/" dir))
+           (asd (merge-pathnames "clmcp-clear-fasls-fixture.asd" dir))
+           (main (merge-pathnames "main.lisp" src-dir)))
+      (unwind-protect
+          (flet ((write-main (value)
+                   (with-open-file (out main :direction :output
+                                             :if-exists :supersede)
+                     (format out "(defpackage #:clmcp-clear-fasls-fixture/src/main~%~
+                                    (:use #:cl)~%  (:export #:answer))~%~
+                                  (in-package #:clmcp-clear-fasls-fixture/src/main)~%~
+                                  (defun answer () ~A)~%"
+                             value))))
+            (uiop:delete-directory-tree dir :validate t
+                                            :if-does-not-exist :ignore)
+            (ensure-directories-exist src-dir)
+            (with-open-file (out asd :direction :output
+                                     :if-exists :supersede)
+              (write-string "(asdf:defsystem \"clmcp-clear-fasls-fixture\"
+  :class :package-inferred-system
+  :depends-on (\"clmcp-clear-fasls-fixture/src/main\"))" out))
+            (write-main 1)
+            (asdf:load-asd asd)
+            (ok (string= "loaded"
+                         (gethash "status"
+                                  (load-system "clmcp-clear-fasls-fixture"))))
+            (ok (= 1 (funcall (find-symbol
+                               "ANSWER" "CLMCP-CLEAR-FASLS-FIXTURE/SRC/MAIN"))))
+            ;; Rewrite the dependency subsystem's source immediately —
+            ;; almost always within the same second as the compile above,
+            ;; which is exactly the case clear_fasls must defeat.
+            (write-main 2)
+            (ok (string= "loaded"
+                         (gethash "status"
+                                  (load-system "clmcp-clear-fasls-fixture"
+                                               :clear-fasls t))))
+            (ok (= 2 (funcall (find-symbol
+                               "ANSWER" "CLMCP-CLEAR-FASLS-FIXTURE/SRC/MAIN")))
+                "clear_fasls must pick up a same-second source rewrite"))
+        (uiop:delete-directory-tree dir :validate t
+                                        :if-does-not-exist :ignore)))))


### PR DESCRIPTION
## Summary

`load-system`'s `clear_fasls` option was implemented as `(asdf:load-system name :force clear-fasls)`. ASDF's `:force t` only forces the **named** system — not its dependencies. For `package-inferred-system` projects the actual code lives in dependency subsystems (`"sys/src/main"`), so `clear_fasls` recompiled nothing: the top system has no Lisp components of its own.

This matters in practice because `file-write-date` has second granularity. When a source edit lands in the same second as the previous compile (e.g. an automated agent patching a file immediately after a verify cycle), ASDF considers the stale fasl current and reloads the **old** code over the freshly patched source. Observed in the wild as a verification harness reporting red after a correct patch (and, in paired benchmarking, the mirror image: a stale *fixed* fasl masking a re-broken source as green).

## Fix

`clear_fasls` now deletes the fasls under the system's output-translation directory (`%delete-system-fasls`, via `asdf:apply-output-translations` on the system source directory) before loading, making recompilation unconditional — including package-inferred dependency subsystems. The `:force clear-fasls` pass-through is kept as before.

## Test plan

- [x] New regression test `load-system-clear-fasls-recompiles-package-inferred`: builds a temp package-inferred fixture, compiles it, rewrites the dependency subsystem's source **within the same second**, then asserts `clear_fasls: true` picks up the new definition. Red on the previous implementation, green after the fix.
- [x] Full suite green (`rove cl-mcp.asd`: all 50 tests passed).
- [x] `mallet src/system-loader-core.lisp tests/system-loader-test.lisp` clean.
- [x] End-to-end: a zero-latency scripted fix loop over a stdio cl-mcp child (same-second patch after baseline compile) now reaches clean-verified green without sleeps or manual fasl deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)