### PR TITLE
fix(lisp-patch-form): route post-prologue failures through the tool-error shape

### DIFF
--- a/src/lisp-edit-form-core.lisp
+++ b/src/lisp-edit-form-core.lisp
@@ -277,7 +277,7 @@ before TARGET's start position."
 
 (defun %locate-target-form (file-path form-type form-name readtable)
   "Shared prologue: resolve paths, read file, parse, find target, extract snippet.
-Returns seven values:
+Returns eight values:
   ABS — absolute pathname
   REL — relative namestring for FS write
   ORIGINAL — full file text

--- a/src/lisp-patch-form.lisp
+++ b/src/lisp-patch-form.lisp
@@ -18,7 +18,7 @@
   (:import-from #:cl-mcp/src/state
                 #:protocol-version)
   (:import-from #:cl-mcp/src/tools/helpers
-                #:make-ht #:result #:text-content
+                #:make-ht #:result #:rpc-error #:text-content
                 #:arg-validation-error #:tool-error #:json-bool)
   (:import-from #:cl-mcp/src/tools/define-tool
                 #:define-tool)
@@ -150,11 +150,8 @@ to use for parsing the file."
   (unless (member dry-run '(t nil))
     (error "dry-run must be boolean"))
   (multiple-value-bind (abs rel original nodes target target-snippet _ file-package-name)
-      (handler-case
-          (%locate-target-form file-path form-type form-name readtable)
-        (error (e)
-          (error 'patch-operation-error
-                 :reason (format nil "~A" e))))
+      (%locate-target-form file-path form-type form-name readtable)
+    (declare (ignore _))
     (multiple-value-bind (updated modified-form)
         (%apply-patch-operation original target old-text new-text)
       (let ((would-change (not (string= original updated))))
@@ -266,8 +263,27 @@ is used instead of Eclector, which means comments are NOT preserved."))
                                "content" (text-content summary)
                                (when changed-p
                                  (list "delta" (- (length new_text) (length old_text)))))))))
+      ;; CLAUSE ORDER IS LOAD-BEARING. PATCH-OPERATION-ERROR and
+      ;; ARG-VALIDATION-ERROR are both subtypes of ERROR, so both must stay
+      ;; ahead of the generic clause; reordering silently changes the response
+      ;; shape of every expected failure rather than breaking the build.
       (patch-operation-error (e)
         (tool-error id
                     (sanitize-for-json
                      (sanitize-error-message (format nil "~A" e)))
-                    :protocol-version (protocol-version state))))))
+                    :protocol-version (protocol-version state)))
+      ;; Re-signal so DEFINE-TOOL's own ARG-VALIDATION-ERROR clause formats it;
+      ;; otherwise the generic clause below would swallow genuine argument
+      ;; errors and misreport them as internal failures. HANDLER-CASE unwinds
+      ;; before running a handler body, so this re-signal cannot re-enter the
+      ;; clauses above or below it — it necessarily reaches DEFINE-TOOL's
+      ;; generated HANDLER-CASE.
+      (arg-validation-error (e)
+        (error e))
+      (error (e)
+        (let ((msg (sanitize-for-json
+                    (sanitize-error-message (format nil "~A" e)))))
+          (if (and (protocol-version state)
+                   (string>= (protocol-version state) "2025-11-25"))
+              (result id (make-ht "content" (text-content msg) "isError" t))
+              (rpc-error id -32603 msg)))))))

--- a/tests/lisp-patch-form-test.lisp
+++ b/tests/lisp-patch-form-test.lisp
@@ -40,6 +40,47 @@ then clean up."
          (funcall thunk abs)
       (ignore-errors (delete-file abs)))))
 
+(defun %directory-writable-p (dir)
+  "Return T when a probe file can be created inside DIR.
+Used to detect processes (e.g. root) for which chmod does not deny writes."
+  (let ((probe (merge-pathnames* ".cl-mcp-write-probe"
+                                 (uiop:ensure-directory-pathname dir))))
+    (handler-case
+        (progn
+          (with-open-file (stream probe :direction :output
+                                        :if-exists :supersede
+                                        :if-does-not-exist :create)
+            (write-char #\x stream))
+          (ignore-errors (delete-file probe))
+          t)
+      (error () nil))))
+
+(defun with-readonly-temp-file (relative initial thunk)
+  "Create RELATIVE with INITIAL content, make it and its directory read-only,
+then call THUNK with the absolute path. Permissions are restored and the
+fixture removed even when THUNK signals, so a failing test cannot leave the
+tree unwritable. When permissions are not enforced for this process (e.g.
+running as root), THUNK is skipped instead."
+  (let* ((abs (project-path relative))
+         (dir (native-namestring (uiop:pathname-directory-pathname abs)))
+         (dir-pre-existed (probe-file dir)))
+    (ensure-directories-exist abs)
+    (fs-write-file relative initial)
+    (unwind-protect
+         (progn
+           (uiop:run-program (list "chmod" "444" abs))
+           (uiop:run-program (list "chmod" "555" dir))
+           (if (%directory-writable-p dir)
+               (skip "filesystem permissions are not enforced for this process")
+               (funcall thunk abs)))
+      (ignore-errors (uiop:run-program (list "chmod" "755" dir)))
+      (ignore-errors (uiop:run-program (list "chmod" "644" abs)))
+      (ignore-errors (delete-file abs))
+      ;; Only remove the directory when this call created it, so a caller
+      ;; passing a path directly under tests/tmp cannot rmdir the shared dir.
+      (unless dir-pre-existed
+        (ignore-errors (uiop:delete-empty-directory dir))))))
+
 (defun %try-load (system)
   "Attempt to load SYSTEM via Quicklisp or ASDF. Returns T on success, NIL on failure."
   (handler-case
@@ -514,3 +555,114 @@ then clean up."
             (ok err "old protocol should produce rpc error for empty old_text")
             (ok (eql -32602 (gethash "code" err))
                 "error code should be -32602 not -32603")))))))
+
+(deftest lisp-patch-form-handler-form-not-found-tool-error
+  (testing "form not found at 2025-11-25 returns isError, not an internal error"
+    (with-temp-file "tests/tmp/patch-handler-form-not-found.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (let ((state (cl-mcp/src/state:make-state))
+              (handler #'cl-mcp/src/lisp-patch-form::lisp-patch-form-handler)
+              (args (cl-mcp/src/tools/helpers:make-ht
+                     "file_path" path
+                     "form_type" "defun"
+                     "form_name" "no-such-form-xyzzy"
+                     "old_text" "(+ x 1)"
+                     "new_text" "(* x 2)")))
+          (setf (cl-mcp/src/state:protocol-version state) "2025-11-25")
+          (let* ((response (funcall handler state "test-nf-1" args))
+                 (result-obj (gethash "result" response))
+                 (content (and result-obj (gethash "content" result-obj)))
+                 (text (and content (> (length content) 0)
+                            (gethash "text" (aref content 0)))))
+            (ng (gethash "error" response)
+                "form-not-found at 2025-11-25 should not produce an rpc error")
+            (ok result-obj "response should have result field")
+            (ok (and result-obj (gethash "isError" result-obj))
+                "result should have isError = true")
+            (ok (and text (search "not found" text))
+                "message should say the form was not found")
+            (ok (and text (null (search "Internal error during" text)))
+                "message must not carry an internal-error prefix")))))))
+
+(deftest lisp-patch-form-handler-form-not-found-legacy-protocol
+  (testing "form not found on a legacy protocol returns -32603, as lisp-edit-form does"
+    (with-temp-file "tests/tmp/patch-handler-form-not-found-legacy.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (let ((state (cl-mcp/src/state:make-state))
+              (handler #'cl-mcp/src/lisp-patch-form::lisp-patch-form-handler)
+              (args (cl-mcp/src/tools/helpers:make-ht
+                     "file_path" path
+                     "form_type" "defun"
+                     "form_name" "no-such-form-xyzzy"
+                     "old_text" "(+ x 1)"
+                     "new_text" "(* x 2)")))
+          (setf (cl-mcp/src/state:protocol-version state) "2025-06-18")
+          (let* ((response (funcall handler state "test-nf-2" args))
+                 (err (gethash "error" response))
+                 (message (and err (gethash "message" err))))
+            (ok err "legacy protocol should produce an rpc error")
+            (ok (eql -32603 (gethash "code" err))
+                "form-not-found is an internal error, not invalid params")
+            (ok (and message (search "not found" message))
+                "message should say the form was not found")
+            (ok (and message (null (search "Internal error during" message)))
+                "message must not carry an internal-error prefix")))))))
+
+(deftest lisp-patch-form-handler-post-prologue-failure-tool-error
+  (testing "unwritable target at 2025-11-25 returns isError without an internal-error prefix"
+    (with-readonly-temp-file "tests/tmp/patch-readonly/target.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (let ((state (cl-mcp/src/state:make-state))
+              (handler #'cl-mcp/src/lisp-patch-form::lisp-patch-form-handler)
+              (args (cl-mcp/src/tools/helpers:make-ht
+                     "file_path" path
+                     "form_type" "defun"
+                     "form_name" "target"
+                     "old_text" "(+ x 1)"
+                     "new_text" "(* x 2)")))
+          (setf (cl-mcp/src/state:protocol-version state) "2025-11-25")
+          (let* ((response (funcall handler state "test-pp-1" args))
+                 (result-obj (gethash "result" response))
+                 (content (and result-obj (gethash "content" result-obj)))
+                 (text (and content (> (length content) 0)
+                            (gethash "text" (aref content 0)))))
+            (ng (gethash "error" response)
+                "post-prologue failure at 2025-11-25 should not produce an rpc error")
+            (ok result-obj "response should have result field")
+            (ok (and result-obj (gethash "isError" result-obj))
+                "result should have isError = true")
+            (ok (and text (null (search "Internal error during" text)))
+                "message must not carry an internal-error prefix")
+            ;; Deliberately not asserting on the errno text: that comes from
+            ;; glibc strerror and is localized by LC_MESSAGES. Assert on the
+            ;; fixture path instead, which is ours and locale-stable.
+            (ok (and text (search "patch-readonly" text))
+                "message should name the file that could not be written")))))))
+
+(deftest lisp-patch-form-handler-post-prologue-failure-legacy-protocol
+  (testing "unwritable target on a legacy protocol returns a bare -32603"
+    (with-readonly-temp-file "tests/tmp/patch-readonly-legacy/target.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (let ((state (cl-mcp/src/state:make-state))
+              (handler #'cl-mcp/src/lisp-patch-form::lisp-patch-form-handler)
+              (args (cl-mcp/src/tools/helpers:make-ht
+                     "file_path" path
+                     "form_type" "defun"
+                     "form_name" "target"
+                     "old_text" "(+ x 1)"
+                     "new_text" "(* x 2)")))
+          (setf (cl-mcp/src/state:protocol-version state) "2025-06-18")
+          (let* ((response (funcall handler state "test-pp-2" args))
+                 (err (gethash "error" response))
+                 (message (and err (gethash "message" err))))
+            (ok err "legacy protocol should produce an rpc error")
+            (ok (eql -32603 (gethash "code" err))
+                "post-prologue failure is an internal error")
+            (ok (and message (null (search "Internal error during" message)))
+                "message must not carry an internal-error prefix")
+            (ok (and message (search "patch-readonly-legacy" message))
+                "message should name the file that could not be written")))))))


### PR DESCRIPTION
PR #122 のレビュー中に見つかった不整合の修正。`main` から独立しており #122 とファイル重複なし。

## 出発点の訂正

当初の問題提起は「`lisp-patch-form` はフォーム未検出を `Internal error during` で包む」だったが、
**これは事実と異なる**。実測すると既にクリーンだった:

```
form_name が存在しない、protocol 2025-11-25:
  {"result":{"content":[{"type":"text","text":"Form defun no-such-form-xyzzy not found in ..."}],"isError":true}}
```

`lisp-patch-form` 関数が `%locate-target-form` の任意のエラーを `patch-operation-error` に
再ラップし、ツール本体が `tool-error` に流していた。2025-11-25 では `lisp-edit-form` と同一。

なぜ report が食い違ったかも判明した。**2日違いの2コミットが正反対の判断をしている**:

```
2026-03-09 9cbf8b2  fix(lisp-edit-form): preserve -32603 for execution errors on old protocols
2026-03-11 001cf91  fix(lisp-patch-form): use -32602 for operational errors, not -32603
```

双方に、相手が誤りだと主張する回帰テストが付いている。

## 実在した2つの欠陥

ハンドラを両プロトコルバージョンで駆動して測定。

**1. プロローグ以降の失敗が `-32603` に逃げる。** ツール本体の `handler-case` に
`patch-operation-error` 節しかなかったため、`%locate-target-form` より後で発生した失敗
（書き込み権限エラー等）が `define-tool` の catch-all に落ち、**2025-11-25 でも**
`Internal error during lisp-patch-form:` が付いていた。MCP クライアントが描画しない形。

| | 修正前 | 修正後 |
|---|---|---|
| patch @2025-11-25 | `-32603` + `Internal error during` 前置 | `{content, isError}` |
| edit @2025-11-25（参照） | `{content, isError}` | 変更なし — 両者一致 |

**2. プロローグの `handler-case` が内部失敗を「Invalid params」と誤分類。** 裸の `error` を
捕捉して全て `patch-operation-error` に化かしていたため、`can't read #. while *READ-EVAL* is NIL`
や `couldn't read from : Is a directory` が `-32602` になっていた。これは
`patch-operation-error` を導入したコミット 2f96803 自身が掲げた設計
（"expected failures ... **separate from internal errors**"）に反する。

`lisp-patch-form` はコードベースで**唯一**、操作上の失敗に `-32602` を返すツールだった。

## 変更の影響範囲

| ケース | 修正前 | 修正後 |
|---|---|---|
| プロローグ以降の失敗 @2025-11-25 | `-32603` + 前置 | `{content, isError}` |
| フォーム未検出 @legacy | `-32602` | `-32603`（`lisp-edit-form` に整合、意図的） |
| リーダー内部失敗 @legacy | `-32602` | `-32603` |
| フォーム未検出 @2025-11-25 | `{content, isError}` | **変更なし** |
| `old_text` 未検出 / 複数一致 / 空 | `-32602` / `{content, isError}` | **変更なし** |

`arg-validation-error` も `error` の部分型なので、明示的な再 signal 節を追加している。
これが無いと空の `old_text` が `-32602` から `-32603` に退行する。`tool-error` を
インライン展開せず再 signal にしたのは、`define-tool` の生成節を「`arg-validation-error` を
どう描画するか」の単一の定義として残すため。

## テスト

このパスの回帰テストは**ゼロ件**だった（既存の `form_name` は全て fixture 内に実在するもの）。
4件追加し、うち3件は基準コミットのソースを差し戻すと失敗することを確認済み。
残り1件は「経路を付け替えても 2025-11-25 の形が保たれる」ことのガードで、修正なしでも通る。

`rove cl-mcp.asd` を他プロセスが走っていない状態で実行し exit 0（3021 ✓ / 0 ✗、53システム、
pool/worker 8スイート全てクリーン）。`compile-system :force t` で cl-mcp 起因の警告0件。

## 意図的にスコープ外としたもの

- **`patch-operation-error` 経路の legacy コード統一**。上記2コミットの意見対立であり、
  どちらかを選ぶことは片方の回帰テストを消すこと。バグ修正ではなく製品判断
- 調査で見つかった別系統の不整合2件。どちらも**同一ファミリ内の矛盾**で、今回の
  edit/patch 間の差より紛らわしい。別 issue にする価値がある
  - `code-find` は未検出を `{content, isError}` で返すが、兄弟の `code-describe` は `-32603`
  - `clhs-lookup` はセクション未検出が `isError`、シンボル未検出が `-32603`

## 付随的な変更

- `(declare (ignore _))` を追加。編集対象の `multiple-value-bind` が出していた
  STYLE-WARNING を解消する。**この警告は本ブランチ以前から存在し**（`7d65be7` の
  ファイルを単独コンパイルして確認）、ASDF の通常出力では見えない
- `src/lisp-edit-form-core.lisp` の `%locate-target-form` docstring が
  "Returns seven values" と書いた上で8つ列挙していたのを訂正。上記の `declare` の
  正しさがこの一覧に依存するため

## 検証できなかった点

テスト内の errno 文字列アサーションをロケール非依存な内容に置き換えたが、
**SBCL では元々問題にならなかった**ことが判明している。SBCL は `setlocale` を呼ばないため
終始 `C` ロケールで動作する（同一環境で SBCL は `LC_MESSAGES => "C"`、Python は
`en_GB.utf8` を報告する対照実験で確認）。潜在的な設計上の匂いの解消であって、
実バグの修正ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)