### PR TITLE
feat: worker init hook — run an app inside a cl-mcp worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Disable the worker pool with `MCP_NO_WORKER_POOL=1` or the `:worker-pool` keywor
 | `MCP_WORKER_INIT_SYSTEM` | ASDF system to load in the elected owner worker at bind (master gate for the init hook) | (unset = off) |
 | `MCP_WORKER_INIT_ENTRY` | `PKG:SYMBOL` nullary thunk run after the load (preferred activation) | (none) |
 | `MCP_WORKER_INIT_EVAL` | Lisp form run via repl-eval as an escape hatch | (none) |
+| `MCP_WORKER_INIT_PACKAGE` | Package used to read/eval `MCP_WORKER_INIT_EVAL` | `CL-USER` |
 | `MCP_WORKER_INIT_MAX_FAILURES` | Soft init failures before init auto-retry latches off | `1` |
 | `MCP_WORKER_INIT_MODE` | `singleton` (one owner binds a fixed port). v1 supports `singleton` only | `singleton` |
 
@@ -243,6 +244,20 @@ endpoint. `pool-kill-worker` restarts the runtime without dropping `/mcp`.
 Example (recurya): add a nullary `recurya/dev:start-dev-runtime!` thunk that
 starts the DB and web server, then set `MCP_WORKER_INIT_SYSTEM=recurya/dev`
 and `MCP_WORKER_INIT_ENTRY=recurya/dev:start-dev-runtime!`.
+
+Known v1 limitations:
+
+- **Single dev runtime / single session.** `singleton` mode is designed for one
+  developer session driving one fixed-port app. Ownership is bound to the owner
+  session and never migrates to a different *live* session, so hot-reload stays
+  in the app's process. A narrow multi-session race remains (if the owner's
+  worker crashes during the same window that a second session binds), so two
+  concurrent sessions against one init runtime is not supported in v1; a future
+  per-worker/ephemeral-port mode is planned for that.
+- **Reset is not instantaneous.** `pool-kill-worker` re-arms the runtime, but the
+  app is re-initialized lazily on the session's next tool call (not eagerly), so
+  the app is briefly down after a reset until the next MCP request. The parent
+  `/mcp` endpoint stays up throughout.
 
 ## Security Model
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ Known v1 limitations:
   app is re-initialized lazily on the session's next tool call (not eagerly), so
   the app is briefly down after a reset until the next MCP request. The parent
   `/mcp` endpoint stays up throughout.
+- **Soft-failure retry is worker-scoped.** `MCP_WORKER_INIT_MAX_FAILURES` counts
+  init failures across a session's worker (re)binds (e.g. successive hard-crash
+  recoveries). A *soft* init failure (the app reports an error but the worker
+  stays alive) keeps the runtime owned by that session (no migration) but is not
+  auto-retried on the same worker — recover it with `pool-kill-worker`.
 
 ## Security Model
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Disable the worker pool with `MCP_NO_WORKER_POOL=1` or the `:worker-pool` keywor
 | `MCP_NO_WORKER_POOL` | Set to `1` to disable worker pool isolation | (not set = pool enabled) |
 | `CL_MCP_WORKER_POOL_WARMUP` | Number of standby workers to maintain (non-negative integer) | `1` |
 | `CL_MCP_MAX_POOL_SIZE` | Maximum total workers, bound + standby (positive integer) | `16` |
+| `MCP_WORKER_INIT_SYSTEM` | ASDF system to load in the elected owner worker at bind (master gate for the init hook) | (unset = off) |
+| `MCP_WORKER_INIT_ENTRY` | `PKG:SYMBOL` nullary thunk run after the load (preferred activation) | (none) |
+| `MCP_WORKER_INIT_EVAL` | Lisp form run via repl-eval as an escape hatch | (none) |
+| `MCP_WORKER_INIT_MAX_FAILURES` | Soft init failures before init auto-retry latches off | `1` |
+| `MCP_WORKER_INIT_MODE` | `singleton` (one owner binds a fixed port). v1 supports `singleton` only | `singleton` |
 
 ### Tuning warmup for cold-start handshakes
 
@@ -211,6 +216,33 @@ are then created on demand the first time a session needs one,
 trading first-eval latency for the smallest possible startup
 footprint. Once your client establishes the session you can ignore
 the warmup; the pool will grow as sessions arrive.
+
+### Running an app inside a worker (init hook)
+
+Set `MCP_WORKER_INIT_SYSTEM` (and optionally `MCP_WORKER_INIT_ENTRY`) to have
+the pool run a startup routine inside the single worker elected as the
+"runtime owner" when a session binds it. This lets an app (e.g. a web server)
+run in the same process that serves `repl-eval`/`load-system`, so hot-reload
+lands in the app's process, while the parent keeps the persistent `/mcp`
+endpoint. `pool-kill-worker` restarts the runtime without dropping `/mcp`.
+
+- The init runs on a background thread under a worker-global ASDF load lock,
+  so it never races a `load-system` RPC.
+- Init failures never trip the crash circuit breaker; a failed init leaves a
+  plain, usable REPL worker. Check `pool-status` (`init_owner_session`,
+  `init_disabled`, `init_failures`) to see runtime state.
+- Requires the pool enabled (do not set `MCP_NO_WORKER_POOL=1`); cl-mcp warns
+  at startup if the init vars are set while the pool is disabled.
+- The init form must be bind-robust and idempotent, and should pass
+  `:address "127.0.0.1"` for a localhost-only dev server. Do not embed
+  secrets in `MCP_WORKER_INIT_EVAL`.
+- Reloading code with `load-system :force t` while the app is serving live
+  requests can race in-flight request threads (class/method redefinition);
+  reload between requests or quiesce the app's acceptor first.
+
+Example (recurya): add a nullary `recurya/dev:start-dev-runtime!` thunk that
+starts the DB and web server, then set `MCP_WORKER_INIT_SYSTEM=recurya/dev`
+and `MCP_WORKER_INIT_ENTRY=recurya/dev:start-dev-runtime!`.
 
 ## Security Model
 

--- a/docs/superpowers/plans/2026-07-05-worker-init-hook.md
+++ b/docs/superpowers/plans/2026-07-05-worker-init-hook.md
@@ -1,0 +1,1526 @@
+# Worker Init Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a parent-orchestrated, session-bound, single-owner worker init hook so an app (e.g. recurya's web server) can auto-start inside a cl-mcp worker while the parent keeps the persistent `/mcp` endpoint, with init failures fully walled off from the crash breaker.
+
+**Architecture:** The hook is **absent from `worker/main:start`** (so standby/replenishment/crash-replacement workers boot bare and never bind the fixed port). The parent, at the `:bound` transition, elects a single **runtime owner session** and sends a fire-and-forget `worker/init-start` RPC; the worker runs init on a background thread guarded by a worker-global `*asdf-load-lock*`, calling `load-system` with `timeout=nil` (the direct branch — no `destroy-thread` corruption). The parent polls `worker/init-status`, surfaces state in `pool-status`, and treats init-attributable crashes separately from the circuit breaker.
+
+**Tech Stack:** SBCL, ASDF `package-inferred-system`, Rove tests, `bordeaux-threads`, `usocket`, `yason`.
+
+**Spec:** `docs/plans/2026-07-05-worker-init-hook-design.md` (design examination). Read §5 (v1 design), §6 (implementation sketch), and the failure-scenario table before starting.
+
+**Scope note:** Phase 1 (worker `*asdf-load-lock*`) is independently shippable and valuable even without the hook — it fixes the pre-existing concurrent-ASDF-load hazard. It is a reasonable first PR. Phases 4–5 (parent ownership + breaker isolation) are the heavy correctness work; all four correctness pillars in design §9 must land before enabling the feature in production.
+
+---
+
+## File Structure
+
+**Worker process (loaded via `cl-mcp/src/worker/main` in the child SBCL):**
+- Create `src/worker/init-hook.lisp` — package `cl-mcp/src/worker/init-hook`. Owns `*asdf-load-lock*` + `with-asdf-load-lock`, the init state machine (`*init-state*`), entry resolution (`%resolve-entry`), the init runner (`%run-init`), and the two RPC handlers (`handle-init-start`, `handle-init-status`). One file, one responsibility: "everything the worker does for the init hook."
+- Modify `src/worker/handlers.lisp` — import `with-asdf-load-lock`, `handle-init-start`, `handle-init-status` from the new file; wrap the `load-system` and `run-tests` calls in the lock; register the two new methods.
+
+**Parent process (loaded via `cl-mcp/main`):**
+- Modify `src/pool.lisp` — config parsing (`%parse-worker-init-config`, `%env-string`), ownership specials (`*runtime-owner*`, `*runtime-init-failures*`, `*runtime-init-disabled*`, `*init-attributable-crashes*`), election (`%elect-runtime-owner`, `%release-runtime-owner-if`), orchestration (`%ensure-runtime-init`, `%start-init-and-monitor`), call-site wiring, breaker isolation, and `pool-status-info` fields.
+- Modify `src/worker-client.lisp` — denylist the `MCP_WORKER_INIT_*` vars in `%build-environment`.
+
+**Tests:**
+- Create `tests/worker-init-hook-test.lisp` — package `cl-mcp/tests/worker-init-hook-test`. Load-lock serialization, state machine, entry resolution, and an integration test (spawn a worker server, drive `worker/init-start` → `worker/init-status`).
+- Create `tests/pool-init-config-test.lisp` — package `cl-mcp/tests/pool-init-config-test`. Config parsing, env denylist, election logic, ownership release, breaker isolation.
+- Modify `tests.lisp` — register both new test packages in the `cl-mcp/tests` aggregate.
+
+**Docs:**
+- Modify `README.md` — document the `MCP_WORKER_INIT_*` env vars and recurya wiring.
+
+---
+
+## Conventions for every task
+
+- **Run a single test file** via the `run-tests` MCP tool: `{"system": "cl-mcp/tests/<name>-test"}`. Shell fallback for a clean image: `rove cl-mcp.asd` from the repo root (runs the whole suite).
+- **Run one test** via `repl-eval`: `(rove:run-test 'cl-mcp/tests/<pkg>::<test-name>)` after `load-system`.
+- **Edit `.lisp` files with `lisp-edit-form`/`lisp-patch-form`**, never the text Edit tool (per project MEMORY). After structural edits, run `lisp-check-parens`.
+- **Lint before each commit:** `mallet src/*.lisp` (and the edited test files).
+- New worker-side files are auto-loaded by `package-inferred-system` once `handlers.lisp` imports them; no `cl-mcp.asd` edit is needed. New test files MUST be added to `tests.lisp`.
+
+---
+
+## Phase 1 — Worker ASDF load lock (correctness pillar #1; independently shippable)
+
+### Task 1: Create `src/worker/init-hook.lisp` with the ASDF load lock
+
+**Files:**
+- Create: `src/worker/init-hook.lisp`
+- Create: `tests/worker-init-hook-test.lisp`
+- Modify: `tests.lisp`
+
+- [ ] **Step 1: Create the new test file with the failing serialization test**
+
+Create `tests/worker-init-hook-test.lisp`:
+
+```lisp
+;;;; tests/worker-init-hook-test.lisp
+;;;;
+;;;; Tests for the worker-side init hook: load lock, init state machine,
+;;;; entry resolution, and the init RPC handlers.
+
+(defpackage #:cl-mcp/tests/worker-init-hook-test
+  (:use #:cl)
+  (:import-from #:rove #:deftest #:testing #:ok #:skip)
+  (:import-from #:cl-mcp/src/worker/init-hook
+                #:*asdf-load-lock*
+                #:with-asdf-load-lock))
+
+(in-package #:cl-mcp/tests/worker-init-hook-test)
+
+(deftest with-asdf-load-lock-serializes
+  (testing "two threads holding the lock never overlap in the critical section"
+    (let ((inside 0) (max-inside 0) (lock (bt:make-lock "probe")))
+      (flet ((body ()
+               (with-asdf-load-lock
+                 (bt:with-lock-held (lock)
+                   (incf inside)
+                   (setf max-inside (max max-inside inside)))
+                 (sleep 0.02)
+                 (bt:with-lock-held (lock) (decf inside)))))
+        (let ((threads (loop repeat 5
+                             collect (bt:make-thread #'body :name "probe"))))
+          (dolist (th threads) (bt:join-thread th))))
+      (ok (= max-inside 1)
+          "at most one thread was inside the load-lock critical section"))))
+```
+
+- [ ] **Step 2: Register the new test package in `tests.lisp`**
+
+Add this line to the `defpackage #:cl-mcp/tests` form in `tests.lisp`, after the `cl-mcp/tests/worker-test` import (line 47):
+
+```lisp
+  (:import-from #:cl-mcp/tests/worker-init-hook-test)
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run via `run-tests`: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: FAIL / load error — `cl-mcp/src/worker/init-hook` package does not exist yet (`with-asdf-load-lock` unresolved).
+
+- [ ] **Step 4: Create `src/worker/init-hook.lisp` with the lock**
+
+Create `src/worker/init-hook.lisp`:
+
+```lisp
+;;;; src/worker/init-hook.lisp
+;;;;
+;;;; Worker-side machinery for the init hook.  Provides the worker-global
+;;;; ASDF load lock (so cl-mcp-mediated loads never overlap), the init
+;;;; state machine, entry resolution, and the worker/init-start and
+;;;; worker/init-status RPC handlers.  See
+;;;; docs/plans/2026-07-05-worker-init-hook-design.md.
+
+(defpackage #:cl-mcp/src/worker/init-hook
+  (:use #:cl)
+  (:import-from #:bordeaux-threads
+                #:make-lock #:with-lock-held #:make-thread)
+  (:export #:*asdf-load-lock*
+           #:with-asdf-load-lock))
+
+(in-package #:cl-mcp/src/worker/init-hook)
+
+(defvar *asdf-load-lock* (bt:make-lock "asdf-load-lock")
+  "Worker-global lock serializing every cl-mcp-mediated ASDF load site
+(worker/init, worker/load-system, worker/run-tests).  Prevents two
+concurrent ASDF load-ops in one worker image, which the single-threaded
+dispatch loop does NOT prevent because load-system/repl-eval run their
+work on spawned helper threads.")
+
+(defmacro with-asdf-load-lock (&body body)
+  "Evaluate BODY holding *ASDF-LOAD-LOCK*."
+  `(bt:with-lock-held (*asdf-load-lock*) ,@body))
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run via `run-tests`: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: PASS — `with-asdf-load-lock-serializes` green.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+mallet src/worker/init-hook.lisp
+git add src/worker/init-hook.lisp tests/worker-init-hook-test.lisp tests.lisp
+git commit -m "feat(worker): add worker-global ASDF load lock"
+```
+
+---
+
+### Task 2: Serialize the `load-system` and `run-tests` handlers with the lock
+
+**Files:**
+- Modify: `src/worker/handlers.lisp:105-120` (`%handle-load-system`), `src/worker/handlers.lisp:126-155` (`%handle-run-tests`), and the `defpackage` (lines 9-43)
+- Test: `tests/worker-init-hook-test.lisp`
+
+- [ ] **Step 1: Write the failing test — handlers still return their payloads under the lock**
+
+Append to `tests/worker-init-hook-test.lisp`:
+
+```lisp
+(deftest load-system-handler-holds-lock
+  (testing "%handle-load-system runs its ASDF load inside the load lock"
+    ;; The lock must be free before and after; while the handler runs a
+    ;; (fast) load of an already-present system, a concurrent attempt to
+    ;; take the lock must block until the handler releases it.
+    (ok (not (bt:acquire-lock cl-mcp/src/worker/init-hook:*asdf-load-lock* nil))
+        "lock is available (acquire returns non-nil), then release it")
+    (bt:release-lock cl-mcp/src/worker/init-hook:*asdf-load-lock*)
+    (skip "serialization vs a concurrent load is covered by the integration test")))
+```
+
+Note: this is a smoke assertion; genuine serialization across `load-system` and `run-tests` is exercised by the Phase 2 integration test (Task 5) which drives real RPCs. The point of this task is that the handlers compile and still work after wrapping.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run via `run-tests`: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: FAIL — `bt:acquire-lock` on `*asdf-load-lock*` returns a value that trips the assertion phrasing OR compiles but the wrapping is not yet present. (If it passes trivially, proceed; the real verification is Step 4's compile + Task 5 integration.)
+
+- [ ] **Step 3: Add the import to `handlers.lisp`'s `defpackage`**
+
+Add to the `defpackage #:cl-mcp/src/worker/handlers` form (after the `#:cl-mcp/src/worker/server` import at line 41-42):
+
+```lisp
+  (:import-from #:cl-mcp/src/worker/init-hook
+                #:with-asdf-load-lock)
+```
+
+- [ ] **Step 4: Wrap the `load-system` call in `%handle-load-system`**
+
+Replace the `let` binding the load result (lines 116-119) so the `load-system` call is inside the lock. The new body of `%handle-load-system`:
+
+```lisp
+(defun %handle-load-system (params)
+  "Load an ASDF system.  Returns the same structure as define-tool
+\"load-system\".  Holds *ASDF-LOAD-LOCK* so it cannot overlap a
+concurrent worker/init load or another load-system."
+  (let ((system (gethash "system" params))
+         (force (%bool-default params "force" t))
+         (clear-fasls (gethash "clear_fasls" params))
+         (timeout-seconds (gethash "timeout_seconds" params)))
+    (unless system
+      (error "system is required"))
+    (when (and timeout-seconds (not (plusp timeout-seconds)))
+      (error "timeout_seconds must be a positive number"))
+    (let ((ht (with-asdf-load-lock
+                (load-system system
+                             :force force
+                             :clear-fasls clear-fasls
+                             :timeout-seconds (or timeout-seconds 120)))))
+      (build-load-system-response system ht))))
+```
+
+- [ ] **Step 5: Wrap the `run-tests` call in `%handle-run-tests`**
+
+In `%handle-run-tests`, wrap the `do-run` local function body so the test run (which force-reloads the test system) holds the lock. Change the `flet` in lines 137-141 to:
+
+```lisp
+    (flet ((do-run ()
+             (with-asdf-load-lock
+               (run-tests system
+                          :framework framework
+                          :test test
+                          :tests tests))))
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run via `run-tests`: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: PASS. Also run the existing worker suite to confirm no regression: `{"system": "cl-mcp/tests/worker-test"}` → PASS.
+
+- [ ] **Step 7: Verify parens, lint, commit**
+
+Run `lisp-check-parens` on `src/worker/handlers.lisp`. Then:
+
+```bash
+mallet src/worker/handlers.lisp
+git add src/worker/handlers.lisp tests/worker-init-hook-test.lisp
+git commit -m "feat(worker): serialize load-system and run-tests under the ASDF load lock"
+```
+
+---
+
+## Phase 2 — Worker init state machine, entry resolution, and handlers
+
+### Task 3: Init state machine
+
+**Files:**
+- Modify: `src/worker/init-hook.lisp`
+- Test: `tests/worker-init-hook-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/worker-init-hook-test.lisp` (add the state-machine symbols to the test package's `:import-from` for `cl-mcp/src/worker/init-hook` first — edit the `defpackage` to also import `#:%set-init-state #:init-state-snapshot #:%reset-init-state`):
+
+```lisp
+(deftest init-state-transitions
+  (testing "state starts idle, moves to loading/running/failed, snapshots as a hash-table"
+    (cl-mcp/src/worker/init-hook::%reset-init-state)
+    (let ((s0 (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s0) "idle") "starts idle"))
+    (cl-mcp/src/worker/init-hook::%set-init-state :loading)
+    (ok (string= (gethash "init_state"
+                          (cl-mcp/src/worker/init-hook::init-state-snapshot))
+                 "loading")
+        "loading")
+    (cl-mcp/src/worker/init-hook::%set-init-state :running :app-port 13000)
+    (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s) "running") "running")
+      (ok (eql (gethash "app_port" s) 13000) "app_port recorded"))
+    (cl-mcp/src/worker/init-hook::%set-init-state :failed :error "boom")
+    (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s) "failed") "failed")
+      (ok (string= (gethash "last_init_error" s) "boom") "error recorded"))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: FAIL — `%set-init-state`/`init-state-snapshot`/`%reset-init-state` unbound.
+
+- [ ] **Step 3: Implement the state machine in `init-hook.lisp`**
+
+Add to `src/worker/init-hook.lisp` after the `with-asdf-load-lock` macro. First extend the `:export` list to add `#:handle-init-start #:handle-init-status` (used later) and keep internals unexported:
+
+```lisp
+(defvar *init-lock* (bt:make-lock "worker-init-state")
+  "Protects *INIT-STATE*.")
+
+(defvar *init-state* (list :state :idle :app-port nil :error nil :started-at nil)
+  "Init progress: :state is one of :idle :loading :running :failed.")
+
+(defun %reset-init-state ()
+  "Reset init state to :idle (used by tests and re-arming)."
+  (bt:with-lock-held (*init-lock*)
+    (setf *init-state* (list :state :idle :app-port nil :error nil
+                             :started-at nil))))
+
+(defun %set-init-state (state &key app-port error)
+  "Transition init state.  STATE is a keyword; APP-PORT/ERROR update the
+corresponding fields when provided."
+  (bt:with-lock-held (*init-lock*)
+    (setf (getf *init-state* :state) state)
+    (when (eq state :loading)
+      (setf (getf *init-state* :started-at) (get-universal-time)))
+    (when app-port (setf (getf *init-state* :app-port) app-port))
+    (when error (setf (getf *init-state* :error) error))))
+
+(defun init-state-snapshot ()
+  "Return a hash-table snapshot of init state for pool-status / RPC.
+Keys: init_state, app_port, last_init_error, started_at."
+  (bt:with-lock-held (*init-lock*)
+    (let ((ht (make-hash-table :test 'equal)))
+      (setf (gethash "init_state" ht) (string-downcase (getf *init-state* :state))
+            (gethash "app_port" ht) (getf *init-state* :app-port)
+            (gethash "last_init_error" ht) (getf *init-state* :error)
+            (gethash "started_at" ht) (getf *init-state* :started-at))
+      ht)))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: PASS — `init-state-transitions` green.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/worker/init-hook.lisp
+git add src/worker/init-hook.lisp tests/worker-init-hook-test.lisp
+git commit -m "feat(worker): add init state machine"
+```
+
+---
+
+### Task 4: Entry resolution (`%resolve-entry`)
+
+**Files:**
+- Modify: `src/worker/init-hook.lisp`
+- Test: `tests/worker-init-hook-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/worker-init-hook-test.lisp`:
+
+```lisp
+(defun a-test-entry-thunk () 4242)
+
+(deftest resolve-entry
+  (testing "PKG:SYM and PKG::SYM resolve to the fdefinition; bad specs error"
+    (let ((fn (cl-mcp/src/worker/init-hook::%resolve-entry
+               "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST:A-TEST-ENTRY-THUNK")))
+      (ok (functionp fn) "resolves to a function")
+      (ok (eql (funcall fn) 4242) "funcalls the resolved thunk"))
+    (ok (functionp
+         (cl-mcp/src/worker/init-hook::%resolve-entry
+          "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST::A-TEST-ENTRY-THUNK"))
+        "double-colon form resolves")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "no-colon") nil)
+          (error () t))
+        "spec without a colon errors")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "NOSUCHPKG:FOO") nil)
+          (error () t))
+        "missing package errors")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "CL:NO-SUCH-SYMBOL-XYZ") nil)
+          (error () t))
+        "missing symbol errors")))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: FAIL — `%resolve-entry` unbound.
+
+- [ ] **Step 3: Implement `%resolve-entry`**
+
+Add to `src/worker/init-hook.lisp`:
+
+```lisp
+(defun %resolve-entry (spec)
+  "Resolve a \"PKG:SYMBOL\" or \"PKG::SYMBOL\" string to a callable.
+Uses find-package / find-symbol / fdefinition only -- no read, eval, or
+intern -- honoring the project's no-runtime-eval style rule.  Signals an
+error if the package or symbol is missing or the symbol is not fbound."
+  (let* ((dbl (search "::" spec))
+         (colon (or dbl (position #\: spec))))
+    (unless colon
+      (error "init entry ~S must be of the form PKG:SYMBOL" spec))
+    (let* ((pkg-name (string-upcase (subseq spec 0 colon)))
+           (sym-name (string-upcase (subseq spec (+ colon (if dbl 2 1)))))
+           (pkg (find-package pkg-name)))
+      (unless pkg
+        (error "init entry: package ~A not found" pkg-name))
+      (let ((sym (find-symbol sym-name pkg)))
+        (unless sym
+          (error "init entry: symbol ~A not found in package ~A"
+                 sym-name pkg-name))
+        (unless (fboundp sym)
+          (error "init entry: ~A is not fbound" sym))
+        (fdefinition sym)))))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/worker/init-hook.lisp
+git add src/worker/init-hook.lisp tests/worker-init-hook-test.lisp
+git commit -m "feat(worker): add init entry-point resolution"
+```
+
+---
+
+### Task 5: Init runner + RPC handlers, registered on the server
+
+**Files:**
+- Modify: `src/worker/init-hook.lisp`
+- Modify: `src/worker/handlers.lisp` (`defpackage` + `register-all-handlers`)
+- Test: `tests/worker-init-hook-test.lisp`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/worker-init-hook-test.lisp` (add `#:make-worker-server #:server-port #:start-accept-loop #:stop-server` from `cl-mcp/src/worker/server` and `#:register-all-handlers` from `cl-mcp/src/worker/handlers` to the test `defpackage` imports):
+
+```lisp
+(defparameter *entry-ran* nil)
+(defun integration-entry-thunk () (setf *entry-ran* t) 12345)
+
+(defun %rpc (stream id method &optional params)
+  "Send one JSON-RPC line and read one response line; return the parsed hash."
+  (let ((req (make-hash-table :test 'equal)))
+    (setf (gethash "jsonrpc" req) "2.0"
+          (gethash "id" req) id
+          (gethash "method" req) method)
+    (when params (setf (gethash "params" req) params))
+    (yason:encode req stream) (terpri stream) (force-output stream)
+    (yason:parse (read-line stream))))
+
+(deftest init-start-then-status-integration
+  (testing "worker/init-start acks fast; init runs the entry; status reaches running"
+    (if (not (socket-available-p))
+        (skip "socket unavailable")
+        (let ((server (make-worker-server :port 0)))
+          (register-all-handlers server)
+          (setf *entry-ran* nil)
+          (cl-mcp/src/worker/init-hook::%reset-init-state)
+          (unwind-protect
+               (let ((port (server-port server)))
+                 (bt:make-thread (lambda () (start-accept-loop server))
+                                 :name "test-init-accept")
+                 (sleep 0.1)
+                 (let ((socket (usocket:socket-connect "127.0.0.1" port
+                                                       :element-type 'character)))
+                   (unwind-protect
+                        (let* ((stream (usocket:socket-stream socket))
+                               (params (make-hash-table :test 'equal)))
+                          (setf (gethash "entry" params)
+                                "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST:INTEGRATION-ENTRY-THUNK")
+                          (let ((ack (%rpc stream 1 "worker/init-start" params)))
+                            (ok (gethash "accepted" (gethash "result" ack))
+                                "init-start acked with accepted=t"))
+                          ;; Poll status until it leaves :loading (bounded).
+                          (let ((final nil))
+                            (loop repeat 50
+                                  for st = (gethash "result"
+                                            (%rpc stream 2 "worker/init-status"))
+                                  for state = (gethash "init_state" st)
+                                  do (setf final state)
+                                  until (member state '("running" "failed")
+                                                :test #'string=)
+                                  do (sleep 0.05))
+                            (ok (string= final "running") "init reached running")
+                            (ok *entry-ran* "entry thunk executed")))
+                     (ignore-errors (usocket:socket-close socket)))))
+            (stop-server server))))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: FAIL — `worker/init-start` is `Method not found` (handlers not registered).
+
+- [ ] **Step 3: Implement `%run-init` and the two handlers in `init-hook.lisp`**
+
+Add the imports the runner needs to the `defpackage` (`#:cl-mcp/src/system-loader-core #:load-system`, `#:cl-mcp/src/repl-core #:repl-eval`, `#:cl-mcp/src/utils/sanitize #:sanitize-error-message`, `#:cl-mcp/src/tools/helpers #:make-ht`, `#:cl-mcp/src/log #:log-event`). Then add:
+
+```lisp
+(defun %maybe-eval (form-string package-name)
+  "Run FORM-STRING via repl-core:repl-eval in PACKAGE-NAME.  Signals an
+error if the evaluation produced an error-context, so the outer
+handler-case records a :failed init.  Routing through repl-eval (not raw
+eval) reuses the sanctioned evaluator."
+  (let ((pkg (or (find-package (string-upcase package-name)) *package*)))
+    (multiple-value-bind (printed raw stdout stderr err-ctx)
+        (repl-eval form-string :package pkg)
+      (declare (ignore printed raw stdout stderr))
+      (when err-ctx
+        (error "init eval failed: ~A"
+               (if (hash-table-p err-ctx)
+                   (or (gethash "message" err-ctx) err-ctx)
+                   err-ctx))))))
+
+(defun %run-init (params)
+  "Background-thread init runner.  Holds *ASDF-LOAD-LOCK* for the whole
+load so it cannot overlap a concurrent load-system/run-tests.  Loads with
+timeout=NIL (the direct branch -- no spawned thread, no destroy-thread
+mid-compile).  Never signals out of this function: on any error it records
+a :failed init and leaves the worker fully usable."
+  (let ((system (gethash "system" params))
+        (evalform (gethash "eval" params))
+        (entry (gethash "entry" params))
+        (pkg (or (gethash "package" params) "CL-USER")))
+    (%set-init-state :loading)
+    (handler-case
+        (with-asdf-load-lock
+          (when system
+            (load-system system :force nil :timeout-seconds nil))
+          (when evalform
+            (%maybe-eval evalform pkg))
+          (let ((port nil))
+            (when entry
+              (setf port (funcall (%resolve-entry entry))))
+            (%set-init-state :running
+                             :app-port (and (integerp port) port))
+            (log-event :info "worker.init.done"
+                       "app_port" (and (integerp port) port))))
+      (serious-condition (e)
+        (%set-init-state :failed :error (sanitize-error-message e))
+        (log-event :warn "worker.init.failed"
+                   "error" (sanitize-error-message e))))))
+
+(defun handle-init-start (params)
+  "worker/init-start handler.  Spawns the init runner on a background
+thread and returns an ACK immediately, so the parent's RPC does not block
+on the (heavy) load and no long stream-lock is held."
+  (bt:make-thread (lambda () (%run-init params)) :name "mcp-worker-init")
+  (make-ht "accepted" t))
+
+(defun handle-init-status (params)
+  "worker/init-status handler.  Returns the current init state snapshot."
+  (declare (ignore params))
+  (init-state-snapshot))
+```
+
+- [ ] **Step 4: Register the handlers in `handlers.lisp`**
+
+Add to `defpackage #:cl-mcp/src/worker/handlers` the imports (extend the existing `#:cl-mcp/src/worker/init-hook` import clause added in Task 2):
+
+```lisp
+  (:import-from #:cl-mcp/src/worker/init-hook
+                #:with-asdf-load-lock
+                #:handle-init-start
+                #:handle-init-status)
+```
+
+In `register-all-handlers`, add the two registrations before the `log-event` call and bump the count from 8 to 10:
+
+```lisp
+  (register-method server "worker/init-start" #'handle-init-start)
+  (register-method server "worker/init-status" #'handle-init-status)
+  (log-event :info "worker.handlers.registered" "count" 10)
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/worker-init-hook-test"}`
+Expected: PASS — `init-start-then-status-integration` reaches `running` and the entry thunk ran.
+
+- [ ] **Step 6: Verify parens, lint, commit**
+
+Run `lisp-check-parens` on both edited src files. Then:
+
+```bash
+mallet src/worker/init-hook.lisp src/worker/handlers.lisp
+git add src/worker/init-hook.lisp src/worker/handlers.lisp tests/worker-init-hook-test.lisp
+git commit -m "feat(worker): add worker/init-start and worker/init-status handlers"
+```
+
+---
+
+## Phase 3 — Parent config parsing, env denylist, pool-off guard
+
+### Task 6: Parse `MCP_WORKER_INIT_*` config in the pool
+
+**Files:**
+- Modify: `src/pool.lisp` (config section, ~lines 90-141; `initialize-pool` ~686-741)
+- Create: `tests/pool-init-config-test.lisp`
+- Modify: `tests.lisp`
+
+- [ ] **Step 1: Create the config test file**
+
+Create `tests/pool-init-config-test.lisp`:
+
+```lisp
+;;;; tests/pool-init-config-test.lisp
+;;;;
+;;;; Tests for parent-side worker-init-hook config parsing, env denylist,
+;;;; ownership election, and crash-breaker isolation.
+
+(defpackage #:cl-mcp/tests/pool-init-config-test
+  (:use #:cl)
+  (:import-from #:rove #:deftest #:testing #:ok)
+  (:import-from #:cl-mcp/src/pool
+                #:*worker-init-config*))
+
+(in-package #:cl-mcp/tests/pool-init-config-test)
+
+(defun %with-env (bindings thunk)
+  "Set env BINDINGS ((name . value) ...) for the duration of THUNK, then
+restore.  A NIL value unsets the variable."
+  (let ((saved (loop for (name . nil) in bindings
+                     collect (cons name (uiop:getenv name)))))
+    (unwind-protect
+         (progn
+           (loop for (name . value) in bindings
+                 do (if value (setf (uiop/os:getenv name) value)
+                        (sb-posix:unsetenv name)))
+           (funcall thunk))
+      (loop for (name . value) in saved
+            do (if value (setf (uiop/os:getenv name) value)
+                   (sb-posix:unsetenv name))))))
+
+(deftest parse-worker-init-config
+  (testing "config is nil when SYSTEM is unset, populated when set"
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . nil))
+      (lambda ()
+        (ok (null (cl-mcp/src/pool::%parse-worker-init-config))
+            "no SYSTEM => nil config")))
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . "recurya/dev")
+                 ("MCP_WORKER_INIT_ENTRY" . "recurya/dev:start-dev-runtime!")
+                 ("MCP_WORKER_INIT_MAX_FAILURES" . "1"))
+      (lambda ()
+        (let ((cfg (cl-mcp/src/pool::%parse-worker-init-config)))
+          (ok cfg "config present")
+          (ok (string= (getf cfg :system) "recurya/dev") "system parsed")
+          (ok (string= (getf cfg :entry) "recurya/dev:start-dev-runtime!")
+              "entry parsed")
+          (ok (eql (getf cfg :max-failures) 1) "max-failures parsed"))))))
+```
+
+- [ ] **Step 2: Register the test package in `tests.lisp`**
+
+Add after the `cl-mcp/tests/pool-kill-worker-test` import (line 52):
+
+```lisp
+  (:import-from #:cl-mcp/tests/pool-init-config-test)
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `*worker-init-config*` and `%parse-worker-init-config` unbound.
+
+- [ ] **Step 4: Add `%env-string`, specials, and `%parse-worker-init-config` to `pool.lisp`**
+
+After the `%env-int` defun (ends line 117), add `%env-string`:
+
+```lisp
+(defun %env-string (name)
+  "Return the environment variable NAME as a string, or NIL when unset or
+empty."
+  (let ((s (uiop:getenv name)))
+    (and s (plusp (length s)) s)))
+```
+
+After the existing config defvars (after `*shutdown-replenish-wait-seconds*`, line 140), add:
+
+```lisp
+(defvar *worker-init-config* nil
+  "Parsed worker-init-hook config, or NIL when the feature is off.
+A plist: (:system S :entry E :eval EV :package P :max-failures N :mode M).")
+
+(defun %parse-worker-init-config ()
+  "Read MCP_WORKER_INIT_* from the environment into a config plist, or NIL
+when MCP_WORKER_INIT_SYSTEM is unset (feature off).  MCP_WORKER_INIT_SYSTEM
+is the master gate, mirroring MCP_WORKER_SWANK."
+  (let ((system (%env-string "MCP_WORKER_INIT_SYSTEM")))
+    (when system
+      (list :system system
+            :entry (%env-string "MCP_WORKER_INIT_ENTRY")
+            :eval (%env-string "MCP_WORKER_INIT_EVAL")
+            :package (or (%env-string "MCP_WORKER_INIT_PACKAGE") "CL-USER")
+            :max-failures (%env-int "MCP_WORKER_INIT_MAX_FAILURES" 1 :min 1)
+            :mode (or (%env-string "MCP_WORKER_INIT_MODE") "singleton")))))
+```
+
+Export `*worker-init-config*` from the `pool` package by adding `#:*worker-init-config*` to the `:export` list of `defpackage #:cl-mcp/src/pool` (after `#:*max-pool-size*`, line 51).
+
+- [ ] **Step 5: Populate the config in `initialize-pool`**
+
+In `initialize-pool`, inside the `bt:with-lock-held (*pool-lock*)` reset block (lines 723-728), add a line so the config is refreshed on every pool init:
+
+```lisp
+      (setf *worker-init-config* (%parse-worker-init-config))
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS — `parse-worker-init-config` green.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp tests.lisp
+git commit -m "feat(pool): parse MCP_WORKER_INIT_* config"
+```
+
+---
+
+### Task 7: Denylist `MCP_WORKER_INIT_*` in the worker environment
+
+**Files:**
+- Modify: `src/worker-client.lisp:188-192` (`*worker-env-denylist*`)
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp` (add `#:%build-environment` is internal; test the denylist var directly — add `#:cl-mcp/src/worker-client` to the test `defpackage` `:import-from` with no symbols, then reference the internal denylist):
+
+```lisp
+(deftest init-vars-are-denylisted
+  (testing "MCP_WORKER_INIT_* are excluded from inherited worker env"
+    (let ((denylist cl-mcp/src/worker-client::*worker-env-denylist*))
+      (ok (member "MCP_WORKER_INIT_SYSTEM" denylist :test #'string=)
+          "SYSTEM denylisted")
+      (ok (member "MCP_WORKER_INIT_ENTRY" denylist :test #'string=)
+          "ENTRY denylisted")
+      (ok (member "MCP_WORKER_INIT_EVAL" denylist :test #'string=)
+          "EVAL denylisted"))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — the `MCP_WORKER_INIT_*` names are not in the denylist.
+
+- [ ] **Step 3: Add the vars to the denylist**
+
+Replace the `*worker-env-denylist*` defparameter (lines 188-192) with:
+
+```lisp
+(defparameter *worker-env-denylist*
+  '("MCP_WORKER_SECRET" "MCP_WORKER_ID" "MCP_PARENT_PID" "MCP_LOG_FILE"
+    ;; The parent is the sole reader of these; the worker receives init
+    ;; params via RPC.  Denylisting prevents init forms that embed secrets
+    ;; from leaking into every worker's environment.
+    "MCP_WORKER_INIT_SYSTEM" "MCP_WORKER_INIT_ENTRY" "MCP_WORKER_INIT_EVAL"
+    "MCP_WORKER_INIT_PACKAGE" "MCP_WORKER_INIT_MAX_FAILURES"
+    "MCP_WORKER_INIT_MODE")
+  "Environment variables that must NOT be inherited from the parent.
+MCP_WORKER_SECRET/ID/PARENT_PID are set explicitly per-worker.
+MCP_LOG_FILE is excluded so workers don't write to the parent's log file.
+MCP_WORKER_INIT_* are read only by the parent and passed as RPC params.")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/worker-client.lisp
+git add src/worker-client.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(worker): denylist MCP_WORKER_INIT_* from worker env inheritance"
+```
+
+---
+
+### Task 8: Pool-off guard warning
+
+**Files:**
+- Modify: `src/pool.lisp` (`initialize-pool`, near the end ~740)
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp`:
+
+```lisp
+(deftest pool-off-guard-warns
+  (testing "%warn-if-init-without-pool warns when INIT is set but pool disabled"
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . "recurya/dev")
+                 ("MCP_NO_WORKER_POOL" . "1"))
+      (lambda ()
+        (ok (handler-case
+                (progn (cl-mcp/src/pool::%warn-if-init-without-pool) nil)
+              (warning () t))
+            "signals a warning when INIT set with pool disabled")))
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . nil)
+                 ("MCP_NO_WORKER_POOL" . "1"))
+      (lambda ()
+        (ok (handler-case
+                (progn (cl-mcp/src/pool::%warn-if-init-without-pool) t)
+              (warning () nil))
+            "no warning when INIT unset")))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `%warn-if-init-without-pool` unbound.
+
+- [ ] **Step 3: Implement the guard and call it from `initialize-pool`**
+
+Add near `%parse-worker-init-config` in `pool.lisp`:
+
+```lisp
+(defun %warn-if-init-without-pool ()
+  "Warn (and log) when MCP_WORKER_INIT_SYSTEM is set while the worker pool
+is disabled -- the init hook is inert in that configuration, so a silent
+no-op would look like a broken web server."
+  (when (and (%env-string "MCP_WORKER_INIT_SYSTEM")
+             (%env-string "MCP_NO_WORKER_POOL"))
+    (log-event :warn "pool.init-hook.inert"
+               "reason" "MCP_WORKER_INIT_* set but MCP_NO_WORKER_POOL=1")
+    (warn "MCP_WORKER_INIT_* is set but MCP_NO_WORKER_POOL=1: the worker ~
+init hook is inert. Unset MCP_NO_WORKER_POOL to enable it.")))
+```
+
+In `initialize-pool`, call it right after the config is parsed (after the `(setf *worker-init-config* ...)` line added in Task 6, but outside the lock — place it just before `(%schedule-replenish)` near line 739):
+
+```lisp
+    (%warn-if-init-without-pool)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): warn when init hook is configured but pool is disabled"
+```
+
+---
+
+## Phase 4 — Parent ownership + orchestration (correctness pillars #2, #3)
+
+### Task 9: Ownership specials + `%elect-runtime-owner`
+
+**Files:**
+- Modify: `src/pool.lisp` (global-state section ~142-190; new election function)
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp` (add `#:make-worker` from `cl-mcp/src/worker-client` to the test `defpackage`):
+
+```lisp
+(deftest elect-runtime-owner-rules
+  (testing "grant when owner nil; re-grant same session; refuse live other session"
+    (let ((*standby-noop* nil))
+      (declare (ignore *standby-noop*)))
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        ;; A fake worker with NIL process-info is treated as NOT alive by
+        ;; %worker-process-alive-p, so it models a dead owner.
+        (let ((w-a (cl-mcp/src/worker-client:make-worker
+                    :id 1 :state :bound :session-id "sess-a"))
+              (w-b (cl-mcp/src/worker-client:make-worker
+                    :id 2 :state :bound :session-id "sess-b")))
+          ;; owner nil -> grant to A
+          (ok (cl-mcp/src/pool::%elect-runtime-owner w-a "sess-a")
+              "grants when owner is nil")
+          ;; same session -> re-grant to A's replacement (also A's session)
+          (ok (cl-mcp/src/pool::%elect-runtime-owner w-a "sess-a")
+              "re-grants to the same session")
+          ;; different session, current owner process is DEAD (nil proc)
+          ;; -> reclaim granted to B
+          (ok (cl-mcp/src/pool::%elect-runtime-owner w-b "sess-b")
+              "reclaims when the current owner process is dead"))))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `%with-owner-reset` / `%elect-runtime-owner` unbound.
+
+- [ ] **Step 3: Add ownership specials and the election function**
+
+After the crash-breaker defparameters (after `*max-concurrent-recoveries*`, line 190), add:
+
+```lisp
+(defvar *runtime-owner* nil
+  "The current runtime owner as (SESSION-ID . WORKER), or NIL.  The owner
+is the single worker permitted to run a singleton init (bind the fixed
+app port).  Guarded by *pool-lock*.")
+
+(defvar *runtime-init-failures* 0
+  "Count of soft init failures for the current runtime.  Guarded by *pool-lock*.")
+
+(defvar *runtime-init-disabled* nil
+  "When T, init is not (re-)attempted until re-armed (pool-kill-worker /
+config reload).  Guarded by *pool-lock*.")
+
+(defvar *init-attributable-crashes* (make-hash-table :test 'eql)
+  "Set of worker IDs whose crash happened during a cl-mcp-triggered init.
+Such crashes are excluded from the crash circuit breaker.  Guarded by
+*pool-lock*.")
+
+(defun %with-owner-reset (thunk)
+  "Test helper: reset ownership/failure state under *pool-lock*, run THUNK."
+  (bt:with-lock-held (*pool-lock*)
+    (setf *runtime-owner* nil
+          *runtime-init-failures* 0
+          *runtime-init-disabled* nil)
+    (clrhash *init-attributable-crashes*))
+  (funcall thunk))
+
+(defun %elect-runtime-owner (worker session-id)
+  "Under *pool-lock* (caller must hold it OR call via a wrapper that does):
+grant runtime ownership to WORKER for SESSION-ID and return T, else NIL.
+Grant iff the current owner is NIL, is the SAME session, or its worker
+process is provably dead.  Never migrate to a different session while the
+current owner's process is alive -- this keeps the app and the developer's
+repl-eval/load-system in the same process and keeps exactly one port holder."
+  (let ((current *runtime-owner*))
+    (when (or (null current)
+              (string= (car current) session-id)
+              (not (%worker-process-alive-p (cdr current))))
+      (setf *runtime-owner* (cons session-id worker))
+      (log-event :info "pool.runtime-owner.elected"
+                 "session" session-id "worker_id" (worker-id worker))
+      (return-from %elect-runtime-owner t))
+    (log-event :info "pool.init.skipped-not-owner"
+               "session" session-id
+               "owner_session" (car current))
+    nil))
+```
+
+Note: `%elect-runtime-owner` reads/writes `*runtime-owner*` and must be called with `*pool-lock*` held. `%with-owner-reset` takes the lock only for the reset; the election calls inside the test run without the lock — acceptable in a single-threaded test, but add a `bt:with-lock-held` around each election call in the test if you prefer strictness. For production, `%ensure-runtime-init` (Task 11) holds the lock around the election.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS — `elect-runtime-owner-rules` green.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): add runtime-owner election"
+```
+
+---
+
+### Task 10: `%release-runtime-owner-if`
+
+**Files:**
+- Modify: `src/pool.lisp`
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp`:
+
+```lisp
+(deftest release-runtime-owner
+  (testing "release clears ownership only for the owning worker"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w1 (cl-mcp/src/worker-client:make-worker
+                   :id 1 :state :bound :session-id "s1"))
+              (w2 (cl-mcp/src/worker-client:make-worker
+                   :id 2 :state :bound :session-id "s2")))
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (cl-mcp/src/pool::%elect-runtime-owner w1 "s1"))
+          ;; releasing a non-owner does nothing
+          (cl-mcp/src/pool::%release-runtime-owner-if w2)
+          (ok cl-mcp/src/pool::*runtime-owner* "non-owner release is a no-op")
+          ;; releasing the owner clears it
+          (cl-mcp/src/pool::%release-runtime-owner-if w1)
+          (ok (null cl-mcp/src/pool::*runtime-owner*)
+              "owner release clears *runtime-owner*"))))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `%release-runtime-owner-if` unbound.
+
+- [ ] **Step 3: Implement `%release-runtime-owner-if`**
+
+Add to `pool.lisp` after `%elect-runtime-owner`:
+
+```lisp
+(defun %release-runtime-owner-if (worker)
+  "Clear *runtime-owner* if WORKER is the current owner.  Takes *pool-lock*.
+Called when an owner worker is released, killed, or removed on crash."
+  (bt:with-lock-held (*pool-lock*)
+    (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+      (log-event :info "pool.runtime-owner.released"
+                 "worker_id" (worker-id worker))
+      (setf *runtime-owner* nil))))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): add runtime-owner release"
+```
+
+---
+
+### Task 11: `%ensure-runtime-init` + init-start + monitor
+
+**Files:**
+- Modify: `src/pool.lisp`
+- Test: `tests/pool-init-config-test.lisp` (integration, socket-guarded)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/pool-init-config-test.lisp` (add `#:spawn-worker #:kill-worker` from `cl-mcp/src/worker-client`, and a socket check helper):
+
+```lisp
+(defun %socket-available-p ()
+  (handler-case
+      (let ((s (usocket:socket-listen "127.0.0.1" 0 :reuse-address t
+                                                     :element-type 'character)))
+        (unwind-protect t (ignore-errors (usocket:socket-close s))))
+    (error () nil)))
+
+(defparameter *ensure-entry-ran* nil)
+(defun ensure-entry-thunk () (setf *ensure-entry-ran* t) 4599)
+
+(deftest ensure-runtime-init-drives-a-real-worker
+  (testing "%ensure-runtime-init elects, sends init-start, entry runs"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (cl-mcp/src/worker-client:spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry
+                                 "CL-MCP/TESTS/POOL-INIT-CONFIG-TEST:ENSURE-ENTRY-THUNK"
+                                 :eval nil :package "CL-USER"
+                                 :max-failures 1 :mode "singleton")))
+                     (setf *ensure-entry-ran* nil)
+                     (setf (cl-mcp/src/worker-client:worker-session-id worker) "sx")
+                     (setf (cl-mcp/src/worker-client:worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "sx")
+                     ;; monitor runs async; poll for entry side effect
+                     (loop repeat 60 until *ensure-entry-ran* do (sleep 0.05))
+                     (ok *ensure-entry-ran* "entry thunk ran in the worker"))
+                (ignore-errors (cl-mcp/src/worker-client:kill-worker worker)))))))))
+```
+
+Note: `spawn-worker` authenticates the worker; the entry thunk must exist in the *worker* image. Because the worker loads `cl-mcp/src/worker/main` (not the test system), `ENSURE-ENTRY-THUNK` will NOT be defined in the worker. So this test must instead use an `:eval` that has a visible side effect the parent can observe via `worker/init-status`. Rework the test to assert on init state rather than a parent-side global:
+
+```lisp
+(deftest ensure-runtime-init-drives-a-real-worker
+  (testing "%ensure-runtime-init elects and drives init to a terminal state"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (cl-mcp/src/worker-client:spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry nil
+                                 :eval "(+ 1 2)" :package "CL-USER"
+                                 :max-failures 1 :mode "singleton")))
+                     (setf (cl-mcp/src/worker-client:worker-session-id worker) "sx"
+                           (cl-mcp/src/worker-client:worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "sx")
+                     ;; Poll worker/init-status via a direct RPC until terminal.
+                     (let ((state nil))
+                       (loop repeat 60
+                             for r = (ignore-errors
+                                       (cl-mcp/src/worker-client:worker-rpc
+                                        worker "worker/init-status" nil :timeout 5))
+                             when r do (setf state (gethash "init_state" r))
+                             until (member state '("running" "failed") :test #'equal)
+                             do (sleep 0.05))
+                       (ok (equal state "running")
+                           "init reached running for a trivial eval")))
+                (ignore-errors (cl-mcp/src/worker-client:kill-worker worker)))))))))
+```
+
+Add `#:worker-rpc #:worker-session-id #:worker-state` to the test `defpackage` imports from `cl-mcp/src/worker-client`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `%ensure-runtime-init` unbound.
+
+- [ ] **Step 3: Implement orchestration in `pool.lisp`**
+
+Add after `%release-runtime-owner-if`:
+
+```lisp
+(defun %init-params (config)
+  "Build the worker/init-start params hash-table from CONFIG plist."
+  (let ((ht (make-hash-table :test 'equal)))
+    (setf (gethash "system" ht) (getf config :system)
+          (gethash "entry" ht) (getf config :entry)
+          (gethash "eval" ht) (getf config :eval)
+          (gethash "package" ht) (getf config :package))
+    ht))
+
+(defun %monitor-init (worker session-id max-failures)
+  "Poll worker/init-status until terminal, updating failure/disable state.
+Runs on a short-lived background thread.  A worker-crash during init is an
+init-attributable hard failure: mark the worker so the breaker excludes it,
+disable further init, and release ownership."
+  (handler-case
+      (loop
+        (sleep 0.1)
+        (let ((st (worker-rpc worker "worker/init-status" nil :timeout 5)))
+          (let ((state (and (hash-table-p st) (gethash "init_state" st))))
+            (cond
+              ((equal state "running")
+               (log-event :info "pool.init.running"
+                          "session" session-id
+                          "app_port" (gethash "app_port" st))
+               (return))
+              ((equal state "failed")
+               (let ((err (gethash "last_init_error" st)))
+                 (log-event :warn "pool.init.failed"
+                            "session" session-id "error" err)
+                 (bt:with-lock-held (*pool-lock*)
+                   ;; A transient EADDRINUSE gets one free retry without
+                   ;; consuming the failure latch.
+                   (if (and err (search "address" (string-downcase err)))
+                       (log-event :info "pool.init.eaddrinuse-retry"
+                                  "session" session-id)
+                       (incf *runtime-init-failures*))
+                   (when (>= *runtime-init-failures* max-failures)
+                     (setf *runtime-init-disabled* t)
+                     (log-event :warn "pool.init.disabled"
+                                "failures" *runtime-init-failures*)))
+                 (%release-runtime-owner-if worker))
+               (return))
+              (t nil)))))
+    (cl-mcp/src/worker-client:worker-crashed ()
+      ;; Init-attributable hard crash: exclude from the breaker, disable init.
+      (bt:with-lock-held (*pool-lock*)
+        (setf (gethash (worker-id worker) *init-attributable-crashes*) t
+              *runtime-init-disabled* t))
+      (log-event :warn "pool.init.hard-crash"
+                 "session" session-id "worker_id" (worker-id worker))
+      (%release-runtime-owner-if worker))))
+
+(defun %ensure-runtime-init (worker session-id)
+  "Elect WORKER as runtime owner for SESSION-ID and, if elected, send a
+fire-and-forget worker/init-start RPC (fast ack) and spawn a monitor
+thread.  No-op when the feature is off or init is disabled.  Must be
+called at the :bound transition, after the handshake."
+  (let ((config nil) (granted nil))
+    (bt:with-lock-held (*pool-lock*)
+      (setf config *worker-init-config*)
+      (when (and config (not *runtime-init-disabled*))
+        (setf granted (%elect-runtime-owner worker session-id))))
+    (when granted
+      (handler-case
+          (progn
+            (worker-rpc worker "worker/init-start" (%init-params config)
+                        :timeout 5)
+            (let ((max-failures (getf config :max-failures 1)))
+              (bt:make-thread
+               (lambda () (%monitor-init worker session-id max-failures))
+               :name (format nil "pool-init-monitor-~A" (worker-id worker)))))
+        (error (e)
+          (log-event :warn "pool.init.start-failed"
+                     "session" session-id "error" (princ-to-string e))
+          (%release-runtime-owner-if worker))))))
+```
+
+Import `worker-crashed` into `pool.lisp`: add `#:worker-crashed` to the `(:import-from #:cl-mcp/src/worker-client ...)` clause of `defpackage #:cl-mcp/src/pool` (lines 27-41).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: PASS — `ensure-runtime-init-drives-a-real-worker` reaches `running` (or skips if no socket).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): orchestrate worker init via elect + init-start + monitor"
+```
+
+---
+
+### Task 12: Wire call sites (bind, crash recovery, release, kill, pool-kill reset)
+
+**Files:**
+- Modify: `src/pool.lisp` — `get-or-assign-worker` (~932-967), `%handle-worker-crash` (~536-563), `release-session` (~984-1008), `kill-session-worker` (~1021-1047)
+- Test: covered by the integration test in Task 11 plus the existing `pool-test`/`pool-kill-worker-test` suites (run them to confirm no regression)
+
+- [ ] **Step 1: Call `%ensure-runtime-init` after a fresh bind in `get-or-assign-worker`**
+
+In `get-or-assign-worker`, after the `send-root` corruption check block (ends ~line 966, right before the final `worker)` return), insert:
+
+```lisp
+      ;; Fire the init hook only when THIS call newly bound a worker.
+      (when (and (or assigned-from-standby need-spawn) *worker-init-config*)
+        (ignore-errors (%ensure-runtime-init worker session-id)))
+```
+
+- [ ] **Step 2: Call it on crash recovery (only if not disabled)**
+
+In `%handle-worker-crash`, in the `was-bound` recovery branch, after the worker is registered and logged as recovered (`pool.worker.recovered`, ~line 548), insert (still inside the `(t ...)` registered branch of the `cond`):
+
+```lisp
+                      (bt:with-lock-held (*pool-lock*)
+                        (unless *runtime-init-disabled*
+                          (setf %recover-init-worker new-worker)))
+```
+
+Then, after the `handler-case` completes for the recovery (outside the lock, before the `%handle-worker-crash` function returns), add a call. To keep this simple and avoid threading a local through the `unwind-protect`, instead insert the init call directly where `registered` is true, replacing the two-line insert above with a single guarded call after the recovery log:
+
+```lisp
+                      (when (and (not *runtime-init-disabled*)
+                                 *worker-init-config*)
+                        (ignore-errors
+                         (%ensure-runtime-init new-worker session-id)))
+```
+
+(Place it immediately after the `(log-event :info "pool.worker.recovered" ...)` call, inside the `(t ...)` branch.)
+
+- [ ] **Step 3: Release ownership in `release-session` and `kill-session-worker`**
+
+In `release-session`, inside the `((and entry (typep entry 'worker)) ...)` branch (after `(setf *all-workers* (remove worker-to-kill *all-workers*))`, ~line 993), add:
+
+```lisp
+           (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
+             (setf *runtime-owner* nil))
+```
+
+Apply the identical addition in `kill-session-worker`'s worker branch (after its `(setf *all-workers* ...)`, ~line 1032). Both run under `*pool-lock*`, so set the special directly rather than calling `%release-runtime-owner-if` (which would re-take the lock).
+
+- [ ] **Step 4: Eager re-init after pool-kill-worker reset**
+
+`kill-session-worker` is the reset path. After it kills the owner and clears ownership, the app port is unbound until the session's next tool call re-binds and re-elects. For v1 this lazy re-bind is acceptable (design §8, L2 residual). **Do not** add eager re-spawn here in v1 — document the residual in the commit message and rely on the next tool call. (If eager reset is desired later, it is a separate task: spawn+bind a replacement and call `%ensure-runtime-init` synchronously.)
+
+- [ ] **Step 5: Run the pool suites to confirm no regression**
+
+Run: `{"system": "cl-mcp/tests/pool-test"}` → PASS
+Run: `{"system": "cl-mcp/tests/pool-kill-worker-test"}` → PASS
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}` → PASS
+
+- [ ] **Step 6: Verify parens, lint, commit**
+
+Run `lisp-check-parens` on `src/pool.lisp`. Then:
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp
+git commit -m "feat(pool): wire init hook into bind, crash recovery, release, and kill paths"
+```
+
+---
+
+## Phase 5 — Crash-breaker isolation (correctness pillar #4)
+
+### Task 13: Exclude init-attributable crashes from the circuit breaker
+
+**Files:**
+- Modify: `src/pool.lisp` — `%handle-worker-crash` crash-history push (~477-500) and `get-or-assign-worker` Path 1b crash-history push (~853-875)
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp`:
+
+```lisp
+(deftest init-crash-excluded-from-breaker
+  (testing "%init-attributable-crash-p reflects the marked set"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w (cl-mcp/src/worker-client:make-worker :id 77 :state :crashed)))
+          (ok (not (cl-mcp/src/pool::%init-attributable-crash-p w))
+              "unmarked worker is not init-attributable")
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (setf (gethash 77 cl-mcp/src/pool::*init-attributable-crashes*) t))
+          (ok (cl-mcp/src/pool::%init-attributable-crash-p w)
+              "marked worker is init-attributable"))))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — `%init-attributable-crash-p` unbound.
+
+- [ ] **Step 3: Add the predicate and gate both crash-history pushes**
+
+Add to `pool.lisp` near the ownership helpers:
+
+```lisp
+(defun %init-attributable-crash-p (worker)
+  "T if WORKER's crash was attributed to a cl-mcp-triggered init.  Must be
+called with *pool-lock* held (reads *init-attributable-crashes*).  Such
+crashes are excluded from the crash circuit breaker so a bad web-server
+init cannot brick a session's repl-eval/load-system."
+  (gethash (worker-id worker) *init-attributable-crashes*))
+```
+
+In `%handle-worker-crash`, in the `was-bound` branch, wrap the crash-history push (lines 480-484) so it is skipped for init-attributable crashes. The `let ((history ...))` block becomes:
+
+```lisp
+           (let ((history (gethash session-id *crash-history*)))
+             (unless (%init-attributable-crash-p crashed-worker)
+               (setf history
+                     (remove-if (lambda (ts) (< ts window-start)) history))
+               (push now history)
+               (setf (gethash session-id *crash-history*) history)
+               (setf (worker-crash-history-pushed-p crashed-worker) t)
+               (when (>= (length history) *crash-breaker-threshold*)
+                 (log-event :error "pool.circuit-breaker.tripped"
+                            "session" session-id
+                            "crashes" (length history)
+                            "window_seconds" *crash-breaker-window*)
+                 (remhash session-id *crash-history*)
+                 (when (eql (gethash session-id *affinity-map*) crashed-worker)
+                   (remhash session-id *affinity-map*))
+                 (setf *all-workers* (remove crashed-worker *all-workers*))
+                 (return-from %handle-worker-crash))))
+```
+
+In `get-or-assign-worker` Path 1b, guard the crash-history push (the `(when (and (eq :crashed (worker-state entry)) (not (worker-crash-history-pushed-p entry))) ...)` block, ~lines 853-863) by adding `(not (%init-attributable-crash-p entry))` to its `and`:
+
+```lisp
+         (when (and (eq :crashed (worker-state entry))
+                    (not (worker-crash-history-pushed-p entry))
+                    (not (%init-attributable-crash-p entry)))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}` → PASS
+Run: `{"system": "cl-mcp/tests/pool-test"}` → PASS (no regression)
+
+- [ ] **Step 5: Verify parens, lint, commit**
+
+Run `lisp-check-parens` on `src/pool.lisp`. Then:
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): exclude init-attributable crashes from the circuit breaker"
+```
+
+---
+
+## Phase 6 — Observability + docs
+
+### Task 14: Surface init state in `pool-status-info`
+
+**Files:**
+- Modify: `src/pool.lisp` — `pool-status-info` (~1144-1165)
+- Test: `tests/pool-init-config-test.lisp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pool-init-config-test.lisp`:
+
+```lisp
+(deftest pool-status-includes-init-fields
+  (testing "pool-status-info exposes runtime init fields"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((info (cl-mcp/src/pool:pool-status-info)))
+          (ok (nth-value 1 (gethash "init_owner_session" info))
+              "init_owner_session key present")
+          (ok (nth-value 1 (gethash "init_disabled" info))
+              "init_disabled key present")
+          (ok (nth-value 1 (gethash "init_failures" info))
+              "init_failures key present"))))))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}`
+Expected: FAIL — keys absent.
+
+- [ ] **Step 3: Add the fields in `pool-status-info`**
+
+In `pool-status-info`, extend the final `(setf (gethash ...) ...)` block that populates `info` (before `info` is returned, ~line 1164) with:
+
+```lisp
+      (bt:with-lock-held (*pool-lock*)
+        (setf (gethash "init_owner_session" info)
+                (and *runtime-owner* (car *runtime-owner*))
+              (gethash "init_owner_worker" info)
+                (and *runtime-owner* (worker-id (cdr *runtime-owner*)))
+              (gethash "init_disabled" info) (if *runtime-init-disabled* t nil)
+              (gethash "init_failures" info) *runtime-init-failures*))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `{"system": "cl-mcp/tests/pool-init-config-test"}` → PASS
+Run: `{"system": "cl-mcp/tests/pool-status-test"}` → PASS (no regression)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+mallet src/pool.lisp
+git add src/pool.lisp tests/pool-init-config-test.lisp
+git commit -m "feat(pool): surface init owner/state in pool-status"
+```
+
+---
+
+### Task 15: Full-system compile check + full suite
+
+**Files:** none (verification task)
+
+- [ ] **Step 1: Force-compile the whole system to catch warnings**
+
+Run via `repl-eval`: `(asdf:compile-system :cl-mcp :force t)`
+Expected: returns `T` with no new `WARNING`/`ERROR` lines beyond pre-existing ones. Investigate any new warning (per project MEMORY, a `COMPILE-FILE-ERROR` usually means unbalanced parens — run `lisp-check-parens` on the offending file).
+
+- [ ] **Step 2: Run the full test suite from a clean process**
+
+Run from the repo root: `rove cl-mcp.asd`
+Expected: all suites PASS, including `worker-init-hook-test`, `pool-init-config-test`, `worker-test`, `pool-test`, `pool-kill-worker-test`, `pool-status-test`.
+
+- [ ] **Step 3: Commit nothing (verification only)**
+
+If Steps 1–2 required fixes, they were committed under their respective tasks. If a fix was needed here, commit it with a descriptive message, e.g. `fix(pool): resolve compile warning in init orchestration`.
+
+---
+
+### Task 16: Document env vars and recurya wiring in README
+
+**Files:**
+- Modify: `README.md` — Environment Variables table (~193-200) and a new subsection
+
+- [ ] **Step 1: Add the init-hook rows to the Environment Variables table**
+
+In `README.md`, add these rows to the table under `## Environment Variables` (after the `CL_MCP_MAX_POOL_SIZE` row, line 200):
+
+```markdown
+| `MCP_WORKER_INIT_SYSTEM` | ASDF system to load in the elected owner worker at bind (master gate for the init hook) | (unset = off) |
+| `MCP_WORKER_INIT_ENTRY` | `PKG:SYMBOL` nullary thunk run after the load (preferred activation) | (none) |
+| `MCP_WORKER_INIT_EVAL` | Lisp form run via repl-eval as an escape hatch | (none) |
+| `MCP_WORKER_INIT_MAX_FAILURES` | Soft init failures before init auto-retry latches off | `1` |
+| `MCP_WORKER_INIT_MODE` | `singleton` (one owner binds a fixed port). v1 supports `singleton` only | `singleton` |
+```
+
+- [ ] **Step 2: Add a subsection documenting the hook**
+
+Add after the "Tuning warmup" subsection (after line 213), a new subsection:
+
+```markdown
+### Running an app inside a worker (init hook)
+
+Set `MCP_WORKER_INIT_SYSTEM` (and optionally `MCP_WORKER_INIT_ENTRY`) to have
+the pool run a startup routine inside the single worker elected as the
+"runtime owner" when a session binds it. This lets an app (e.g. a web server)
+run in the same process that serves `repl-eval`/`load-system`, so hot-reload
+lands in the app's process, while the parent keeps the persistent `/mcp`
+endpoint. `pool-kill-worker` restarts the runtime without dropping `/mcp`.
+
+- The init runs on a background thread under a worker-global ASDF load lock,
+  so it never races a `load-system` RPC.
+- Init failures never trip the crash circuit breaker; a failed init leaves a
+  plain, usable REPL worker. Check `pool-status` (`init_owner_session`,
+  `init_disabled`, `init_failures`) to see runtime state.
+- Requires the pool enabled (do not set `MCP_NO_WORKER_POOL=1`).
+- The init form must be bind-robust and idempotent, and should pass
+  `:address "127.0.0.1"` for a localhost-only dev server. Do not embed
+  secrets in `MCP_WORKER_INIT_EVAL`.
+
+Example (recurya): add a nullary `recurya/dev:start-dev-runtime!` thunk that
+starts the DB and web server, then set `MCP_WORKER_INIT_SYSTEM=recurya/dev`
+and `MCP_WORKER_INIT_ENTRY=recurya/dev:start-dev-runtime!`. See
+`docs/plans/2026-07-05-worker-init-hook-design.md` §7 for the full wiring.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document the worker init hook and its env vars"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design §5 v1 pillars → tasks):
+- Pillar #1 (`*asdf-load-lock*` + init loads with `timeout=nil`): Tasks 1, 2, 5 (`%run-init` uses `:timeout-seconds nil`).
+- Pillar #2 (async ack-then-poll, no long stream-lock hold): Task 5 (`handle-init-start` acks) + Task 11 (`%ensure-runtime-init` sends fast RPC + monitor thread).
+- Pillar #3 (session-bound ownership; refuse migration to a live other session): Tasks 9, 10, 12.
+- Pillar #4 (init crashes excluded from breaker + quarantine): Tasks 11 (`%monitor-init` disables on hard crash), 13 (exclusion predicate + gated pushes).
+- Trigger/config surface (§5.7): Tasks 6, 7 (denylist), 16 (docs).
+- Observability (§5.5): Task 14 (`pool-status`). MCP notification + first-owner banner are **deferred** (design §5.5 lists them as additional; v1 ships the mandatory `pool-status` fields). Note this deferral to the maintainer.
+- Pool-off guard (§5.7 F7): Task 8.
+- recurya wiring (§7): documented in Task 16; the `recurya/dev:start-dev-runtime!` thunk lives in the recurya repo (out of this plan's tree).
+
+**2. Placeholder scan:** No "TBD"/"add error handling"/"similar to Task N". Every code step shows complete forms. The one soft spot — genuine cross-RPC serialization — is explicitly routed to the integration test (Task 5/11) rather than left vague.
+
+**3. Type/name consistency across tasks:** `*asdf-load-lock*` / `with-asdf-load-lock` (Tasks 1,2,5); `%set-init-state`/`init-state-snapshot`/`%reset-init-state` (Tasks 3,5); `%resolve-entry` (Tasks 4,5); `handle-init-start`/`handle-init-status` (Tasks 5, registered with the exact method strings `worker/init-start`/`worker/init-status`); `*runtime-owner*` as `(session-id . worker)` cons used consistently in `%elect-runtime-owner`, `%release-runtime-owner-if`, `%ensure-runtime-init`, `release-session`, `kill-session-worker`, `pool-status-info` (Tasks 9–14); `*init-attributable-crashes*` keyed by `worker-id` in Tasks 11 and 13; `%init-params`/`%monitor-init`/`%ensure-runtime-init` (Task 11) referenced by call sites in Task 12.
+
+**Known deferrals to flag at go/no-go** (design §8): live hot-reload vs in-flight request threads (documented, not fixed); out-of-band loads bypass the lock (unset `MCP_WORKER_SWANK`); eager reset after `pool-kill-worker` (Task 12 Step 4 keeps v1 lazy); MCP notification + first-owner banner; `load-system` *tool* timeout still uses `destroy-thread` (separate hardening PR).

--- a/src/http.lisp
+++ b/src/http.lisp
@@ -7,7 +7,8 @@
   (:import-from #:cl-mcp/src/protocol #:make-state #:process-json-line)
   (:import-from #:cl-mcp/src/proxy #:*use-worker-pool*)
   (:import-from #:cl-mcp/src/pool
-                #:initialize-pool #:shutdown-pool #:release-session)
+                #:initialize-pool #:shutdown-pool #:release-session
+                #:%warn-if-init-without-pool)
   (:import-from #:bordeaux-threads #:make-lock #:with-lock-held)
   (:import-from #:hunchentoot)
   (:import-from #:yason)
@@ -480,6 +481,8 @@ Returns the acceptor instance and port number."
 
   (when worker-pool-supplied-p
     (setf *use-worker-pool* worker-pool))
+
+  (%warn-if-init-without-pool *use-worker-pool*)
 
   ;; Configure authentication
   (setf *http-auth-token*

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -37,6 +37,7 @@
                 #:worker-last-crash-reason
                 #:worker-last-exit-status
                 #:worker-last-exit-code
+                #:worker-crashed
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
   (:import-from #:cl-mcp/src/proxy
@@ -271,6 +272,10 @@ one holder of the fixed port."
               ;; would land the developer's hot-reload in the wrong process (L4).
               (and (not (%worker-process-alive-p (cdr current)))
                    (not (gethash (car current) *affinity-map*))))
+      ;; A new runtime (no prior owner, or a different session) starts with a
+      ;; clean soft-failure count; a same-session re-election preserves it.
+      (unless (and current (string= (car current) session-id))
+        (setf *runtime-init-failures* 0))
       (setf *runtime-owner* (cons session-id worker))
       (log-event :info "pool.runtime-owner.elected"
                  "session" session-id "worker_id" (worker-id worker))
@@ -288,6 +293,102 @@ released, killed, or removed on crash."
       (log-event :info "pool.runtime-owner.released"
                  "worker_id" (worker-id worker))
       (setf *runtime-owner* nil))))
+
+(defun %init-params (config)
+  "Build the worker/init-start params hash-table from CONFIG plist."
+  (let ((ht (make-hash-table :test 'equal)))
+    (setf (gethash "system" ht) (getf config :system)
+          (gethash "entry" ht) (getf config :entry)
+          (gethash "eval" ht) (getf config :eval)
+          (gethash "package" ht) (getf config :package))
+    ht))
+
+(defun %monitor-init (worker session-id max-failures)
+  "Poll worker/init-status until terminal, updating failure/disable state.
+Runs on a short-lived background thread with backoff (0.1s -> 2s cap; no
+hard wall-clock deadline -- a slow cold-FASL init legitimately stays
+:loading and is resolved by the operator via pool-kill-worker).  All state
+mutations are guarded on this worker still being the runtime owner, so an
+external kill / reassignment is not misattributed as an init failure.  A
+crash while we still own is init-attributable (excluded from the crash
+breaker).  Any other abnormal exit still releases ownership so the runtime
+is never stranded."
+  (handler-case
+      (let ((delay 0.1))
+        (loop
+          (sleep delay)
+          (setf delay (min (* delay 1.5) 2.0))
+          (let* ((st (worker-rpc worker "worker/init-status" nil :timeout 5))
+                 (state (and (hash-table-p st) (gethash "init_state" st))))
+            (cond
+              ((equal state "running")
+               (log-event :info "pool.init.running"
+                          "session" session-id
+                          "app_port" (gethash "app_port" st))
+               (return))
+              ((equal state "failed")
+               (log-event :warn "pool.init.failed"
+                          "session" session-id
+                          "error" (gethash "last_init_error" st))
+               (bt:with-lock-held (*pool-lock*)
+                 ;; Only account against the runtime we still own.
+                 (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+                   (incf *runtime-init-failures*)
+                   (when (>= *runtime-init-failures* max-failures)
+                     (setf *runtime-init-disabled* t)
+                     (log-event :warn "pool.init.disabled"
+                                "failures" *runtime-init-failures*))))
+               (%release-runtime-owner-if worker)
+               (return))
+              (t nil)))))
+    (worker-crashed ()
+      (bt:with-lock-held (*pool-lock*)
+        (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+          ;; init-attributable hard crash: exclude from breaker, disable init.
+          (setf (gethash (worker-id worker) *init-attributable-crashes*) t
+                *runtime-init-disabled* t)
+          (log-event :warn "pool.init.hard-crash"
+                     "session" session-id "worker_id" (worker-id worker))))
+      (%release-runtime-owner-if worker))
+    (serious-condition (e)
+      ;; version skew (worker-rpc-error "method not found"), malformed status,
+      ;; etc. -- never leave *runtime-owner* stranded.
+      (log-event :warn "pool.init.monitor-error"
+                 "session" session-id "error" (princ-to-string e))
+      (%release-runtime-owner-if worker))))
+
+(defun %ensure-runtime-init (worker session-id)
+  "Elect WORKER as runtime owner for SESSION-ID and, if elected, send a
+fire-and-forget worker/init-start RPC (fast ack) and spawn a monitor
+thread.  No-op when the feature is off or init is disabled.  Must be
+called at the :bound transition, after the handshake.  Holds *pool-lock*
+only across the election, not across the RPC."
+  (let ((config nil) (granted nil))
+    (bt:with-lock-held (*pool-lock*)
+      (setf config *worker-init-config*)
+      (when (and config (not *runtime-init-disabled*))
+        (setf granted (%elect-runtime-owner worker session-id))))
+    (when granted
+      (handler-case
+          (progn
+            (worker-rpc worker "worker/init-start" (%init-params config)
+                        :timeout 5)
+            (let ((max-failures (getf config :max-failures 1)))
+              (bt:make-thread
+               (lambda () (%monitor-init worker session-id max-failures))
+               :name (format nil "pool-init-monitor-~A" (worker-id worker)))))
+        (worker-crashed ()
+          (bt:with-lock-held (*pool-lock*)
+            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+              (setf (gethash (worker-id worker) *init-attributable-crashes*) t
+                    *runtime-init-disabled* t)))
+          (log-event :warn "pool.init.hard-crash"
+                     "session" session-id "worker_id" (worker-id worker))
+          (%release-runtime-owner-if worker))
+        (error (e)
+          (log-event :warn "pool.init.start-failed"
+                     "session" session-id "error" (princ-to-string e))
+          (%release-runtime-owner-if worker))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Placeholder struct -- coordinates concurrent spawn requests
@@ -826,6 +927,10 @@ Serialized by *init-lock* to prevent concurrent initialization."
             *all-workers* nil
             *recovery-threads* nil
             *worker-init-config* (%parse-worker-init-config))
+      (setf *runtime-owner* nil
+            *runtime-init-failures* 0
+            *runtime-init-disabled* nil)
+      (clrhash *init-attributable-crashes*)
       (clrhash *crash-history*))
     ;; Start health monitor.  Sets *pool-running* to T, which gates
     ;; the replenish thread below: %replenish-standbys exits early

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -279,6 +279,16 @@ one holder of the fixed port."
                "session" session-id "owner_session" (car current))
     nil))
 
+(defun %release-runtime-owner-if (worker)
+  "Clear *runtime-owner* if WORKER is the current owner.  Takes *pool-lock*.
+Called (from paths NOT already holding the lock) when an owner worker is
+released, killed, or removed on crash."
+  (bt:with-lock-held (*pool-lock*)
+    (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+      (log-event :info "pool.runtime-owner.released"
+                 "worker_id" (worker-id worker))
+      (setf *runtime-owner* nil))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Placeholder struct -- coordinates concurrent spawn requests
 ;;; ---------------------------------------------------------------------------

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -1254,19 +1254,20 @@ worker was bound, :PLACEHOLDER if a spawn was in progress (cancelled)."
            (remhash session-id *crash-history*)
            (setf *all-workers* (remove worker-to-kill *all-workers*))
            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
-             (setf *runtime-owner* nil))
-           ;; pool-kill-worker is the documented re-arm for a quarantined
-           ;; runtime.  disabled=t implies owner=nil, so clearing the latch
-           ;; unconditionally (when the feature is on) cannot disturb a live
-           ;; healthy owner, and it lets the next bind re-attempt init.
-           (when *worker-init-config*
-             (setf *runtime-init-disabled* nil
-                   *runtime-init-failures* 0)))
+             (setf *runtime-owner* nil)))
           ((and entry (typep entry 'worker-placeholder))
            (setf (worker-placeholder-cancelled entry) t
                  kill-result :placeholder)
            (remhash session-id *affinity-map*)
-           (remhash session-id *crash-history*)))))
+           (remhash session-id *crash-history*)))
+        ;; pool-kill-worker is the documented re-arm for a quarantined runtime.
+        ;; It must fire even when the crashed owner worker was already reaped
+        ;; from the affinity map (so kill found :no-worker).  disabled=t implies
+        ;; owner=nil, so clearing the latch unconditionally (feature on) cannot
+        ;; disturb a live healthy owner.
+        (when *worker-init-config*
+          (setf *runtime-init-disabled* nil
+                *runtime-init-failures* 0))))
     (when worker-to-kill
       (log-event :info "pool.session.worker-killed"
                  "session" session-id

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -226,6 +226,59 @@ halting recovery for a session.")
   "Maximum number of concurrent crash recovery threads.
 Prevents resource exhaustion when many workers crash simultaneously.")
 
+(defvar *runtime-owner* nil
+  "The current runtime owner as (SESSION-ID . WORKER), or NIL.  The owner
+is the single worker permitted to run a singleton init (bind the fixed
+app port).  Guarded by *pool-lock*.")
+
+(defvar *runtime-init-failures* 0
+  "Count of soft init failures for the current runtime.  Guarded by *pool-lock*.")
+
+(defvar *runtime-init-disabled* nil
+  "When T, init is not (re-)attempted until re-armed (pool-kill-worker /
+config reload).  Guarded by *pool-lock*.")
+
+(defvar *init-attributable-crashes* (make-hash-table :test 'eql)
+  "Set of worker IDs whose crash happened during a cl-mcp-triggered init.
+Such crashes are excluded from the crash circuit breaker.  Guarded by
+*pool-lock*.")
+
+(defun %with-owner-reset (thunk)
+  "Test helper: reset ownership/failure state under *pool-lock*, then run THUNK."
+  (bt:with-lock-held (*pool-lock*)
+    (setf *runtime-owner* nil
+          *runtime-init-failures* 0
+          *runtime-init-disabled* nil)
+    (clrhash *init-attributable-crashes*))
+  (funcall thunk))
+
+(defun %elect-runtime-owner (worker session-id)
+  "Grant runtime ownership to WORKER for SESSION-ID and return T, else NIL.
+MUST be called with *pool-lock* held (reads/writes *runtime-owner*).
+Grant iff the current owner is NIL, is the SAME session, or the current
+owner's worker is dead AND its session is gone from *affinity-map*.
+NEVER migrate to a different session while the OWNER SESSION is still
+alive (present in *affinity-map*), even if that session's current worker
+has crashed and is being recovered -- this keeps the app and the
+developer's repl-eval/load-system in the same process and keeps exactly
+one holder of the fixed port."
+  (let ((current *runtime-owner*))
+    (when (or (null current)
+              (string= (car current) session-id)
+              ;; Reclaim to a DIFFERENT session only when the previous owner's
+              ;; worker is dead AND its session is gone from the affinity map.
+              ;; Never migrate the runtime to another still-live session -- that
+              ;; would land the developer's hot-reload in the wrong process (L4).
+              (and (not (%worker-process-alive-p (cdr current)))
+                   (not (gethash (car current) *affinity-map*))))
+      (setf *runtime-owner* (cons session-id worker))
+      (log-event :info "pool.runtime-owner.elected"
+                 "session" session-id "worker_id" (worker-id worker))
+      (return-from %elect-runtime-owner t))
+    (log-event :info "pool.init.skipped-not-owner"
+               "session" session-id "owner_session" (car current))
+    nil))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Placeholder struct -- coordinates concurrent spawn requests
 ;;; ---------------------------------------------------------------------------

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -315,11 +315,16 @@ init cannot brick a session's repl-eval/load-system."
 Runs on a short-lived background thread with backoff (0.1s -> 2s cap; no
 hard wall-clock deadline -- a slow cold-FASL init legitimately stays
 :loading and is resolved by the operator via pool-kill-worker).  All state
-mutations are guarded on this worker still being the runtime owner, so an
-external kill / reassignment is not misattributed as an init failure.  A
-crash while we still own is init-attributable (excluded from the crash
-breaker).  Any other abnormal exit still releases ownership so the runtime
-is never stranded."
+mutations are guarded on this worker still being the runtime owner.
+
+On terminal :running or (soft) :failed the worker is still alive, so the
+eager init-attributable mark is cleared -- a later crash of it is a
+workload crash that SHOULD feed the breaker.  On a soft :failed BELOW
+max-failures, ownership is RETAINED (so no other live session can migrate
+the singleton runtime in); it is released only once quarantined
+(disabled=t), preserving the disabled=t => owner=nil invariant.  A crash
+DURING init is init-attributable (excluded from the breaker) and disables
+further init."
   (handler-case
       (let ((delay 0.1))
         (loop
@@ -332,34 +337,40 @@ is never stranded."
                (log-event :info "pool.init.running"
                           "session" session-id
                           "app_port" (gethash "app_port" st))
+               (bt:with-lock-held (*pool-lock*)
+                 (remhash (worker-id worker) *init-attributable-crashes*))
                (return))
               ((equal state "failed")
                (log-event :warn "pool.init.failed"
                           "session" session-id
                           "error" (gethash "last_init_error" st))
-               (bt:with-lock-held (*pool-lock*)
-                 ;; Only account against the runtime we still own.
-                 (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
-                   (incf *runtime-init-failures*)
-                   (when (>= *runtime-init-failures* max-failures)
-                     (setf *runtime-init-disabled* t)
-                     (log-event :warn "pool.init.disabled"
-                                "failures" *runtime-init-failures*))))
-               (%release-runtime-owner-if worker)
+               (let ((release nil))
+                 (bt:with-lock-held (*pool-lock*)
+                   ;; init terminally soft-failed but the worker is alive -> a
+                   ;; later crash is a workload crash: clear the eager mark.
+                   (remhash (worker-id worker) *init-attributable-crashes*)
+                   (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+                     (incf *runtime-init-failures*)
+                     (when (>= *runtime-init-failures* max-failures)
+                       (setf *runtime-init-disabled* t
+                             release t)
+                       (log-event :warn "pool.init.disabled"
+                                  "failures" *runtime-init-failures*))))
+                 ;; Release ownership ONLY once quarantined; below max we keep
+                 ;; ownership so a different live session cannot take over.
+                 (when release
+                   (%release-runtime-owner-if worker)))
                (return))
               (t nil)))))
     (worker-crashed ()
       (bt:with-lock-held (*pool-lock*)
         (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
-          ;; init-attributable hard crash: exclude from breaker, disable init.
           (setf (gethash (worker-id worker) *init-attributable-crashes*) t
                 *runtime-init-disabled* t)
           (log-event :warn "pool.init.hard-crash"
                      "session" session-id "worker_id" (worker-id worker))))
       (%release-runtime-owner-if worker))
     (serious-condition (e)
-      ;; version skew (worker-rpc-error "method not found"), malformed status,
-      ;; etc. -- never leave *runtime-owner* stranded.
       (log-event :warn "pool.init.monitor-error"
                  "session" session-id "error" (princ-to-string e))
       (%release-runtime-owner-if worker))))
@@ -369,12 +380,19 @@ is never stranded."
 fire-and-forget worker/init-start RPC (fast ack) and spawn a monitor
 thread.  No-op when the feature is off or init is disabled.  Must be
 called at the :bound transition, after the handshake.  Holds *pool-lock*
-only across the election, not across the RPC."
+only across the election, not across the RPC.
+
+On election, the worker is marked init-attributable EAGERLY (under the
+same lock the crash path checks) so that a crash during init is excluded
+from the circuit breaker even if the health monitor detects the dead
+worker before the init monitor does."
   (let ((config nil) (granted nil))
     (bt:with-lock-held (*pool-lock*)
       (setf config *worker-init-config*)
       (when (and config (not *runtime-init-disabled*))
-        (setf granted (%elect-runtime-owner worker session-id))))
+        (setf granted (%elect-runtime-owner worker session-id))
+        (when granted
+          (setf (gethash (worker-id worker) *init-attributable-crashes*) t))))
     (when granted
       (handler-case
           (progn
@@ -393,6 +411,10 @@ only across the election, not across the RPC."
                      "session" session-id "worker_id" (worker-id worker))
           (%release-runtime-owner-if worker))
         (error (e)
+          ;; A non-crash init-start failure means init never ran; drop the
+          ;; eager mark so a later crash of this (still-live) worker counts.
+          (bt:with-lock-held (*pool-lock*)
+            (remhash (worker-id worker) *init-attributable-crashes*))
           (log-event :warn "pool.init.start-failed"
                      "session" session-id "error" (princ-to-string e))
           (%release-runtime-owner-if worker))))))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -294,6 +294,13 @@ released, killed, or removed on crash."
                  "worker_id" (worker-id worker))
       (setf *runtime-owner* nil))))
 
+(defun %init-attributable-crash-p (worker)
+  "T if WORKER's crash was attributed to a cl-mcp-triggered init.  Must be
+called with *pool-lock* held (reads *init-attributable-crashes*).  Such
+crashes are excluded from the crash circuit breaker so a bad web-server
+init cannot brick a session's repl-eval/load-system."
+  (gethash (worker-id worker) *init-attributable-crashes*))
+
 (defun %init-params (config)
   "Build the worker/init-start params hash-table from CONFIG plist."
   (let ((ht (make-hash-table :test 'equal)))
@@ -679,26 +686,27 @@ to prevent recovery threads from spawning orphan workers."
               (window-start (- now *crash-breaker-window*)))
          (bordeaux-threads:with-lock-held (*pool-lock*)
            (let ((history (gethash session-id *crash-history*)))
-             (setf history
-                   (remove-if (lambda (ts) (< ts window-start)) history))
-             (push now history)
-             (setf (gethash session-id *crash-history*) history)
-             ;; Mark that crash-history was pushed for this worker to
-             ;; prevent double-counting when get-or-assign-worker also
-             ;; encounters this crashed worker in Path 1b.
-             (setf (worker-crash-history-pushed-p crashed-worker) t)
-             (when (>= (length history) *crash-breaker-threshold*)
-               (log-event :error "pool.circuit-breaker.tripped"
-                          "session" session-id
-                          "crashes" (length history)
-                          "window_seconds" *crash-breaker-window*)
-               ;; Clear crash history to prevent stale data if session
-               ;; ID is reused or session reconnects later.
-               (remhash session-id *crash-history*)
-               (when (eql (gethash session-id *affinity-map*) crashed-worker)
-                 (remhash session-id *affinity-map*))
-               (setf *all-workers* (remove crashed-worker *all-workers*))
-               (return-from %handle-worker-crash)))))
+             (unless (%init-attributable-crash-p crashed-worker)
+               (setf history
+                     (remove-if (lambda (ts) (< ts window-start)) history))
+               (push now history)
+               (setf (gethash session-id *crash-history*) history)
+               ;; Mark that crash-history was pushed for this worker to
+               ;; prevent double-counting when get-or-assign-worker also
+               ;; encounters this crashed worker in Path 1b.
+               (setf (worker-crash-history-pushed-p crashed-worker) t)
+               (when (>= (length history) *crash-breaker-threshold*)
+                 (log-event :error "pool.circuit-breaker.tripped"
+                            "session" session-id
+                            "crashes" (length history)
+                            "window_seconds" *crash-breaker-window*)
+                 ;; Clear crash history to prevent stale data if session
+                 ;; ID is reused or session reconnects later.
+                 (remhash session-id *crash-history*)
+                 (when (eql (gethash session-id *affinity-map*) crashed-worker)
+                   (remhash session-id *affinity-map*))
+                 (setf *all-workers* (remove crashed-worker *all-workers*))
+                 (return-from %handle-worker-crash))))))
        (handler-case
            (let ((new-worker nil) (registered nil))
              (unwind-protect
@@ -1060,7 +1068,8 @@ cannot be created."
          ;; worker (prevents double-counting in the race window where
          ;; the health monitor detects the crash first).
          (when (and (eq :crashed (worker-state entry))
-                    (not (worker-crash-history-pushed-p entry)))
+                    (not (worker-crash-history-pushed-p entry))
+                    (not (%init-attributable-crash-p entry)))
            (let* ((now (get-universal-time))
                   (window-start (- now *crash-breaker-window*))
                   (history (gethash session-id *crash-history*)))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -49,6 +49,7 @@
   (:import-from #:cl-mcp/src/log #:log-event)
   (:export #:*worker-pool-warmup*
            #:*max-pool-size*
+           #:*worker-init-config*
            #:*health-check-interval-seconds*
            #:*shutdown-replenish-wait-seconds*
            #:initialize-pool
@@ -116,6 +117,12 @@ reads the environment once at load time."
                  name s default)
            default))))))
 
+(defun %env-string (name)
+  "Return the environment variable NAME as a string, or NIL when unset or
+empty."
+  (let ((s (uiop:getenv name)))
+    (and s (plusp (length s)) s)))
+
 (defvar *worker-pool-warmup*
   (%env-int "CL_MCP_WORKER_POOL_WARMUP" 1 :min 0)
   "Number of standby workers to pre-spawn and maintain.
@@ -138,6 +145,23 @@ be a positive integer).  Must be >= *worker-pool-warmup*.")
 
 (defvar *shutdown-replenish-wait-seconds* 0.05d0
   "Polling interval (seconds) while waiting for replenish thread shutdown.")
+
+(defvar *worker-init-config* nil
+  "Parsed worker-init-hook config, or NIL when the feature is off.
+A plist: (:system S :entry E :eval EV :package P :max-failures N :mode M).")
+
+(defun %parse-worker-init-config ()
+  "Read MCP_WORKER_INIT_* from the environment into a config plist, or NIL
+when MCP_WORKER_INIT_SYSTEM is unset (feature off).  MCP_WORKER_INIT_SYSTEM
+is the master gate, mirroring MCP_WORKER_SWANK."
+  (let ((system (%env-string "MCP_WORKER_INIT_SYSTEM")))
+    (when system
+      (list :system system
+            :entry (%env-string "MCP_WORKER_INIT_ENTRY")
+            :eval (%env-string "MCP_WORKER_INIT_EVAL")
+            :package (or (%env-string "MCP_WORKER_INIT_PACKAGE") "CL-USER")
+            :max-failures (%env-int "MCP_WORKER_INIT_MAX_FAILURES" 1 :min 1)
+            :mode (or (%env-string "MCP_WORKER_INIT_MODE") "singleton")))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Global pool state
@@ -724,7 +748,8 @@ Serialized by *init-lock* to prevent concurrent initialization."
       (setf *affinity-map* (make-hash-table :test 'equal)
             *standby-workers* nil
             *all-workers* nil
-            *recovery-threads* nil)
+            *recovery-threads* nil
+            *worker-init-config* (%parse-worker-init-config))
       (clrhash *crash-history*))
     ;; Start health monitor.  Sets *pool-running* to T, which gates
     ;; the replenish thread below: %replenish-standbys exits early

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -50,6 +50,7 @@
   (:export #:*worker-pool-warmup*
            #:*max-pool-size*
            #:*worker-init-config*
+           #:%warn-if-init-without-pool
            #:*health-check-interval-seconds*
            #:*shutdown-replenish-wait-seconds*
            #:initialize-pool
@@ -162,6 +163,18 @@ is the master gate, mirroring MCP_WORKER_SWANK."
             :package (or (%env-string "MCP_WORKER_INIT_PACKAGE") "CL-USER")
             :max-failures (%env-int "MCP_WORKER_INIT_MAX_FAILURES" 1 :min 1)
             :mode (or (%env-string "MCP_WORKER_INIT_MODE") "singleton")))))
+
+(defun %warn-if-init-without-pool (pool-enabled-p)
+  "Warn (and log) when MCP_WORKER_INIT_SYSTEM is set while the worker pool
+is disabled (POOL-ENABLED-P is NIL) -- the init hook is inert in that
+configuration, so a silent no-op would look like a broken web server.
+Called from the transport entry points after the pool-enabled decision."
+  (when (and (%env-string "MCP_WORKER_INIT_SYSTEM") (not pool-enabled-p))
+    (log-event :warn "pool.init-hook.inert"
+               "reason" "MCP_WORKER_INIT_* set but worker pool disabled")
+    (warn "MCP_WORKER_INIT_* is set but the worker pool is disabled ~
+(MCP_NO_WORKER_POOL=1 or :worker-pool nil): the worker init hook is inert. ~
+Enable the pool to use it.")))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Global pool state

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -1394,4 +1394,11 @@ max_pool_size, warmup_target, workers (vector of per-worker hashes)."
             (gethash "max_pool_size" info) *max-pool-size*
             (gethash "warmup_target" info) *worker-pool-warmup*
             (gethash "workers" info) workers)
+      (with-lock-held (*pool-lock*)
+        (setf (gethash "init_owner_session" info)
+                (and *runtime-owner* (car *runtime-owner*))
+              (gethash "init_owner_worker" info)
+                (and *runtime-owner* (worker-id (cdr *runtime-owner*)))
+              (gethash "init_disabled" info) (if *runtime-init-disabled* t nil)
+              (gethash "init_failures" info) *runtime-init-failures*))
       info)))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -746,7 +746,10 @@ to prevent recovery threads from spawning orphan workers."
                       (log-event :info "pool.worker.recovered"
                                  "old_worker_id" (worker-id crashed-worker)
                                  "new_worker_id" (worker-id new-worker)
-                                 "session" session-id))))
+                                 "session" session-id)
+                      (when *worker-init-config*
+                        (ignore-errors
+                         (%ensure-runtime-init new-worker session-id))))))
                (when (and new-worker (not registered))
                  (ignore-errors (kill-worker new-worker)))))
          (error (e)
@@ -1170,6 +1173,9 @@ cannot be created."
           (%schedule-replenish)
           (error "Worker ~A crashed during project root setup for session ~A"
                  (worker-id worker) session-id)))
+      ;; Fire the init hook only when THIS call newly bound a worker.
+      (when (and (or assigned-from-standby need-spawn) *worker-init-config*)
+        (ignore-errors (%ensure-runtime-init worker session-id)))
       worker)))
 
 ;;; ---------------------------------------------------------------------------
@@ -1196,7 +1202,9 @@ impending kill as a crash."
            (setf (worker-state worker-to-kill) :released)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
-           (setf *all-workers* (remove worker-to-kill *all-workers*)))
+           (setf *all-workers* (remove worker-to-kill *all-workers*))
+           (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
+             (setf *runtime-owner* nil)))
           ((and entry (typep entry 'worker-placeholder))
            (setf (worker-placeholder-cancelled entry) t)
            (remhash session-id *affinity-map*)
@@ -1235,7 +1243,16 @@ worker was bound, :PLACEHOLDER if a spawn was in progress (cancelled)."
            (setf (worker-state worker-to-kill) :released)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
-           (setf *all-workers* (remove worker-to-kill *all-workers*)))
+           (setf *all-workers* (remove worker-to-kill *all-workers*))
+           (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
+             (setf *runtime-owner* nil))
+           ;; pool-kill-worker is the documented re-arm for a quarantined
+           ;; runtime.  disabled=t implies owner=nil, so clearing the latch
+           ;; unconditionally (when the feature is on) cannot disturb a live
+           ;; healthy owner, and it lets the next bind re-attempt init.
+           (when *worker-init-config*
+             (setf *runtime-init-disabled* nil
+                   *runtime-init-failures* 0)))
           ((and entry (typep entry 'worker-placeholder))
            (setf (worker-placeholder-cancelled entry) t
                  kill-result :placeholder)

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -5,7 +5,8 @@
   (:import-from #:cl-mcp/src/log #:log-event)
   (:import-from #:cl-mcp/src/protocol #:process-json-line #:make-state)
   (:import-from #:cl-mcp/src/proxy #:*use-worker-pool*)
-  (:import-from #:cl-mcp/src/pool #:initialize-pool #:shutdown-pool)
+  (:import-from #:cl-mcp/src/pool
+                #:initialize-pool #:shutdown-pool #:%warn-if-init-without-pool)
   (:import-from #:cl-mcp/src/tcp #:serve-tcp)
   (:import-from #:cl-mcp/src/worker-client
                 #:%read-line-limited #:+max-json-line-bytes+
@@ -36,6 +37,7 @@ NIL runs all tools in-process.  When not supplied, the current value of
 *use-worker-pool* is used (which defaults to T unless MCP_NO_WORKER_POOL=1)."
   (when worker-pool-supplied-p
     (setf *use-worker-pool* worker-pool))
+  (%warn-if-init-without-pool *use-worker-pool*)
   (ecase transport
     (:stdio
      (when *use-worker-pool* (initialize-pool))

--- a/src/tools/pool-status.lisp
+++ b/src/tools/pool-status.lisp
@@ -37,6 +37,14 @@ tcp_port (integer), pid (integer), state (\"bound\" or \"standby\")."
              (format s "~&Max pool size: ~A, Warmup target: ~A"
                      (gethash "max_pool_size" info)
                      (gethash "warmup_target" info))
+             (when (or (gethash "init_owner_session" info)
+                       (gethash "init_disabled" info)
+                       (plusp (or (gethash "init_failures" info) 0)))
+               (format s "~&Init hook: owner=~A~@[ (worker #~A)~] disabled=~A failures=~A"
+                       (or (gethash "init_owner_session" info) "none")
+                       (gethash "init_owner_worker" info)
+                       (if (gethash "init_disabled" info) "true" "false")
+                       (gethash "init_failures" info)))
              (let ((workers (gethash "workers" info)))
                (when (and workers (plusp (length workers)))
                  (format s "~&~%Workers:")

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -186,10 +186,17 @@ Handles both LF and CRLF line endings."
 ;;; ---------------------------------------------------------------------------
 
 (defparameter *worker-env-denylist*
-  '("MCP_WORKER_SECRET" "MCP_WORKER_ID" "MCP_PARENT_PID" "MCP_LOG_FILE")
+  '("MCP_WORKER_SECRET" "MCP_WORKER_ID" "MCP_PARENT_PID" "MCP_LOG_FILE"
+    ;; The parent is the sole reader of these; the worker receives init
+    ;; params via RPC.  Denylisting prevents init forms that embed secrets
+    ;; from leaking into every worker's environment.
+    "MCP_WORKER_INIT_SYSTEM" "MCP_WORKER_INIT_ENTRY" "MCP_WORKER_INIT_EVAL"
+    "MCP_WORKER_INIT_PACKAGE" "MCP_WORKER_INIT_MAX_FAILURES"
+    "MCP_WORKER_INIT_MODE")
   "Environment variables that must NOT be inherited from the parent.
 MCP_WORKER_SECRET/ID/PARENT_PID are set explicitly per-worker.
-MCP_LOG_FILE is excluded so workers don't write to the parent's log file.")
+MCP_LOG_FILE is excluded so workers don't write to the parent's log file.
+MCP_WORKER_INIT_* are read only by the parent and passed as RPC params.")
 
 (defun %build-environment (secret id)
   "Build the environment for worker processes.

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -40,6 +40,8 @@
                 #:build-inspect-response)
   (:import-from #:cl-mcp/src/worker/server
                 #:register-method)
+  (:import-from #:cl-mcp/src/worker/init-hook
+                #:with-asdf-load-lock)
   (:export #:register-all-handlers))
 
 (in-package #:cl-mcp/src/worker/handlers)
@@ -104,7 +106,8 @@ result_preview, and error_context."
 
 (defun %handle-load-system (params)
   "Load an ASDF system.  Returns the same structure as define-tool
-\"load-system\"."
+\"load-system\".  Holds *ASDF-LOAD-LOCK* so it cannot overlap a
+concurrent worker/init load or another load-system."
   (let ((system (gethash "system" params))
          (force (%bool-default params "force" t))
          (clear-fasls (gethash "clear_fasls" params))
@@ -113,10 +116,11 @@ result_preview, and error_context."
       (error "system is required"))
     (when (and timeout-seconds (not (plusp timeout-seconds)))
       (error "timeout_seconds must be a positive number"))
-    (let ((ht (load-system system
-                           :force force
-                           :clear-fasls clear-fasls
-                           :timeout-seconds (or timeout-seconds 120))))
+    (let ((ht (with-asdf-load-lock
+                (load-system system
+                             :force force
+                             :clear-fasls clear-fasls
+                             :timeout-seconds (or timeout-seconds 120)))))
       (build-load-system-response system ht))))
 
 ;;; ---------------------------------------------------------------------------
@@ -125,7 +129,9 @@ result_preview, and error_context."
 
 (defun %handle-run-tests (params)
   "Run tests for a system.  Returns the same structure as define-tool
-\"run-tests\".  Honors timeout_seconds to limit test execution time."
+\"run-tests\".  Honors timeout_seconds to limit test execution time.
+Holds *ASDF-LOAD-LOCK* during the test run so it cannot overlap a
+concurrent load."
   (let ((system (gethash "system" params))
          (framework (gethash "framework" params))
          (test (gethash "test" params))
@@ -135,10 +141,11 @@ result_preview, and error_context."
     (unless system
       (error "system is required"))
     (flet ((do-run ()
-             (run-tests system
-                        :framework framework
-                        :test test
-                        :tests tests)))
+             (with-asdf-load-lock
+               (run-tests system
+                          :framework framework
+                          :test test
+                          :tests tests))))
       (let ((test-result (if timeout
                              (handler-case
                                  (sb-ext:with-timeout timeout

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -41,7 +41,9 @@
   (:import-from #:cl-mcp/src/worker/server
                 #:register-method)
   (:import-from #:cl-mcp/src/worker/init-hook
-                #:with-asdf-load-lock)
+                #:with-asdf-load-lock
+                #:handle-init-start
+                #:handle-init-status)
   (:export #:register-all-handlers))
 
 (in-package #:cl-mcp/src/worker/handlers)
@@ -272,5 +274,7 @@ Returns a success payload."
   (register-method server "worker/code-find-references" #'%handle-code-find-references)
   (register-method server "worker/inspect-object" #'%handle-inspect-object)
   (register-method server "worker/set-project-root" #'%handle-set-project-root)
-  (log-event :info "worker.handlers.registered" "count" 8)
+  (register-method server "worker/init-start" #'handle-init-start)
+  (register-method server "worker/init-status" #'handle-init-status)
+  (log-event :info "worker.handlers.registered" "count" 10)
   server)

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -10,8 +10,15 @@
   (:use #:cl)
   (:import-from #:bordeaux-threads
                 #:make-lock #:with-lock-held)
+  (:import-from #:cl-mcp/src/system-loader-core #:load-system)
+  (:import-from #:cl-mcp/src/repl-core #:repl-eval)
+  (:import-from #:cl-mcp/src/utils/sanitize #:sanitize-error-message)
+  (:import-from #:cl-mcp/src/tools/helpers #:make-ht)
+  (:import-from #:cl-mcp/src/log #:log-event)
   (:export #:*asdf-load-lock*
-           #:with-asdf-load-lock))
+           #:with-asdf-load-lock
+           #:handle-init-start
+           #:handle-init-status))
 
 (in-package #:cl-mcp/src/worker/init-hook)
 
@@ -80,3 +87,69 @@ error if the package or symbol is missing or the symbol is not fbound."
         (unless (fboundp sym)
           (error "init entry: ~A is not fbound" sym))
         (fdefinition sym)))))
+
+(defun %maybe-eval (form-string package-name)
+  "Run FORM-STRING via repl-core:repl-eval in PACKAGE-NAME.  Signals an
+error if the evaluation produced an error-context, so the outer
+handler-case records a :failed init.  Routing through repl-eval (not raw
+eval) reuses the sanctioned evaluator.  repl-eval returns its error-context
+as a plist keyed by keywords (:message, :condition-type, ...), so we pull
+:message for a clean failure string."
+  (let ((pkg (or (find-package (string-upcase package-name)) *package*)))
+    (multiple-value-bind (printed raw stdout stderr err-ctx)
+        (repl-eval form-string :package pkg)
+      (declare (ignore printed raw stdout stderr))
+      (when err-ctx
+        (error "init eval failed: ~A"
+               (or (and (listp err-ctx) (getf err-ctx :message))
+                   err-ctx))))))
+
+(defun %run-init (params)
+  "Background-thread init runner.  Holds *ASDF-LOAD-LOCK* for the whole
+load so it cannot overlap a concurrent load-system/run-tests.  Loads with
+timeout=NIL (the direct branch -- no spawned thread, no destroy-thread
+mid-compile).  Never signals out of this function: on any error it records
+a :failed init and leaves the worker fully usable."
+  (let ((system (gethash "system" params))
+        (evalform (gethash "eval" params))
+        (entry (gethash "entry" params))
+        (pkg (or (gethash "package" params) "CL-USER")))
+    (%set-init-state :loading)
+    (handler-case
+        (with-asdf-load-lock
+          (when system
+            (load-system system :force nil :timeout-seconds nil))
+          (when evalform
+            (%maybe-eval evalform pkg))
+          (let ((port nil))
+            ;; Entry contract: the thunk MUST return promptly (e.g. a
+            ;; clackup with :use-thread t that starts the server on its own
+            ;; thread and returns) and MUST NOT re-enter WITH-ASDF-LOAD-LOCK
+            ;; or otherwise block -- the worker-global load lock is held for
+            ;; this whole body, so a blocking or re-entrant entry would
+            ;; deadlock every other load site.  A direct LOAD-SYSTEM call
+            ;; from the entry is safe: the lock lives at the handler layer,
+            ;; not inside load-system itself.
+            (when entry
+              (setf port (funcall (%resolve-entry entry))))
+            (%set-init-state :running
+                             :app-port (and (integerp port) port))
+            (log-event :info "worker.init.done"
+                       "app_port" (and (integerp port) port))))
+      (serious-condition (e)
+        (let ((msg (or (ignore-errors (sanitize-error-message e)) "init failed")))
+          (%set-init-state :failed :error msg)
+          (ignore-errors
+            (log-event :warn "worker.init.failed" "error" msg)))))))
+
+(defun handle-init-start (params)
+  "worker/init-start handler.  Spawns the init runner on a background
+thread and returns an ACK immediately, so the parent's RPC does not block
+on the (heavy) load and no long stream-lock is held."
+  (bt:make-thread (lambda () (%run-init params)) :name "mcp-worker-init")
+  (make-ht "accepted" t))
+
+(defun handle-init-status (params)
+  "worker/init-status handler.  Returns the current init state snapshot."
+  (declare (ignore params))
+  (init-state-snapshot))

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -25,3 +25,36 @@ work on spawned helper threads.")
 (defmacro with-asdf-load-lock (&body body)
   "Evaluate BODY holding *ASDF-LOAD-LOCK*."
   `(bt:with-lock-held (*asdf-load-lock*) ,@body))
+
+(defvar *init-lock* (bt:make-lock "worker-init-state")
+  "Protects *INIT-STATE*.")
+
+(defvar *init-state* (list :state :idle :app-port nil :error nil :started-at nil)
+  "Init progress: :state is one of :idle :loading :running :failed.")
+
+(defun %reset-init-state ()
+  "Reset init state to :idle (used by tests and re-arming)."
+  (bt:with-lock-held (*init-lock*)
+    (setf *init-state* (list :state :idle :app-port nil :error nil
+                             :started-at nil))))
+
+(defun %set-init-state (state &key app-port error)
+  "Transition init state.  STATE is a keyword; APP-PORT/ERROR update the
+corresponding fields when provided."
+  (bt:with-lock-held (*init-lock*)
+    (setf (getf *init-state* :state) state)
+    (when (eq state :loading)
+      (setf (getf *init-state* :started-at) (get-universal-time)))
+    (when app-port (setf (getf *init-state* :app-port) app-port))
+    (when error (setf (getf *init-state* :error) error))))
+
+(defun init-state-snapshot ()
+  "Return a hash-table snapshot of init state for pool-status / RPC.
+Keys: init_state, app_port, last_init_error, started_at."
+  (bt:with-lock-held (*init-lock*)
+    (let ((ht (make-hash-table :test 'equal)))
+      (setf (gethash "init_state" ht) (string-downcase (getf *init-state* :state))
+            (gethash "app_port" ht) (getf *init-state* :app-port)
+            (gethash "last_init_error" ht) (getf *init-state* :error)
+            (gethash "started_at" ht) (getf *init-state* :started-at))
+      ht)))

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -58,3 +58,25 @@ Keys: init_state, app_port, last_init_error, started_at."
             (gethash "last_init_error" ht) (getf *init-state* :error)
             (gethash "started_at" ht) (getf *init-state* :started-at))
       ht)))
+
+(defun %resolve-entry (spec)
+  "Resolve a \"PKG:SYMBOL\" or \"PKG::SYMBOL\" string to a callable.
+Uses find-package / find-symbol / fdefinition only -- no read, eval, or
+intern -- honoring the project's no-runtime-eval style rule.  Signals an
+error if the package or symbol is missing or the symbol is not fbound."
+  (let* ((dbl (search "::" spec))
+         (colon (or dbl (position #\: spec))))
+    (unless colon
+      (error "init entry ~S must be of the form PKG:SYMBOL" spec))
+    (let* ((pkg-name (string-upcase (subseq spec 0 colon)))
+           (sym-name (string-upcase (subseq spec (+ colon (if dbl 2 1)))))
+           (pkg (find-package pkg-name)))
+      (unless pkg
+        (error "init entry: package ~A not found" pkg-name))
+      (let ((sym (find-symbol sym-name pkg)))
+        (unless sym
+          (error "init entry: symbol ~A not found in package ~A"
+                 sym-name pkg-name))
+        (unless (fboundp sym)
+          (error "init entry: ~A is not fbound" sym))
+        (fdefinition sym)))))

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -1,0 +1,27 @@
+;;;; src/worker/init-hook.lisp
+;;;;
+;;;; Worker-side machinery for the init hook.  Provides the worker-global
+;;;; ASDF load lock (so cl-mcp-mediated loads never overlap), the init
+;;;; state machine, entry resolution, and the worker/init-start and
+;;;; worker/init-status RPC handlers.  See
+;;;; docs/plans/2026-07-05-worker-init-hook-design.md.
+
+(defpackage #:cl-mcp/src/worker/init-hook
+  (:use #:cl)
+  (:import-from #:bordeaux-threads
+                #:make-lock #:with-lock-held)
+  (:export #:*asdf-load-lock*
+           #:with-asdf-load-lock))
+
+(in-package #:cl-mcp/src/worker/init-hook)
+
+(defvar *asdf-load-lock* (bt:make-lock "asdf-load-lock")
+  "Worker-global lock serializing every cl-mcp-mediated ASDF load site
+(worker/init, worker/load-system, worker/run-tests).  Prevents two
+concurrent ASDF load-ops in one worker image, which the single-threaded
+dispatch loop does NOT prevent because load-system/repl-eval run their
+work on spawned helper threads.")
+
+(defmacro with-asdf-load-lock (&body body)
+  "Evaluate BODY holding *ASDF-LOAD-LOCK*."
+  `(bt:with-lock-held (*asdf-load-lock*) ,@body))

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -118,7 +118,14 @@ a :failed init and leaves the worker fully usable."
     (handler-case
         (with-asdf-load-lock
           (when system
-            (load-system system :force nil :timeout-seconds nil))
+            (let* ((result (load-system system :force nil :timeout-seconds nil))
+                   (status (and (hash-table-p result) (gethash "status" result))))
+              ;; load-system returns a status hash (does NOT signal) on compile
+              ;; error / missing system; surface a non-"loaded" status as a
+              ;; failed init instead of falsely reporting :running.
+              (unless (equal status "loaded")
+                (error "init system ~A failed to load (status: ~A)"
+                       system (or status "unknown")))))
           (when evalform
             (%maybe-eval evalform pkg))
           (let ((port nil))

--- a/tests.lisp
+++ b/tests.lisp
@@ -45,6 +45,7 @@
   (:import-from #:cl-mcp/tests/utils-random-test)
   (:import-from #:cl-mcp/tests/system-loader-test)
   (:import-from #:cl-mcp/tests/worker-test)
+  (:import-from #:cl-mcp/tests/worker-init-hook-test)
   (:import-from #:cl-mcp/tests/pool-test)
   (:import-from #:cl-mcp/tests/pool-startup-latency-test)
   (:import-from #:cl-mcp/tests/pool-env-config-test)

--- a/tests.lisp
+++ b/tests.lisp
@@ -51,6 +51,7 @@
   (:import-from #:cl-mcp/tests/pool-env-config-test)
   (:import-from #:cl-mcp/tests/pool-status-test)
   (:import-from #:cl-mcp/tests/pool-kill-worker-test)
+  (:import-from #:cl-mcp/tests/pool-init-config-test)
   (:import-from #:cl-mcp/tests/project-scaffold-test))
 
 (in-package #:cl-mcp/tests)

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -1,0 +1,44 @@
+;;;; tests/pool-init-config-test.lisp
+;;;;
+;;;; Tests for parent-side worker-init-hook config parsing, env denylist,
+;;;; ownership election, and crash-breaker isolation.
+
+(defpackage #:cl-mcp/tests/pool-init-config-test
+  (:use #:cl)
+  (:import-from #:rove #:deftest #:testing #:ok)
+  (:import-from #:cl-mcp/src/pool
+                #:*worker-init-config*))
+
+(in-package #:cl-mcp/tests/pool-init-config-test)
+
+(defun %with-env (bindings thunk)
+  "Set env BINDINGS ((name . value) ...) for the duration of THUNK, then
+restore.  A NIL value unsets the variable."
+  (let ((saved (loop for (name . nil) in bindings
+                     collect (cons name (uiop:getenv name)))))
+    (unwind-protect
+         (progn
+           (loop for (name . value) in bindings
+                 do (if value (setf (uiop/os:getenv name) value)
+                        (sb-posix:unsetenv name)))
+           (funcall thunk))
+      (loop for (name . value) in saved
+            do (if value (setf (uiop/os:getenv name) value)
+                   (sb-posix:unsetenv name))))))
+
+(deftest parse-worker-init-config
+  (testing "config is nil when SYSTEM is unset, populated when set"
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . nil))
+      (lambda ()
+        (ok (null (cl-mcp/src/pool::%parse-worker-init-config))
+            "no SYSTEM => nil config")))
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . "recurya/dev")
+                 ("MCP_WORKER_INIT_ENTRY" . "recurya/dev:start-dev-runtime!")
+                 ("MCP_WORKER_INIT_MAX_FAILURES" . "1"))
+      (lambda ()
+        (let ((cfg (cl-mcp/src/pool::%parse-worker-init-config)))
+          (ok cfg "config present")
+          (ok (string= (getf cfg :system) "recurya/dev") "system parsed")
+          (ok (string= (getf cfg :entry) "recurya/dev:start-dev-runtime!")
+              "entry parsed")
+          (ok (eql (getf cfg :max-failures) 1) "max-failures parsed"))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -278,3 +278,15 @@ restore.  A NIL value unsets the variable."
                                          "sess-init")))
                          "runtime owner elected for the session")))
               (ignore-errors (cl-mcp/src/pool:shutdown-pool))))))))
+
+(deftest init-crash-excluded-from-breaker
+  (testing "%init-attributable-crash-p reflects the marked set"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w (make-worker :id 77 :state :crashed)))
+          (ok (not (cl-mcp/src/pool::%init-attributable-crash-p w))
+              "unmarked worker is not init-attributable")
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (setf (gethash 77 cl-mcp/src/pool::*init-attributable-crashes*) t))
+          (ok (cl-mcp/src/pool::%init-attributable-crash-p w)
+              "marked worker is init-attributable"))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -10,7 +10,7 @@
                 #:*worker-init-config*)
   (:import-from #:cl-mcp/src/worker-client
                 #:make-worker #:spawn-worker #:kill-worker
-                #:worker-session-id #:worker-state))
+                #:worker-session-id #:worker-state #:worker-rpc))
 
 (in-package #:cl-mcp/tests/pool-init-config-test)
 
@@ -158,3 +158,59 @@ restore.  A NIL value unsets the variable."
           (cl-mcp/src/pool::%release-runtime-owner-if w1)
           (ok (null cl-mcp/src/pool::*runtime-owner*)
               "owner release clears *runtime-owner*"))))))
+
+(deftest ensure-runtime-init-drives-a-real-worker
+  (testing "%ensure-runtime-init elects and drives init to a terminal state"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry nil
+                                 :eval "(+ 1 2)" :package "CL-USER"
+                                 :max-failures 1 :mode "singleton")))
+                     (setf (worker-session-id worker) "sx"
+                           (worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "sx")
+                     ;; Poll worker/init-status directly until terminal.
+                     (let ((state nil))
+                       (loop repeat 60
+                             for r = (ignore-errors
+                                       (worker-rpc worker "worker/init-status"
+                                                   nil :timeout 5))
+                             when r do (setf state (gethash "init_state" r))
+                             until (member state '("running" "failed")
+                                            :test #'equal)
+                             do (sleep 0.05))
+                       (ok (equal state "running")
+                           "init reached running for a trivial eval")))
+                (ignore-errors (kill-worker worker)))))))))
+
+(deftest ensure-runtime-init-failed-accounting
+  (testing "a failing init counts toward failures, disables at max, releases ownership"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry nil
+                                 :eval "(error \"boom\")" :package "CL-USER"
+                                 :max-failures 1 :mode "singleton")))
+                     (setf (worker-session-id worker) "sf"
+                           (worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "sf")
+                     (loop repeat 100
+                           until (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                                   cl-mcp/src/pool::*runtime-init-disabled*)
+                           do (sleep 0.05))
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           cl-mcp/src/pool::*runtime-init-disabled*)
+                         "init disabled after max soft failures")
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           (null cl-mcp/src/pool::*runtime-owner*))
+                         "ownership released after failure"))
+                (ignore-errors (kill-worker worker)))))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -8,7 +8,9 @@
   (:import-from #:rove #:deftest #:testing #:ok)
   (:import-from #:cl-mcp/src/pool
                 #:*worker-init-config*)
-  (:import-from #:cl-mcp/src/worker-client))
+  (:import-from #:cl-mcp/src/worker-client
+                #:make-worker #:spawn-worker #:kill-worker
+                #:worker-session-id #:worker-state))
 
 (in-package #:cl-mcp/tests/pool-init-config-test)
 
@@ -72,3 +74,71 @@ restore.  A NIL value unsets the variable."
                 (progn (cl-mcp/src/pool::%warn-if-init-without-pool nil) t)
               (warning () nil))
             "no warning when INIT unset (even with pool disabled)")))))
+
+(defun %socket-available-p ()
+  "Return T if we can bind a TCP socket on localhost."
+  (handler-case
+      (let ((s (usocket:socket-listen "127.0.0.1" 0 :reuse-address t
+                                                     :element-type 'character)))
+        (unwind-protect t (ignore-errors (usocket:socket-close s))))
+    (error () nil)))
+
+(deftest elect-runtime-owner-rules
+  (testing "grant when owner nil; re-grant same session; reclaim when owner dead"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        ;; Fake workers with NIL process-info are treated as NOT alive by
+        ;; %worker-process-alive-p, so they model a dead owner.
+        (let ((w-a (make-worker :id 1 :state :bound :session-id "sess-a"))
+              (w-b (make-worker :id 2 :state :bound :session-id "sess-b")))
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (ok (cl-mcp/src/pool::%elect-runtime-owner w-a "sess-a")
+                "grants when owner is nil")
+            (ok (cl-mcp/src/pool::%elect-runtime-owner w-a "sess-a")
+                "re-grants to the same session")
+            (ok (cl-mcp/src/pool::%elect-runtime-owner w-b "sess-b")
+                "reclaims when the current owner process is dead")))))))
+
+(deftest elect-refuses-live-other-session
+  (testing "election refuses to migrate to a different session while the owner process is alive"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((owner (spawn-worker))
+                  (other (make-worker :id 999 :state :bound :session-id "s-other")))
+              (unwind-protect
+                   (progn
+                     (setf (worker-session-id owner) "s-owner"
+                           (worker-state owner) :bound)
+                     (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                       (ok (cl-mcp/src/pool::%elect-runtime-owner owner "s-owner")
+                           "owner elected")
+                       (ok (not (cl-mcp/src/pool::%elect-runtime-owner other "s-other"))
+                           "refuses a different session while the owner is alive")
+                       (ok (eq (cdr cl-mcp/src/pool::*runtime-owner*) owner)
+                           "owner unchanged after a refused election")))
+                (ignore-errors (kill-worker owner)))))))))
+
+(deftest elect-refuses-live-session-with-dead-worker
+  (testing "no migration to a different session while the owner session is alive (L4)"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w-owner (make-worker :id 10 :state :crashed :session-id "own"))
+              (w-other (make-worker :id 11 :state :bound :session-id "oth")))
+          (unwind-protect
+               (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                 ;; owner session "own" elected and still present in the affinity map;
+                 ;; its worker is dead (nil process-info => not alive)
+                 (setf (gethash "own" cl-mcp/src/pool::*affinity-map*) w-owner)
+                 (ok (cl-mcp/src/pool::%elect-runtime-owner w-owner "own") "owner elected")
+                 (ok (not (cl-mcp/src/pool::%elect-runtime-owner w-other "oth"))
+                     "refuses a different session while the owner session is still alive")
+                 (ok (string= (car cl-mcp/src/pool::*runtime-owner*) "own")
+                     "owner unchanged after refused migration")
+                 ;; once the owner session leaves the map, reclaim is allowed
+                 (remhash "own" cl-mcp/src/pool::*affinity-map*)
+                 (ok (cl-mcp/src/pool::%elect-runtime-owner w-other "oth")
+                     "reclaims once the owner session is gone"))
+            (remhash "own" cl-mcp/src/pool::*affinity-map*)
+            (remhash "oth" cl-mcp/src/pool::*affinity-map*)))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -7,7 +7,8 @@
   (:use #:cl)
   (:import-from #:rove #:deftest #:testing #:ok)
   (:import-from #:cl-mcp/src/pool
-                #:*worker-init-config*))
+                #:*worker-init-config*)
+  (:import-from #:cl-mcp/src/worker-client))
 
 (in-package #:cl-mcp/tests/pool-init-config-test)
 
@@ -42,3 +43,13 @@ restore.  A NIL value unsets the variable."
           (ok (string= (getf cfg :entry) "recurya/dev:start-dev-runtime!")
               "entry parsed")
           (ok (eql (getf cfg :max-failures) 1) "max-failures parsed"))))))
+
+(deftest init-vars-are-denylisted
+  (testing "MCP_WORKER_INIT_* are excluded from inherited worker env"
+    (let ((denylist cl-mcp/src/worker-client::*worker-env-denylist*))
+      (ok (member "MCP_WORKER_INIT_SYSTEM" denylist :test #'string=)
+          "SYSTEM denylisted")
+      (ok (member "MCP_WORKER_INIT_ENTRY" denylist :test #'string=)
+          "ENTRY denylisted")
+      (ok (member "MCP_WORKER_INIT_EVAL" denylist :test #'string=)
+          "EVAL denylisted"))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -53,3 +53,22 @@ restore.  A NIL value unsets the variable."
           "ENTRY denylisted")
       (ok (member "MCP_WORKER_INIT_EVAL" denylist :test #'string=)
           "EVAL denylisted"))))
+
+(deftest pool-off-guard-warns
+  (testing "%warn-if-init-without-pool warns only when INIT set AND pool disabled"
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . "recurya/dev"))
+      (lambda ()
+        (ok (handler-case
+                (progn (cl-mcp/src/pool::%warn-if-init-without-pool nil) nil)
+              (warning () t))
+            "warns when INIT set and pool disabled")
+        (ok (handler-case
+                (progn (cl-mcp/src/pool::%warn-if-init-without-pool t) t)
+              (warning () nil))
+            "no warning when pool enabled")))
+    (%with-env '(("MCP_WORKER_INIT_SYSTEM" . nil))
+      (lambda ()
+        (ok (handler-case
+                (progn (cl-mcp/src/pool::%warn-if-init-without-pool nil) t)
+              (warning () nil))
+            "no warning when INIT unset (even with pool disabled)")))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -302,3 +302,23 @@ restore.  A NIL value unsets the variable."
               "init_disabled key present")
           (ok (nth-value 1 (gethash "init_failures" info))
               "init_failures key present"))))))
+
+(deftest kill-session-worker-rearms-when-no-worker
+  (testing "pool-kill-worker re-arms even when the session's worker was already reaped"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((cl-mcp/src/pool::*worker-init-config*
+                (list :system "x" :max-failures 1 :mode "singleton")))
+          ;; Reachable quarantine after an init hard-crash whose worker the
+          ;; health monitor already reaped: disabled=t, owner=nil, NO affinity entry.
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (setf cl-mcp/src/pool::*runtime-init-disabled* t
+                  cl-mcp/src/pool::*runtime-init-failures* 3))
+          (let ((result (cl-mcp/src/pool:kill-session-worker "gone-session")))
+            (ok (eq result :no-worker) "no worker was bound to the session")
+            (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                  (null cl-mcp/src/pool::*runtime-init-disabled*))
+                "init re-armed even though kill found no worker")
+            (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                  (zerop cl-mcp/src/pool::*runtime-init-failures*))
+                "failure count reset")))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -290,3 +290,15 @@ restore.  A NIL value unsets the variable."
             (setf (gethash 77 cl-mcp/src/pool::*init-attributable-crashes*) t))
           (ok (cl-mcp/src/pool::%init-attributable-crash-p w)
               "marked worker is init-attributable"))))))
+
+(deftest pool-status-includes-init-fields
+  (testing "pool-status-info exposes runtime init fields"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((info (cl-mcp/src/pool:pool-status-info)))
+          (ok (nth-value 1 (gethash "init_owner_session" info))
+              "init_owner_session key present")
+          (ok (nth-value 1 (gethash "init_disabled" info))
+              "init_disabled key present")
+          (ok (nth-value 1 (gethash "init_failures" info))
+              "init_failures key present"))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -10,7 +10,7 @@
                 #:*worker-init-config*)
   (:import-from #:cl-mcp/src/worker-client
                 #:make-worker #:spawn-worker #:kill-worker
-                #:worker-session-id #:worker-state #:worker-rpc))
+                #:worker-session-id #:worker-state #:worker-rpc #:worker-id))
 
 (in-package #:cl-mcp/tests/pool-init-config-test)
 
@@ -322,3 +322,65 @@ restore.  A NIL value unsets the variable."
             (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
                   (zerop cl-mcp/src/pool::*runtime-init-failures*))
                 "failure count reset")))))))
+
+(deftest init-attributable-marked-eagerly-cleared-on-success
+  (testing "election marks the worker init-attributable immediately; success clears it"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry nil :eval "(+ 1 2)"
+                                 :package "CL-USER" :max-failures 1 :mode "singleton")))
+                     (setf (worker-session-id worker) "se"
+                           (worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "se")
+                     ;; EAGER: the worker-id is marked init-attributable right away
+                     ;; (before init could even crash).
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           (gethash (worker-id worker)
+                                    cl-mcp/src/pool::*init-attributable-crashes*))
+                         "worker marked init-attributable at election")
+                     ;; After init reaches running the eager mark is cleared.
+                     (loop repeat 100
+                           until (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                                   (null (gethash (worker-id worker)
+                                            cl-mcp/src/pool::*init-attributable-crashes*)))
+                           do (sleep 0.05))
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           (null (gethash (worker-id worker)
+                                    cl-mcp/src/pool::*init-attributable-crashes*)))
+                         "mark cleared once init reaches running"))
+                (ignore-errors (kill-worker worker)))))))))
+
+(deftest soft-init-failure-below-max-keeps-ownership
+  (testing "a soft init failure below max-failures keeps ownership (no migration)"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (cl-mcp/src/pool::%with-owner-reset
+          (lambda ()
+            (let ((worker (spawn-worker)))
+              (unwind-protect
+                   (let ((cl-mcp/src/pool::*worker-init-config*
+                           (list :system nil :entry nil :eval "(error \"boom\")"
+                                 :package "CL-USER" :max-failures 3 :mode "singleton")))
+                     (setf (worker-session-id worker) "sk"
+                           (worker-state worker) :bound)
+                     (cl-mcp/src/pool::%ensure-runtime-init worker "sk")
+                     (loop repeat 100
+                           until (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                                   (plusp cl-mcp/src/pool::*runtime-init-failures*))
+                           do (sleep 0.05))
+                     (ok (= 1 (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                                cl-mcp/src/pool::*runtime-init-failures*))
+                         "one soft failure recorded")
+                     (ok (not (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                                cl-mcp/src/pool::*runtime-init-disabled*))
+                         "not disabled (below max)")
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           (and cl-mcp/src/pool::*runtime-owner*
+                                (string= (car cl-mcp/src/pool::*runtime-owner*) "sk")))
+                         "ownership retained on soft failure below max"))
+                (ignore-errors (kill-worker worker)))))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -142,3 +142,19 @@ restore.  A NIL value unsets the variable."
                      "reclaims once the owner session is gone"))
             (remhash "own" cl-mcp/src/pool::*affinity-map*)
             (remhash "oth" cl-mcp/src/pool::*affinity-map*)))))))
+
+(deftest release-runtime-owner
+  (testing "release clears ownership only for the owning worker"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w1 (make-worker :id 1 :state :bound :session-id "s1"))
+              (w2 (make-worker :id 2 :state :bound :session-id "s2")))
+          (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+            (cl-mcp/src/pool::%elect-runtime-owner w1 "s1"))
+          ;; releasing a non-owner does nothing
+          (cl-mcp/src/pool::%release-runtime-owner-if w2)
+          (ok cl-mcp/src/pool::*runtime-owner* "non-owner release is a no-op")
+          ;; releasing the owner clears it
+          (cl-mcp/src/pool::%release-runtime-owner-if w1)
+          (ok (null cl-mcp/src/pool::*runtime-owner*)
+              "owner release clears *runtime-owner*"))))))

--- a/tests/pool-init-config-test.lisp
+++ b/tests/pool-init-config-test.lisp
@@ -214,3 +214,67 @@ restore.  A NIL value unsets the variable."
                            (null cl-mcp/src/pool::*runtime-owner*))
                          "ownership released after failure"))
                 (ignore-errors (kill-worker worker)))))))))
+
+(deftest kill-session-worker-rearms-quarantined-runtime
+  (testing "pool-kill-worker clears the disable latch (reachable quarantine: owner nil, disabled t)"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w (make-worker :id 30 :state :bound :session-id "kso"))
+              (cl-mcp/src/pool::*worker-init-config*
+                (list :system "x" :entry nil :eval nil :package "CL-USER"
+                      :max-failures 1 :mode "singleton")))
+          (unwind-protect
+               (progn
+                 ;; Reachable quarantine: disabled=t => owner=nil; a session still has a worker.
+                 (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                   (setf (gethash "kso" cl-mcp/src/pool::*affinity-map*) w
+                         cl-mcp/src/pool::*runtime-owner* nil
+                         cl-mcp/src/pool::*runtime-init-disabled* t
+                         cl-mcp/src/pool::*runtime-init-failures* 5))
+                 (cl-mcp/src/pool:kill-session-worker "kso")
+                 (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                   (ok (null cl-mcp/src/pool::*runtime-init-disabled*)
+                       "init re-armed (disabled cleared) by pool-kill-worker")
+                   (ok (zerop cl-mcp/src/pool::*runtime-init-failures*)
+                       "failure count reset")))
+            (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+              (remhash "kso" cl-mcp/src/pool::*affinity-map*))))))))
+
+(deftest kill-session-worker-releases-owner
+  (testing "killing the owner session releases runtime ownership (healthy owner)"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let ((w (make-worker :id 31 :state :bound :session-id "kow"))
+              (cl-mcp/src/pool::*worker-init-config*
+                (list :system "x" :max-failures 1 :mode "singleton")))
+          (unwind-protect
+               (progn
+                 (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                   (setf (gethash "kow" cl-mcp/src/pool::*affinity-map*) w
+                         cl-mcp/src/pool::*runtime-owner* (cons "kow" w)))
+                 (cl-mcp/src/pool:kill-session-worker "kow")
+                 (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                       (null cl-mcp/src/pool::*runtime-owner*))
+                     "ownership released on owner kill"))
+            (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+              (remhash "kow" cl-mcp/src/pool::*affinity-map*))))))))
+
+(deftest get-or-assign-fires-runtime-init
+  (testing "get-or-assign-worker elects a runtime owner when init config is set"
+    (if (not (%socket-available-p))
+        (rove:skip "socket unavailable")
+        (%with-env '(("MCP_WORKER_INIT_SYSTEM" . "alexandria")
+                     ("MCP_WORKER_INIT_EVAL" . "(+ 1 2)")
+                     ("CL_MCP_WORKER_POOL_WARMUP" . "0"))
+          (lambda ()
+            (unwind-protect
+                 (progn
+                   (cl-mcp/src/pool:initialize-pool)
+                   (let ((w (cl-mcp/src/pool:get-or-assign-worker "sess-init")))
+                     (ok w "worker assigned on demand")
+                     (ok (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                           (and cl-mcp/src/pool::*runtime-owner*
+                                (string= (car cl-mcp/src/pool::*runtime-owner*)
+                                         "sess-init")))
+                         "runtime owner elected for the session")))
+              (ignore-errors (cl-mcp/src/pool:shutdown-pool))))))))

--- a/tests/pool-status-test.lisp
+++ b/tests/pool-status-test.lisp
@@ -56,3 +56,51 @@
           (ok (numberp (gethash "warmup_target" result)))
           (ok (arrayp (gethash "workers" result)))
           (ok (gethash "content" result)))))))
+
+(defun %pool-status-text (result)
+  "Extract the summary text from a pool-status tool RESULT hash-table."
+  (gethash "text" (aref (gethash "content" result) 0)))
+
+(deftest pool-status-text-omits-init-hook-line-when-inactive
+  (testing "pool-status text has no Init hook line when the hook is not engaged"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (let* ((handler (get-tool-handler "pool-status"))
+               (state (make-state))
+               (response (funcall handler state 1 nil))
+               (result (gethash "result" response))
+               (text (%pool-status-text result)))
+          (ok (not (search "Init hook:" text))
+              "no Init hook line when owner is nil, not disabled, zero failures"))))))
+
+(deftest pool-status-text-includes-init-hook-line-when-owner-set
+  (testing "pool-status text shows the Init hook line with owner/worker/failures when an owner is elected"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+          (setf cl-mcp/src/pool::*runtime-owner*
+                  (cons "sess-xyz" (cl-mcp/src/worker-client:make-worker :id 42))
+                cl-mcp/src/pool::*runtime-init-failures* 2))
+        (let* ((handler (get-tool-handler "pool-status"))
+               (state (make-state))
+               (response (funcall handler state 1 nil))
+               (result (gethash "result" response))
+               (text (%pool-status-text result)))
+          (ok (search "Init hook: owner=sess-xyz (worker #42) disabled=false failures=2" text)
+              "Init hook line renders owner, worker id, disabled, and failures"))))))
+
+(deftest pool-status-text-includes-init-hook-line-when-disabled-only
+  (testing "pool-status text shows the Init hook line when disabled with no owner"
+    (cl-mcp/src/pool::%with-owner-reset
+      (lambda ()
+        (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+          (setf cl-mcp/src/pool::*runtime-init-disabled* t))
+        (let* ((handler (get-tool-handler "pool-status"))
+               (state (make-state))
+               (response (funcall handler state 1 nil))
+               (result (gethash "result" response))
+               (text (%pool-status-text result)))
+          (ok (search "Init hook: owner=none disabled=true failures=0" text)
+              "Init hook line shows owner=none and no worker suffix when owner is nil")
+          (ok (not (search "(worker #" text))
+              "no worker suffix when init_owner_worker is nil"))))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -67,3 +67,28 @@
     (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
       (ok (string= (gethash "init_state" s) "failed") "failed")
       (ok (string= (gethash "last_init_error" s) "boom") "error recorded"))))
+
+(defun a-test-entry-thunk () 4242)
+
+(deftest resolve-entry
+  (testing "PKG:SYM and PKG::SYM resolve to the fdefinition; bad specs error"
+    (let ((fn (cl-mcp/src/worker/init-hook::%resolve-entry
+               "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST:A-TEST-ENTRY-THUNK")))
+      (ok (functionp fn) "resolves to a function")
+      (ok (eql (funcall fn) 4242) "funcalls the resolved thunk"))
+    (ok (functionp
+         (cl-mcp/src/worker/init-hook::%resolve-entry
+          "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST::A-TEST-ENTRY-THUNK"))
+        "double-colon form resolves")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "no-colon") nil)
+          (error () t))
+        "spec without a colon errors")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "NOSUCHPKG:FOO") nil)
+          (error () t))
+        "missing package errors")
+    (ok (handler-case
+            (progn (cl-mcp/src/worker/init-hook::%resolve-entry "CL:NO-SUCH-SYMBOL-XYZ") nil)
+          (error () t))
+        "missing symbol errors")))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -138,8 +138,8 @@
                  (let ((socket (usocket:socket-connect "127.0.0.1" port
                                                        :element-type 'character)))
                    (unwind-protect
-                        (let* ((stream (usocket:socket-stream socket))
-                               (params (make-hash-table :test 'equal)))
+                        (let ((stream (usocket:socket-stream socket))
+                              (params (make-hash-table :test 'equal)))
                           (setf (gethash "entry" params)
                                 "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST:INTEGRATION-ENTRY-THUNK")
                           (let ((ack (%rpc stream 1 "worker/init-start" params)))
@@ -185,3 +185,15 @@
             "message is the clean short string, not a raw plist dump")
         (ok (null (search "RESTARTS" (string-upcase err)))
             "no raw error-context plist leaked")))))
+
+(deftest run-init-fails-on-bad-system
+  (testing "%run-init records :failed (not :running) when the system fails to load"
+    (cl-mcp/src/worker/init-hook::%reset-init-state)
+    (let ((params (make-hash-table :test 'equal)))
+      (setf (gethash "system" params) "no-such-system-xyz-98765")
+      (cl-mcp/src/worker/init-hook::%run-init params)
+      (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+        (ok (string= (gethash "init_state" s) "failed")
+            "a bad system load yields :failed, not :running")
+        (ok (gethash "last_init_error" s)
+            "last_init_error is set")))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -1,0 +1,29 @@
+;;;; tests/worker-init-hook-test.lisp
+;;;;
+;;;; Tests for the worker-side init hook: load lock, init state machine,
+;;;; entry resolution, and the init RPC handlers.
+
+(defpackage #:cl-mcp/tests/worker-init-hook-test
+  (:use #:cl)
+  (:import-from #:rove #:deftest #:testing #:ok #:skip)
+  (:import-from #:cl-mcp/src/worker/init-hook
+                #:*asdf-load-lock*
+                #:with-asdf-load-lock))
+
+(in-package #:cl-mcp/tests/worker-init-hook-test)
+
+(deftest with-asdf-load-lock-serializes
+  (testing "two threads holding the lock never overlap in the critical section"
+    (let ((inside 0) (max-inside 0) (lock (bt:make-lock "probe")))
+      (flet ((body ()
+               (with-asdf-load-lock
+                 (bt:with-lock-held (lock)
+                   (incf inside)
+                   (setf max-inside (max max-inside inside)))
+                 (sleep 0.02)
+                 (bt:with-lock-held (lock) (decf inside)))))
+        (let ((threads (loop repeat 5
+                             collect (bt:make-thread #'body :name "probe"))))
+          (dolist (th threads) (bt:join-thread th))))
+      (ok (= max-inside 1)
+          "at most one thread was inside the load-lock critical section"))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -8,7 +8,8 @@
   (:import-from #:rove #:deftest #:testing #:ok #:skip)
   (:import-from #:cl-mcp/src/worker/init-hook
                 #:*asdf-load-lock*
-                #:with-asdf-load-lock))
+                #:with-asdf-load-lock)
+  (:import-from #:cl-mcp/src/worker/handlers))
 
 (in-package #:cl-mcp/tests/worker-init-hook-test)
 
@@ -27,3 +28,23 @@
           (dolist (th threads) (bt:join-thread th))))
       (ok (= max-inside 1)
           "at most one thread was inside the load-lock critical section"))))
+
+(deftest load-system-handler-waits-on-lock
+  (testing "%handle-load-system blocks while *asdf-load-lock* is held, then completes"
+    (let ((started nil) (finished nil))
+      (bt:acquire-lock cl-mcp/src/worker/init-hook:*asdf-load-lock*)
+      (let ((th (bt:make-thread
+                 (lambda ()
+                   (setf started t)
+                   (let ((p (make-hash-table :test 'equal)))
+                     (setf (gethash "system" p) "alexandria"
+                           (gethash "force" p) nil)
+                     (cl-mcp/src/worker/handlers::%handle-load-system p))
+                   (setf finished t))
+                 :name "handler-under-lock")))
+        (sleep 0.2)
+        (ok started "handler thread started")
+        (ok (not finished) "handler is blocked while the load lock is held")
+        (bt:release-lock cl-mcp/src/worker/init-hook:*asdf-load-lock*)
+        (bt:join-thread th)
+        (ok finished "handler completed after the lock was released")))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -48,3 +48,22 @@
         (bt:release-lock cl-mcp/src/worker/init-hook:*asdf-load-lock*)
         (bt:join-thread th)
         (ok finished "handler completed after the lock was released")))))
+
+(deftest init-state-transitions
+  (testing "state starts idle, moves to loading/running/failed, snapshots as a hash-table"
+    (cl-mcp/src/worker/init-hook::%reset-init-state)
+    (let ((s0 (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s0) "idle") "starts idle"))
+    (cl-mcp/src/worker/init-hook::%set-init-state :loading)
+    (ok (string= (gethash "init_state"
+                          (cl-mcp/src/worker/init-hook::init-state-snapshot))
+                 "loading")
+        "loading")
+    (cl-mcp/src/worker/init-hook::%set-init-state :running :app-port 13000)
+    (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s) "running") "running")
+      (ok (eql (gethash "app_port" s) 13000) "app_port recorded"))
+    (cl-mcp/src/worker/init-hook::%set-init-state :failed :error "boom")
+    (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s) "failed") "failed")
+      (ok (string= (gethash "last_init_error" s) "boom") "error recorded"))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -9,7 +9,13 @@
   (:import-from #:cl-mcp/src/worker/init-hook
                 #:*asdf-load-lock*
                 #:with-asdf-load-lock)
-  (:import-from #:cl-mcp/src/worker/handlers))
+  (:import-from #:cl-mcp/src/worker/handlers
+                #:register-all-handlers)
+  (:import-from #:cl-mcp/src/worker/server
+                #:make-worker-server
+                #:server-port
+                #:start-accept-loop
+                #:stop-server))
 
 (in-package #:cl-mcp/tests/worker-init-hook-test)
 
@@ -92,3 +98,90 @@
             (progn (cl-mcp/src/worker/init-hook::%resolve-entry "CL:NO-SUCH-SYMBOL-XYZ") nil)
           (error () t))
         "missing symbol errors")))
+
+(defun socket-available-p ()
+  "Return T if we can bind a TCP socket on localhost."
+  (handler-case
+      (let ((sock (usocket:socket-listen "127.0.0.1" 0
+                                         :reuse-address t
+                                         :element-type 'character)))
+        (unwind-protect t (ignore-errors (usocket:socket-close sock))))
+    (error () nil)))
+
+(defparameter *entry-ran* nil)
+
+(defun integration-entry-thunk () (setf *entry-ran* t) 12345)
+
+(defun %rpc (stream id method &optional params)
+  "Send one JSON-RPC line and read one response line; return the parsed hash."
+  (let ((req (make-hash-table :test 'equal)))
+    (setf (gethash "jsonrpc" req) "2.0"
+          (gethash "id" req) id
+          (gethash "method" req) method)
+    (when params (setf (gethash "params" req) params))
+    (yason:encode req stream) (terpri stream) (force-output stream)
+    (yason:parse (read-line stream))))
+
+(deftest init-start-then-status-integration
+  (testing "worker/init-start acks fast; init runs the entry; status reaches running"
+    (if (not (socket-available-p))
+        (skip "socket unavailable")
+        (let ((server (make-worker-server :port 0)))
+          (register-all-handlers server)
+          (setf *entry-ran* nil)
+          (cl-mcp/src/worker/init-hook::%reset-init-state)
+          (unwind-protect
+               (let ((port (server-port server)))
+                 (bt:make-thread (lambda () (start-accept-loop server))
+                                 :name "test-init-accept")
+                 (sleep 0.1)
+                 (let ((socket (usocket:socket-connect "127.0.0.1" port
+                                                       :element-type 'character)))
+                   (unwind-protect
+                        (let* ((stream (usocket:socket-stream socket))
+                               (params (make-hash-table :test 'equal)))
+                          (setf (gethash "entry" params)
+                                "CL-MCP/TESTS/WORKER-INIT-HOOK-TEST:INTEGRATION-ENTRY-THUNK")
+                          (let ((ack (%rpc stream 1 "worker/init-start" params)))
+                            (ok (gethash "accepted" (gethash "result" ack))
+                                "init-start acked with accepted=t"))
+                          (let ((final nil))
+                            (loop repeat 50
+                                  for st = (gethash "result"
+                                            (%rpc stream 2 "worker/init-status"))
+                                  for state = (gethash "init_state" st)
+                                  do (setf final state)
+                                  until (member state '("running" "failed")
+                                                :test #'string=)
+                                  do (sleep 0.05))
+                            (ok (string= final "running") "init reached running")
+                            (ok *entry-ran* "entry thunk executed")
+                            (ok (eql (gethash "app_port"
+                                              (gethash "result"
+                                                       (%rpc stream 3
+                                                             "worker/init-status")))
+                                     12345)
+                                "app_port recorded")))
+                     (ignore-errors (usocket:socket-close socket)))))
+            (stop-server server))))))
+
+(deftest init-eval-failure-records-failed
+  (testing "an erroring eval form drives init to :failed with the message recorded"
+    (cl-mcp/src/worker/init-hook::%reset-init-state)
+    (let ((params (make-hash-table :test 'equal)))
+      (setf (gethash "eval" params) "(error \"boom\")")
+      ;; %run-init runs synchronously here and never signals out; on an
+      ;; eval error it records :failed via the outer handler-case.
+      (cl-mcp/src/worker/init-hook::%run-init params))
+    (let ((s (cl-mcp/src/worker/init-hook::init-state-snapshot)))
+      (ok (string= (gethash "init_state" s) "failed") "init state is failed")
+      (let ((err (gethash "last_init_error" s)))
+        (ok err "last_init_error is non-nil")
+        (ok (and (stringp err) (search "boom" err)) "message mentions boom")
+        ;; These two discriminate the %maybe-eval fix: if it reverted to
+        ;; dumping the raw error-context plist, the string would be long and
+        ;; would contain the :RESTARTS key.  The clean short message must not.
+        (ok (< (length err) 80)
+            "message is the clean short string, not a raw plist dump")
+        (ok (null (search "RESTARTS" (string-upcase err)))
+            "no raw error-context plist leaked")))))


### PR DESCRIPTION
## Summary

Adds a **worker-startup init hook**: an app (e.g. a web server) can auto-start inside the cl-mcp worker elected as the single **runtime owner** for a session, so the parent keeps the persistent `/mcp` endpoint while hot-reload (`load-system`/`repl-eval`) lands in the app's own process. `pool-kill-worker` restarts the dev runtime without dropping `/mcp`.

- **Worker side** (`src/worker/init-hook.lisp`, `handlers.lisp`): worker-global `*asdf-load-lock*` serializing all cl-mcp-mediated loads (`worker/init`, `load-system`, `run-tests`); init state machine; `%resolve-entry` (find-package/find-symbol, no eval/intern); `%run-init` (background thread, `timeout=nil` direct-branch load so no `destroy-thread` mid-compile, never signals out); `worker/init-start` (fast ack) + `worker/init-status` RPCs.
- **Parent side** (`src/pool.lisp`): `MCP_WORKER_INIT_*` config; **session-bound single-owner election** with an affinity-map session-liveness guard so ownership never migrates to a different *live* session (L4); `%ensure-runtime-init` (elect → fire-and-forget init-start → status monitor with backoff, owner-guarded state mutations); wiring into `get-or-assign-worker` (fresh bind), `%handle-worker-crash` (recovery re-fire, respects the disable latch), `release-session`/`kill-session-worker` (release ownership before kill; kill re-arms the latch); **crash-breaker exclusion** of init-attributable crashes; `pool-status` init fields.
- **Cross-cutting**: `MCP_WORKER_INIT_*` env denylist (parent-only, not leaked to workers); pool-off startup warning; README docs.
- **Inert when `MCP_WORKER_INIT_SYSTEM` is unset** (default) — no behavior change for existing users.

Design & go/no-go bar in `docs/plans/2026-07-05-worker-init-hook-design.md` (local). All four required v1 correctness fixes are present; multiple real defects (L4 migration, init-start crash breaker gap, monitor thread silent death, external-kill misattribution, permanent quarantine, dead re-arm) were caught and fixed during review.

## Test Plan

- [x] `rove cl-mcp.asd` → all tests pass (52 systems green, exit 0)
- [x] Force-compile clean: `(asdf:compile-system :cl-mcp :force t)` — zero warnings attributable to feature files
- [x] `mallet src/*.lisp` clean
- New tests:
  - `tests/worker-init-hook-test.lisp` — load-lock serialization, init state machine, entry resolution, `init-start`→`init-status` integration (real in-process server), eval-failure accounting
  - `tests/pool-init-config-test.lisp` — config parse, env denylist, pool-off guard, owner election incl. the L4 refuse-migration case (real spawned worker) and the session-liveness discriminator, ownership release, `%ensure-runtime-init` happy + failed-accounting, get-or-assign/kill wiring, breaker exclusion, pool-status fields

## Known v1 limitations (documented in README)

- **Single-session / `singleton` only**: a narrow multi-session ownership-migration race remains (owner worker crashes in the same window a second session binds); a future per-worker/ephemeral-port mode is planned.
- **Reset is lazy**: after `pool-kill-worker` the app re-inits on the session's next tool call (not eagerly); the parent `/mcp` endpoint stays up throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)