### PR TITLE
[codex] docs: mention FiveAM test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ system loading, file operations, code introspection, and structure-aware editing
 - **Sandboxed file operations** — read/write/list files restricted to the project root and ASDF system source directories, preventing accidental access outside the project
 - **Structure-aware Lisp editing** — replace, insert, and patch top-level forms using Eclector CST parsing with automatic parinfer repair, preserving formatting and comments
 - **Code intelligence** — symbol lookup, metadata, and cross-references via `sb-introspect`; Lisp-aware file viewing with collapsed signatures and pattern-based expansion
-- **Structured test runner** — run Rove tests with pass/fail counts, failure details, and source locations
+- **Structured test runner** — run Rove and FiveAM tests with pass/fail counts, failure details, and source locations
 - **Worker pool isolation** — eval-dependent tools run in isolated child SBCL processes with automatic crash recovery, circuit breaker, and per-session affinity
 - **Three transports** — stdio, TCP (multi-client), and Streamable HTTP (for Claude Code)
 
@@ -21,7 +21,7 @@ For the full list of tools with input/output schemas, see [docs/tools.md](docs/t
 ## Requirements
 - SBCL 2.x (developed with SBCL 2.5.x)
 - Quicklisp (optional; pure ASDF also works)
-- Dependencies (via ASDF/Quicklisp): runtime — `alexandria`, `cl-ppcre`, `yason`, `usocket`, `bordeaux-threads`, `eclector`, `hunchentoot`; tests — `rove`; optional — `clhs` (loaded on-demand by `clhs-lookup` tool).
+- Dependencies (via ASDF/Quicklisp): runtime — `alexandria`, `cl-ppcre`, `yason`, `usocket`, `bordeaux-threads`, `eclector`, `hunchentoot`; tests — `rove`; optional — `fiveam` (for running FiveAM suites), `clhs` (loaded on-demand by `clhs-lookup` tool).
 
 ## Quick Start
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -333,12 +333,13 @@ Input:
 - `system` (string, required): ASDF system name to test (e.g., `"my-project/tests"`)
 - `framework` (string, optional): Force a specific framework (`"rove"`, `"fiveam"`, or `"auto"` for auto-detect)
 - `test` (string, optional): Run only a specific test by fully qualified name (e.g., `"my-package::my-test-name"`)
+- `tests` (array of strings, optional): Run only the listed fully qualified tests
 
 Output:
 - `passed` (integer): Number of passed tests
 - `failed` (integer): Number of failed tests
-- `pending` (integer): Number of pending/skipped tests (Rove only)
-- `framework` (string): Framework used (`"rove"` or `"asdf"`)
+- `pending` (integer): Number of pending/skipped tests (when reported by the framework)
+- `framework` (string): Framework or outcome category used (`"rove"`, `"fiveam"`, `"asdf"`, `"load-error"`, `"unresolved"`, or `"timeout"`)
 - `duration_ms` (integer): Execution time in milliseconds
 - `failed_tests` (array, when failures exist): Detailed failure information including:
   - `test_name`: Name of the failing test
@@ -355,11 +356,14 @@ Example requests:
 
 // Run a single test
 {"method":"tools/call","params":{"name":"run-tests","arguments":{"system":"cl-mcp/tests/clhs-test","test":"cl-mcp/tests/clhs-test::clhs-lookup-symbol-returns-hash-table"}}}
+
+// Force FiveAM and run selected tests
+{"method":"tools/call","params":{"name":"run-tests","arguments":{"system":"my-project/tests","framework":"fiveam","tests":["my-project/tests::one-test","my-project/tests::another-test"]}}}
 ```
 
 Notes:
 - **Auto-reloads the test system** before execution (clears ASDF's loaded state and reloads from source). Files edited via `lisp-edit-form` are automatically picked up — no need to call `load-system` first.
-- Auto-detects Rove framework when loaded; falls back to ASDF `test-system` for text capture
+- Auto-detects Rove or FiveAM when available; falls back to ASDF `test-system` for text capture
 - Single test execution requires the test package to be loaded first
 - Test names must be fully qualified with package prefix (e.g., `"package::test-name"`)
 

--- a/prompts/repl-driven-development.md
+++ b/prompts/repl-driven-development.md
@@ -154,9 +154,11 @@ Use `repl-eval` for testing expressions, inspecting state, and verifying edits. 
 
 ## Testing
 
-**Preferred: `run-tests` tool** for structured results (pass/fail counts, failure details).
+**Preferred: `run-tests` tool** for structured Rove/FiveAM results (pass/fail counts, failure details).
 - Run system: `{"system": "my-system/tests"}`
 - Run single test: `{"system": "my-system/tests", "test": "my-system/tests::my-specific-test"}` (package must be loaded first)
+- Run selected tests: `{"system": "my-system/tests", "tests": ["my-system/tests::first-test", "my-system/tests::second-test"]}`
+- Force framework when auto-detection is ambiguous: `{"system": "my-system/tests", "framework": "fiveam"}`
 - Failure details: `failed_tests` array with `test_name`, `description`, `form`, `values`, `reason`, `source`
 - Response includes `stdout`/`stderr` fields (structured data only, NOT shown in summary text)
 - **Print debugging**: `format t` output goes to `stdout` (not visible in summary). To see debug prints in the summary, write to `*test-debug-output*`:
@@ -165,7 +167,7 @@ Use `repl-eval` for testing expressions, inspecting state, and verifying edits. 
   ```
   Output from this stream appears in both the `debug_output` field and the content text summary.
 
-**Fallback via `repl-eval`**: `(rove:run :my-system/tests)` after `load-system`.
+**Fallback via `repl-eval`**: use the project's native runner after `load-system`, such as `(rove:run :my-system/tests)` or `(fiveam:run! :my-system/tests)`.
 
 **Rove testing pitfalls:**
 - Rove's `signals` assertion does **not** reliably catch conditions raised inside `restart-case`. Use `handler-case` wrappers instead:


### PR DESCRIPTION
## Summary

Updates public documentation to reflect that `run-tests` supports both Rove and FiveAM.

## Changes

- Mention FiveAM support in the README feature list and optional dependencies.
- Document `run-tests` FiveAM framework selection, selected-test arrays, and framework outcome values in `docs/tools.md`.
- Update the REPL-driven development prompt with FiveAM examples and fallback guidance.

## Impact

Users and agents can now discover the FiveAM test runner support from the README, tool reference, and workflow prompt instead of seeing Rove-only guidance.

## Validation

- Ran `git diff --cached --check`.
- No runtime tests were run because this is documentation-only.