### PR TITLE
fix(worker): project root wins ASDF resolution in the worker

### DIFF
--- a/src/project-root.lisp
+++ b/src/project-root.lisp
@@ -7,7 +7,8 @@
   (:use #:cl)
   (:import-from #:bordeaux-threads #:make-lock)
   (:export #:*project-root*
-           #:*project-root-lock*))
+           #:*project-root-lock*
+           #:register-project-root-source-registry))
 
 (in-package #:cl-mcp/src/project-root)
 
@@ -20,3 +21,70 @@ Set via MCP_PROJECT_ROOT environment variable or fs-set-project-root tool.")
 
 (defvar *project-root-lock* (bt:make-lock "project-root-lock")
   "Lock protecting multi-step mutations of *project-root* and related globals.")
+
+(defvar *registered-project-root* nil
+  "The project-root directory this worker last added to ASDF:*CENTRAL-REGISTRY*
+via REGISTER-PROJECT-ROOT-SOURCE-REGISTRY. Tracked so a root change removes the
+old entry instead of leaving stale project roots in the search list (which would
+leak the previous project's systems into the new root).")
+
+(defun %clear-systems-under (root)
+  "Unregister every ASDF system whose pathname lives under ROOT (a canonical
+directory), so a project's systems do not linger in ASDF's registry after the
+worker moves to a different root. Iterates REGISTERED-SYSTEMS (every found
+system, not just loaded ones — a bare FIND-SYSTEM also caches the definition)
+and tests COMPONENT-PATHNAME, which — unlike SYSTEM-SOURCE-DIRECTORY — is
+non-NIL for package-inferred subsystems (e.g. foo/tests, foo/src/bar) and points
+at the project root. Libraries and systems outside ROOT are untouched."
+  (let ((root (uiop:ensure-directory-pathname root)))
+    (dolist (name (asdf:registered-systems))
+      (let ((path (ignore-errors
+                    (asdf:component-pathname (asdf:find-system name nil)))))
+        (when (and path (uiop:subpathp path root))
+          (ignore-errors (asdf:clear-system name)))))))
+
+(defun register-project-root-source-registry (root)
+  "Make systems whose .asd lives directly under ROOT (a directory) win ASDF
+resolution over same-named systems reachable elsewhere (e.g. a copy under
+~/.roswell/local-projects). ROOT is a directory pathname or namestring.
+
+This is the fix for: editing a project's source under MCP_PROJECT_ROOT had no
+effect when a same-named system was discoverable via the inherited registry —
+ASDF kept resolving, and compiling, the inherited original.
+
+Prepends ROOT to ASDF:*CENTRAL-REGISTRY*, which:
+  - takes precedence over the inherited source registry (the project wins);
+  - is ADDITIVE — the rest of the registry (CL_SOURCE_REGISTRY, user/system
+    config, Roswell's local-projects that resolve rove and cl-mcp itself) is
+    untouched, so nothing is dropped;
+  - is re-checked on every FIND-SYSTEM rather than cached at registration
+    time, so a project .asd created AFTER the root is set (e.g. via
+    project-scaffold) is still found — unlike a cached (:tree ...)
+    source-registry entry.
+
+Maintains exactly ONE managed project-root entry: each call drops the
+previously-registered root (tracked in *REGISTERED-PROJECT-ROOT*) and puts the
+current root at the FRONT. When a reused worker changes roots A -> B, A is
+removed from the search path AND the systems already loaded from under A are
+unregistered (%CLEAR-SYSTEMS-UNDER), so neither the registry nor ASDF's
+loaded-system cache leaks A's systems into root B (otherwise FIND-SYSTEM /
+LOAD-SYSTEM would keep returning, and reloading, the cached A copy). A -> B -> A
+resolves from the current root. Other CENTRAL-REGISTRY entries are left intact.
+Call this whenever the project root is set or changed."
+  ;; Canonicalize via TRUENAME: ASDF records component pathnames with symlinks
+  ;; resolved, so the managed root must be canonical too or %CLEAR-SYSTEMS-UNDER
+  ;; (and equality with a future root) would miss a symlinked project root.
+  (let ((dir (and root
+                  (ignore-errors
+                    (uiop:ensure-directory-pathname
+                     (truename (uiop:ensure-directory-pathname root)))))))
+    (when dir
+      (when (and *registered-project-root*
+                 (not (equal *registered-project-root* dir)))
+        (setf asdf:*central-registry*
+              (remove *registered-project-root* asdf:*central-registry*
+                      :test #'equal))
+        (%clear-systems-under *registered-project-root*))
+      (setf asdf:*central-registry*
+            (cons dir (remove dir asdf:*central-registry* :test #'equal))
+            *registered-project-root* dir))))

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -21,7 +21,8 @@
   (:import-from #:cl-mcp/src/inspect
                 #:inspect-object-by-id)
   (:import-from #:cl-mcp/src/project-root
-                #:*project-root*)
+                #:*project-root*
+                #:register-project-root-source-registry)
   (:import-from #:cl-mcp/src/log
                 #:log-event)
   (:import-from #:cl-mcp/src/utils/paths
@@ -240,6 +241,11 @@ Returns a success payload."
           (setf dir-path resolved)))
       (setf *project-root* dir-path)
       (uiop/os:chdir dir-path)
+      ;; Re-point ASDF resolution at the new project root (see the helper's
+      ;; docstring). This is what fixes dynamic fs-set-project-root and reused
+      ;; pool workers: without it a same-named system already reachable via the
+      ;; inherited registry keeps winning after a root change.
+      (register-project-root-source-registry dir-path)
       (log-event :info "worker.project-root.set" "path" (namestring dir-path))
       (make-ht "content" (text-content
                           (format nil "Project root set to ~A" (namestring dir-path)))

--- a/src/worker/main.lisp
+++ b/src/worker/main.lisp
@@ -17,7 +17,8 @@
   (:import-from #:cl-mcp/src/worker/handlers
                 #:register-all-handlers)
   (:import-from #:cl-mcp/src/project-root
-                #:*project-root*)
+                #:*project-root*
+                #:register-project-root-source-registry)
   (:import-from #:cl-mcp/src/log
                 #:log-event
                 #:*log-context*)
@@ -99,6 +100,10 @@ the directory does not exist."
             (progn
               (setf *project-root* dir)
               (uiop/os:chdir dir)
+              ;; Make the project's own .asd win ASDF resolution (see the
+              ;; helper's docstring). Runs at worker startup when the root is
+              ;; known via MCP_PROJECT_ROOT.
+              (register-project-root-source-registry dir)
               (log-event :info "worker.project-root.set"
                          "path" (namestring dir))
               dir)


### PR DESCRIPTION
## 問題

`MCP_PROJECT_ROOT` / `fs-set-project-root` でプロジェクトを指定しても、**同名のシステムが worker の継承 ASDF レジストリ経由で見つかる場合**（例: `~/.roswell/local-projects` 配下のコピー）、ASDF はそちらを優先解決してコンパイルしてしまう。結果、プロジェクトルート下のソースを編集しても worker の `load-system`/`run-tests` は**未編集の元システムを実行**し続ける（編集ファイルは放置）。

## 原因

worker の ASDF source-registry に **project root が入っていなかった**:
- bare-SBCL 経路: spawn 時の `--eval` が `(:source-registry :inherit-configuration (:tree <cl-mcp-source-dir>))` を設定（inherit が先、project root 無し）。
- Roswell 経路（`ros run -s cl-mcp/src/worker/main`）: source-registry init すら無く、ros の既定（local-projects 継承）に依存。

## 修正

project root 設定時、worker の env に **`CL_SOURCE_REGISTRY=(:source-registry (:tree <root>) :inherit-configuration)`** を設定（project root を最優先）。env なので **両 spawn 経路**をカバー。親からの `CL_SOURCE_REGISTRY` 継承は除外して自前を権威化。bare-SBCL の `--eval` も `MCP_PROJECT_ROOT` を読んで prepend するよう更新。`:inherit-configuration` でライブラリ（rove 等）と cl-mcp 自身は従来どおり解決。

## 検証

- cl-harness-next のベンチ（fixture が local-projects 配下）で再現: ダイヤルは正しい修正を生成するのに worker が未編集の元ソースをコンパイルして **0/7**。本修正で **同 sweep が 7/7**。
- 制御実験で `(asdf:component-pathname (asdf:find-component "<sut>/src/..."))` が修正前=元 fixture、修正後=project root を指すことを確認。
- `rove cl-mcp.asd`（CI 相当）**50/50 緑**、`mallet src/worker-client.lisp` クリーン。