### PR TITLE
fix(clgrep): classify user-defined defining macros; reach dependency sources

### DIFF
--- a/src/clgrep.lisp
+++ b/src/clgrep.lisp
@@ -5,7 +5,7 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:import-from #:cl-mcp/src/utils/paths
-                #:resolve-path-in-project)
+                #:resolve-readable-path)
   (:import-from #:cl-mcp/src/utils/hash
                 #:alist-to-hash-table)
   (:import-from #:cl-mcp/src/utils/clgrep
@@ -19,7 +19,9 @@
 
 (in-package #:cl-mcp/src/clgrep)
 
-;; Path resolution is now handled by cl-mcp/src/utils/paths:resolve-path-in-project
+;; Path resolution is handled by cl-mcp/src/utils/paths:resolve-readable-path,
+;; which accepts registered ASDF system source directories as well as the
+;; project root (clgrep-search is read-only, same policy as the read tools).
 
 (defun %normalize-result (result base-path)
   "Normalize a single search result, making file paths relative to BASE-PATH."
@@ -45,7 +47,10 @@ Accepts a list of strings, a vector of strings, a single string, or NIL."
 
 Arguments:
   PATTERN          - cl-ppcre regular expression pattern (required)
-  PATH             - Search root directory, relative to project root (optional)
+  PATH             - Search root directory (optional, defaults to project root).
+                     Relative paths are merged with the project root; absolute
+                     paths are accepted when inside the project root or inside
+                     the source directory of a registered ASDF system
   RECURSIVE        - Search subdirectories recursively (default: T)
   CASE-INSENSITIVE - Case-insensitive matching (default: NIL)
   FORM-TYPES       - Filter by form types, e.g., '(\"defun\" \"defmethod\") (optional)
@@ -53,7 +58,7 @@ Arguments:
   INCLUDE-FORM     - If true, include full form text in results (default: NIL)
 
 Returns a list of alists, each containing:
-  :file            - File path (relative to project root)
+  :file            - File path (relative to the search root PATH)
   :line            - Line number of the match
   :match           - The matching line text
   :package         - Package name active at that line
@@ -67,7 +72,7 @@ Returns a list of alists, each containing:
             (zerop (length (string-trim '(#\Space #\Tab) pattern))))
     (error "Pattern cannot be empty"))
   (let* ((effective-limit (or limit 200))
-         (search-path (resolve-path-in-project path :must-exist t))
+         (search-path (resolve-readable-path path :must-exist t))
          (types (%parse-form-types form-types))
          (results (semantic-grep search-path pattern
                                  :recursive recursive
@@ -132,7 +137,10 @@ Recommended workflow:
   :args ((pattern :type :string :required t
                   :description "cl-ppcre regular expression pattern to search for")
          (path :type :string
-               :description "Search root directory, relative to project root (optional, defaults to project root)")
+               :description "Search root directory (optional, defaults to project root).
+Relative paths resolve against the project root. An absolute path is accepted when it is
+inside the project root or inside the source directory of a registered ASDF system, so a
+dependency's sources can be searched the same way lisp-read-file can read them.")
          (recursive :type :boolean :default t
                     :description "Search subdirectories recursively (default: true)")
          (case-insensitive :type :boolean :json-name "case_insensitive"

--- a/src/code.lisp
+++ b/src/code.lisp
@@ -73,6 +73,9 @@ PREREQUISITE: The defining system MUST be loaded first (load-system tool).
 Use package-qualified symbols when possible; set project_only=false to include
 external libs.
 
+Each reported line points at the start of the enclosing function's definition,
+not at the exact call site; the 'caller' field names that function.
+
 For simple text-based usage search WITHOUT loading systems, use 'clgrep-search' instead."
   :args ((symbol :type :string :required t
                  :description "Symbol name like \"cl-mcp:run\" (package-qualified preferred)")

--- a/src/project-scaffold.lisp
+++ b/src/project-scaffold.lisp
@@ -198,7 +198,10 @@ cl-mcp's tool surface."
              (next-steps
               (vector
                (format nil
-                       "Auto-registered with ASDF. To re-register: (asdf:load-asd ~S)"
+                       "ASDF registration happened in the cl-mcp parent ~
+                        process only; run load-system to register it in ~
+                        this session's worker (or (asdf:load-asd ~S) via ~
+                        repl-eval)"
                        abs-asd)
                (format nil
                        "To load: run load-system with {\"system\": ~S}"

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -326,32 +326,34 @@ NIL the symbol was not found and an isError payload is returned."
 
 (defun build-code-find-references-response (symbol refs count project-only)
   "Build the standard code-find-references response hash-table.
-Summary text shows each reference as \"<path> (used in <caller>) [type]\"
-so users see the enclosing function name instead of a potentially
-misleading line snippet. The raw path, line, type, caller, and context
-fields remain in the structured \"refs\" payload for programmatic use."
+Summary text shows each reference as \"<path>:<line> (used in <caller>) [type]\",
+falling back to \"<path>:<line> [type]\" when the caller is unknown or is an
+anonymous lambda. The line keeps every row clickable and sortable; the caller
+name says which function the reference sits in. As documented on
+CL-MCP/SRC/CODE-CORE:CODE-FIND-REFERENCES, the line points at the start of the
+enclosing function rather than at the exact call site. The raw path, line,
+type, caller, and context fields remain in the structured \"refs\" payload for
+programmatic use."
   (let* ((summary-lines
-           (map 'list
-                (lambda (h)
-                  (let ((path (gethash "path" h))
-                        (caller (gethash "caller" h))
-                        (type (gethash "type" h))
-                        (line (gethash "line" h)))
-                    (cond
-                      ((and caller (plusp (length caller))
-                            (string/= caller "(lambda)"))
-                       (format nil "~A (used in ~A) [~A]" path caller type))
-                      (t
-                       (format nil "~A:~A [~A]" path line type)))))
-                refs))
-         (summary (if summary-lines
-                      (format nil "~{~A~%~}" summary-lines)
-                      "")))
-    (make-ht "refs" refs
-             "count" count
-             "symbol" symbol
-             "project_only" project-only
-             "content" (text-content summary))))
+          (map 'list
+               (lambda (h)
+                 (let ((path (gethash "path" h))
+                       (caller (gethash "caller" h))
+                       (type (gethash "type" h))
+                       (line (gethash "line" h)))
+                   (cond
+                    ((and caller (plusp (length caller))
+                          (string/= caller "(lambda)"))
+                     (format nil "~A:~A (used in ~A) [~A]" path line caller
+                             type))
+                    (t (format nil "~A:~A [~A]" path line type)))))
+               refs))
+         (summary
+          (if summary-lines
+              (format nil "~{~A~%~}" summary-lines)
+              "")))
+    (make-ht "refs" refs "count" count "symbol" symbol "project_only"
+             project-only "content" (text-content summary))))
 
 (defun build-inspect-response (inspection-result)
   "Build the standard inspect-object response hash-table.

--- a/src/utils/clgrep.lisp
+++ b/src/utils/clgrep.lisp
@@ -361,27 +361,50 @@
     (or (and (>= (length n) 3) (string= n "DEF" :end1 3))
         (and (>= (length n) 7) (string= n "DEFINE-" :end1 7)))))
 
+(defun %strip-package-qualifier (head)
+  "Return HEAD without a leading package qualifier.
+
+   A defining macro is routinely invoked through its package -- (ROUTES:DEFINE-RULE
+   ...) outside the DSL's own package, and (ASDF:DEFSYSTEM ...) in this repository's
+   own .asd files.  The qualifier is a property of the call site, not of the form's
+   type, so it is dropped before the head is classified or reported.
+
+   Dropping it is also what keeps clgrep in step with src/lisp-read-file.lisp's
+   %DEFINITION-NAMES: that one reads the head with Eclector and looks at the
+   resulting symbol, so it only ever sees the SYMBOL-NAME and never the qualifier."
+  (let ((colon (position #\: head :from-end t)))
+    (if colon
+        (subseq head (1+ colon))
+        head)))
+
 (defun extract-form-type-and-name (form-text)
   "Extract the form type and name from FORM-TEXT.
    Returns an alist with :type and :name, or NIL if not a recognized form.
    A head is recognized when it is in *KNOWN-FORM-TYPES* or when it satisfies
    %DEFINITION-PREFIX-P, so user-defined defining macros classify too.
 
+   The head may carry a package qualifier; %STRIP-PACKAGE-QUALIFIER removes it
+   before either test runs, so the reported type is the one a caller filters on.
+
    Examples:
      (defun foo ...) => ((:type . \"defun\") (:name . \"foo\"))
      (defmethod bar ...) => ((:type . \"defmethod\") (:name . \"bar\"))
      (defvar *x* ...) => ((:type . \"defvar\") (:name . \"*x*\"))
-     (define-rule r ...) => ((:type . \"define-rule\") (:name . \"r\"))"
+     (define-rule r ...) => ((:type . \"define-rule\") (:name . \"r\"))
+     (routes:define-rule r ...) => ((:type . \"define-rule\") (:name . \"r\"))"
   (let ((trimmed (string-trim '(#\Space #\Tab #\Newline) form-text)))
     (when (and (> (length trimmed) 0)
                (char= (char trimmed 0) #\())
-      ;; Extract the first token (form type) and second token (name)
+      ;; Extract the first token (form type) and second token (name).  The head
+      ;; group admits an optional PACKAGE: or PACKAGE:: prefix; without it the
+      ;; colon ends the match and a qualified head parses as no form at all.
       (multiple-value-bind (match groups)
           (cl-ppcre:scan-to-strings
-           "^\\(\\s*([a-zA-Z][a-zA-Z0-9*_+-]*)\\s+([^\\s()]+|\\([^)]+\\))"
+           "^\\(\\s*([a-zA-Z][a-zA-Z0-9*_+-]*(?::{1,2}[a-zA-Z*][a-zA-Z0-9*_+-]*)?)\\s+([^\\s()]+|\\([^)]+\\))"
            trimmed)
         (when match
-          (let ((form-type (string-downcase (aref groups 0)))
+          (let ((form-type (%strip-package-qualifier
+                            (string-downcase (aref groups 0))))
                 (form-name (aref groups 1)))
             ;; *KNOWN-FORM-TYPES* still matters for heads no prefix rule can
             ;; catch, such as IN-PACKAGE.

--- a/src/utils/clgrep.lisp
+++ b/src/utils/clgrep.lisp
@@ -398,9 +398,11 @@
       ;; Extract the first token (form type) and second token (name).  The head
       ;; group admits an optional PACKAGE: or PACKAGE:: prefix; without it the
       ;; colon ends the match and a qualified head parses as no form at all.
+      ;; Dots and slashes are constituent characters, and every package in this
+      ;; repository is slash-delimited, so both sides of the colon accept them.
       (multiple-value-bind (match groups)
           (cl-ppcre:scan-to-strings
-           "^\\(\\s*([a-zA-Z][a-zA-Z0-9*_+-]*(?::{1,2}[a-zA-Z*][a-zA-Z0-9*_+-]*)?)\\s+([^\\s()]+|\\([^)]+\\))"
+           "^\\(\\s*([a-zA-Z][a-zA-Z0-9*_+./-]*(?::{1,2}[a-zA-Z*][a-zA-Z0-9*_+./-]*)?)\\s+([^\\s()]+|\\([^)]+\\))"
            trimmed)
         (when match
           (let ((form-type (%strip-package-qualifier
@@ -443,6 +445,18 @@
       (when (zerop depth)
         (values (subseq text start pos) pos)))))
 
+(defun %head-scan-pattern (form-type form-name)
+  "Return a regex anchoring a scan at the head of a FORM-TYPE definition of
+   FORM-NAME.
+
+   FORM-TYPE comes from EXTRACT-FORM-TYPE-AND-NAME, which strips any package
+   qualifier, so the pattern has to admit the qualifier again -- anchoring on
+   the bare type would fail to match the (CL:DEFUN ...) text it was derived
+   from and leave a classified form with no signature."
+  (format nil "^\\(\\s*(?:[^\\s():]+:{1,2})?~A\\s+~A\\s*"
+          (cl-ppcre:quote-meta-chars form-type)
+          (cl-ppcre:quote-meta-chars form-name)))
+
 (defun extract-form-signature (form-text)
   "Extract the signature from FORM-TEXT.
    Returns a string representing the signature, or NIL if not a recognized form.
@@ -462,9 +476,7 @@
                              "define-compiler-macro" "deftest")
                  :test #'string=)
          (let* ((trimmed (string-trim '(#\Space #\Tab #\Newline) form-text))
-                (name-pattern (format nil "^\\(\\s*~A\\s+~A\\s*"
-                                      (cl-ppcre:quote-meta-chars form-type)
-                                      (cl-ppcre:quote-meta-chars form-name)))
+                (name-pattern (%head-scan-pattern form-type form-name))
                 (name-end (nth-value 1 (cl-ppcre:scan name-pattern trimmed))))
            (when name-end
              (multiple-value-bind (lambda-list end-pos)
@@ -483,8 +495,7 @@
         ;; Class definitions: name + superclasses
         ((string= form-type "defclass")
          (let* ((trimmed (string-trim '(#\Space #\Tab #\Newline) form-text))
-                (name-pattern (format nil "^\\(\\s*defclass\\s+~A\\s*"
-                                      (cl-ppcre:quote-meta-chars form-name)))
+                (name-pattern (%head-scan-pattern form-type form-name))
                 (name-end (nth-value 1 (cl-ppcre:scan name-pattern trimmed))))
            (when name-end
              (multiple-value-bind (superclasses end-pos)

--- a/src/utils/clgrep.lisp
+++ b/src/utils/clgrep.lisp
@@ -342,14 +342,36 @@
     "defsystem" "deftest")
   "List of known form type keywords to recognize.")
 
+(defun %definition-prefix-p (form-type)
+  "Return T when FORM-TYPE names a defining macro by prefix.
+
+   FORM-TYPE is the head token extracted from raw text, not a read symbol,
+   so the comparison is done on the string. This mirrors %DEFINITION-NAMES in
+   src/lisp-read-file.lisp exactly: a head whose name starts with DEF (or with
+   DEFINE-, which DEF already subsumes) counts as a definition. Keeping the two
+   rules identical is the point -- it is what lets clgrep classify user-defined
+   defining macros such as DEFINE-RULE or DEFTHING, and stops clgrep-search and
+   lisp-read-file from disagreeing about what a form is.
+
+   This rule has a known false positive: heads like DEFAULT or DEFER also start
+   with DEF and will be reported as definitions. %DEFINITION-NAMES already
+   accepts that risk, so clgrep adopts the same trade-off deliberately rather
+   than diverging."
+  (let ((n (string-upcase form-type)))
+    (or (and (>= (length n) 3) (string= n "DEF" :end1 3))
+        (and (>= (length n) 7) (string= n "DEFINE-" :end1 7)))))
+
 (defun extract-form-type-and-name (form-text)
   "Extract the form type and name from FORM-TEXT.
    Returns an alist with :type and :name, or NIL if not a recognized form.
+   A head is recognized when it is in *KNOWN-FORM-TYPES* or when it satisfies
+   %DEFINITION-PREFIX-P, so user-defined defining macros classify too.
 
    Examples:
      (defun foo ...) => ((:type . \"defun\") (:name . \"foo\"))
      (defmethod bar ...) => ((:type . \"defmethod\") (:name . \"bar\"))
-     (defvar *x* ...) => ((:type . \"defvar\") (:name . \"*x*\"))"
+     (defvar *x* ...) => ((:type . \"defvar\") (:name . \"*x*\"))
+     (define-rule r ...) => ((:type . \"define-rule\") (:name . \"r\"))"
   (let ((trimmed (string-trim '(#\Space #\Tab #\Newline) form-text)))
     (when (and (> (length trimmed) 0)
                (char= (char trimmed 0) #\())
@@ -361,7 +383,10 @@
         (when match
           (let ((form-type (string-downcase (aref groups 0)))
                 (form-name (aref groups 1)))
-            (when (member form-type *known-form-types* :test #'string=)
+            ;; *KNOWN-FORM-TYPES* still matters for heads no prefix rule can
+            ;; catch, such as IN-PACKAGE.
+            (when (or (member form-type *known-form-types* :test #'string=)
+                      (%definition-prefix-p form-type))
               (list (cons :type form-type)
                     (cons :name form-name)))))))))
 

--- a/src/utils/clgrep.lisp
+++ b/src/utils/clgrep.lisp
@@ -452,8 +452,14 @@
    FORM-TYPE comes from EXTRACT-FORM-TYPE-AND-NAME, which strips any package
    qualifier, so the pattern has to admit the qualifier again -- anchoring on
    the bare type would fail to match the (CL:DEFUN ...) text it was derived
-   from and leave a classified form with no signature."
-  (format nil "^\\(\\s*(?:[^\\s():]+:{1,2})?~A\\s+~A\\s*"
+   from and leave a classified form with no signature.
+
+   That same function also downcases the type, so the scan runs
+   case-insensitively: a source that spells the head (DEFUN ...) is classified
+   as DEFUN either way, and a case-sensitive anchor would find nothing to
+   measure the lambda list from.  Only the head is affected; FORM-NAME is
+   reported with the case the source used."
+  (format nil "(?i)^\\(\\s*(?:[^\\s():]+:{1,2})?~A\\s+~A\\s*"
           (cl-ppcre:quote-meta-chars form-type)
           (cl-ppcre:quote-meta-chars form-name)))
 

--- a/src/utils/paths.lisp
+++ b/src/utils/paths.lisp
@@ -13,6 +13,7 @@
            #:allowed-read-path
            #:ensure-write-path
            #:resolve-path-in-project
+           #:resolve-readable-path
            #:normalize-path-for-display
            #:broad-root-p))
 
@@ -150,6 +151,32 @@ Signals an error if PATH is outside project root."
       (unless (path-inside-p canonical base)
         (error "Path ~A is outside project root ~A" target base))
       canonical)))
+
+(declaim (ftype (function ((or null string pathname) &key (:must-exist boolean))
+                           pathname)
+                resolve-readable-path))
+
+(defun resolve-readable-path (path &key (must-exist nil))
+  "Resolve PATH to an absolute pathname that is readable per the read policy.
+Shares RESOLVE-PATH-IN-PROJECT's calling contract: a NIL or empty PATH resolves
+to *project-root*, a relative PATH is merged against it, MUST-EXIST signals when
+the target does not exist, and a disallowed PATH signals rather than returning
+NIL. The containment rule is ALLOWED-READ-PATH's instead: subpaths of
+*project-root* AND source directories of registered ASDF systems are both
+accepted. Use this for read-only tools, which should reach the dependency
+sources that the read tools already expose."
+  (ensure-project-root)
+  (let* ((base *project-root*)
+         (target (if (or (null path) (and (stringp path) (string= path "")))
+                     (uiop/pathname:ensure-directory-pathname base)
+                     (canonical-path path))))
+    (when (and must-exist
+               (null (handler-case (truename target) (file-error () nil))))
+      (error "Path does not exist: ~A" target))
+    (or (allowed-read-path target)
+        (error "Path ~A is outside project root ~A and outside the source ~
+                directory of every registered ASDF system"
+               target base))))
 
 (declaim (ftype (function ((or null string pathname)) (or null string))
                 normalize-path-for-display))

--- a/tests/clgrep-test.lisp
+++ b/tests/clgrep-test.lisp
@@ -163,3 +163,44 @@
         ;; Single file results should all be from fs.lisp
         (dolist (r single-file-results)
           (ok (search "fs.lisp" (cdr (assoc :file r)))))))))
+
+(deftest clgrep-search-accepts-registered-asdf-system-directory
+  (testing "an absolute path inside a registered ASDF system outside the project root is searched"
+    ;; clgrep-search is read-only, so it uses the same policy as the read tools
+    ;; (lisp-read-file / fs-read-file): project root OR a registered system's
+    ;; source directory. Without this, discovery on a dependency was blocked
+    ;; while reading the very same files was allowed.
+    (let ((*project-root* (asdf:system-source-directory :cl-mcp))
+          (system-dir (asdf:system-source-directory :alexandria)))
+      (ok (not (uiop:subpathp system-dir *project-root*))
+          "alexandria must live outside the project root for this test to mean anything")
+      (let ((results (clgrep-search "defun" :path (namestring system-dir)
+                                    :recursive t :limit 5
+                                    :form-types '("defun"))))
+        (ok (listp results))
+        (ok (> (length results) 0)
+            "should find defun forms in the dependency's sources")
+        (dolist (r results)
+          (ok (string-equal "defun" (cdr (assoc :form-type r)))))))))
+
+(deftest clgrep-search-rejects-path-outside-every-allowed-root
+  (testing "a path in neither the project root nor a registered system still signals"
+    (let ((*project-root* (asdf:system-source-directory :cl-mcp)))
+      (let ((message (handler-case (progn (clgrep-search "defun" :path "/etc") nil)
+                       (error (e) (princ-to-string e)))))
+        (ok message "/etc must be rejected")
+        (ok (search "/etc" message)
+            (format nil "the error must name the rejected path, got: ~A" message))))))
+
+(deftest clgrep-search-path-default-and-relative-unchanged
+  (testing "omitting path searches the project root"
+    (let ((*project-root* (asdf:system-source-directory :cl-mcp)))
+      (let ((results (clgrep-search "clgrep-search" :recursive t :limit 10)))
+        (ok (listp results))
+        (ok (> (length results) 0)
+            "should find clgrep-search somewhere under the project root"))))
+  (testing "a relative path under the project root still resolves"
+    (let ((*project-root* (asdf:system-source-directory :cl-mcp)))
+      (let ((results (clgrep-search "defun" :path "src/" :recursive nil :limit 5)))
+        (ok (listp results))
+        (ok (> (length results) 0) "should find defun under src/")))))

--- a/tests/clgrep-utils-test.lisp
+++ b/tests/clgrep-utils-test.lisp
@@ -271,7 +271,23 @@ Final line
     ;; Non-recognized form
     (ok (null (extract-form-type-and-name "(my-custom-form foo)")))
     ;; Non-form string
-    (ok (null (extract-form-type-and-name "just some text")))))
+    (ok (null (extract-form-type-and-name "just some text"))))
+  (testing "should classify user-defined defining macros by DEF/DEFINE- prefix"
+    ;; A DSL macro that is not, and should not need to be, whitelisted.
+    (let ((result (extract-form-type-and-name
+                   "(define-rule non-empty (s) \"doc\" (plusp (length s)))")))
+      (ok (string= "define-rule" (cdr (assoc :type result))))
+      (ok (string= "non-empty" (cdr (assoc :name result)))))
+    ;; Bare DEF prefix, no hyphen.
+    (let ((result (extract-form-type-and-name "(defthing foo 1)")))
+      (ok (string= "defthing" (cdr (assoc :type result))))
+      (ok (string= "foo" (cdr (assoc :name result)))))
+    ;; in-package is the whitelist entry no prefix rule would ever catch.
+    (let ((result (extract-form-type-and-name "(in-package #:foo)")))
+      (ok (string= "in-package" (cdr (assoc :type result))))
+      (ok (string= "#:foo" (cdr (assoc :name result)))))
+    ;; Clearly not a definition: the head token parses but is rejected.
+    (ok (null (extract-form-type-and-name "(let ((x 1)) x)")))))
 
 (deftest test-semantic-grep-form-type-filter
   (testing "should filter results by form type"
@@ -290,6 +306,66 @@ Final line
                     "grep-file"
                     :form-types '("defclass"))))
       (ok (= 0 (length results))))))
+
+(defparameter *dsl-file-content*
+  "(in-package #:clgrep-dsl-demo)
+
+(define-rule non-empty (s)
+  \"value must be a non-empty string\"
+  (probe-value s))
+
+(defun probe-value (s)
+  (and (stringp s) (plusp (length s))))
+"
+  "A DSL-style source file whose top-level forms use a user-defined
+   defining macro that is not in *KNOWN-FORM-TYPES*.")
+
+(defmacro with-temp-dsl-project ((var) &body body)
+  "Create a temp directory holding one DSL source file, bind its path to VAR."
+  `(let ((,var (uiop:ensure-directory-pathname
+                (merge-pathnames
+                 (format nil "clgrep-dsl-~A-~A/"
+                         (get-universal-time) (random 1000000))
+                 (uiop:temporary-directory)))))
+     (unwind-protect
+         (progn
+           (ensure-directories-exist ,var)
+           (with-open-file (out (merge-pathnames "rules.lisp" ,var)
+                                :direction :output :if-exists :supersede)
+             (write-string *dsl-file-content* out))
+           ,@body)
+       (when (uiop:directory-exists-p ,var)
+         (uiop:delete-directory-tree ,var :validate t)))))
+
+(deftest test-semantic-grep-user-defined-form-type
+  (with-temp-dsl-project (dir)
+    (testing "user-defined defining macros are classified, not reported as NIL"
+      (let ((results (semantic-grep dir "probe-value" :include-form nil)))
+        (ok (= 2 (length results)))
+        (ok (every (lambda (r) (cdr (assoc :form-type r))) results)
+            "no result has a NIL form-type")
+        (let ((rule (find "define-rule" results
+                          :key (lambda (r) (cdr (assoc :form-type r)))
+                          :test #'equal)))
+          (ok rule "the define-rule form is classified")
+          (ok (string= "non-empty" (cdr (assoc :form-name rule)))))))
+    (testing "form-types filters on a user-defined type"
+      (let ((results (semantic-grep dir "probe-value"
+                                    :form-types '("define-rule")
+                                    :include-form nil)))
+        (ok (= 1 (length results)))
+        (ok (string= "define-rule" (cdr (assoc :form-type (first results)))))
+        (ok (string= "non-empty" (cdr (assoc :form-name (first results)))))))
+    (testing "form-types still excludes the rows of other types"
+      (let ((results (semantic-grep dir "probe-value"
+                                    :form-types '("defun")
+                                    :include-form nil)))
+        (ok (= 1 (length results)))
+        (ok (string= "probe-value" (cdr (assoc :form-name (first results)))))))
+    (testing "form-types with an absent type returns nothing"
+      (ok (null (semantic-grep dir "probe-value"
+                               :form-types '("define-endpoint")
+                               :include-form nil))))))
 
 (deftest test-extract-form-signature
   (testing "should extract signatures from various form types"

--- a/tests/clgrep-utils-test.lisp
+++ b/tests/clgrep-utils-test.lisp
@@ -287,7 +287,34 @@ Final line
       (ok (string= "in-package" (cdr (assoc :type result))))
       (ok (string= "#:foo" (cdr (assoc :name result)))))
     ;; Clearly not a definition: the head token parses but is rejected.
-    (ok (null (extract-form-type-and-name "(let ((x 1)) x)")))))
+    (ok (null (extract-form-type-and-name "(let ((x 1)) x)"))))
+  (testing "should classify package-qualified defining macro heads"
+    ;; A DSL macro reached through its package. The qualifier is dropped so the
+    ;; type equals what a caller filters on and what %DEFINITION-NAMES reports
+    ;; for the same form -- it reads the head as a symbol, so it only ever sees
+    ;; the SYMBOL-NAME.
+    (let ((result (extract-form-type-and-name
+                   "(routes:define-rule non-empty (s) \"doc\" (plusp (length s)))")))
+      (ok (string= "define-rule" (cdr (assoc :type result))))
+      (ok (string= "non-empty" (cdr (assoc :name result)))))
+    ;; Internal symbol, double colon.
+    (let ((result (extract-form-type-and-name "(routes::defthing foo 1)")))
+      (ok (string= "defthing" (cdr (assoc :type result))))
+      (ok (string= "foo" (cdr (assoc :name result)))))
+    ;; This repository's own .asd files use a qualified head.
+    (let ((result (extract-form-type-and-name
+                   "(asdf:defsystem \"cl-mcp\" :class :package-inferred-system)")))
+      (ok (string= "defsystem" (cdr (assoc :type result))))
+      (ok (string= "\"cl-mcp\"" (cdr (assoc :name result)))))
+    ;; A whitelist entry reached through its package classifies too.
+    (let ((result (extract-form-type-and-name "(cl:defun foo (x) x)")))
+      (ok (string= "defun" (cdr (assoc :type result))))
+      (ok (string= "foo" (cdr (assoc :name result)))))
+    ;; A qualified head that is not a definition is still rejected.
+    (ok (null (extract-form-type-and-name "(routes:apply-rules x)")))
+    ;; A keyword head is not a package qualifier: .asd component forms such as
+    ;; (:file \"main\") must keep parsing as non-definitions.
+    (ok (null (extract-form-type-and-name "(:file \"main\")")))))
 
 (deftest test-semantic-grep-form-type-filter
   (testing "should filter results by form type"
@@ -320,8 +347,10 @@ Final line
   "A DSL-style source file whose top-level forms use a user-defined
    defining macro that is not in *KNOWN-FORM-TYPES*.")
 
-(defmacro with-temp-dsl-project ((var) &body body)
-  "Create a temp directory holding one DSL source file, bind its path to VAR."
+(defmacro with-temp-dsl-project ((var &optional (content '*dsl-file-content*))
+                                 &body body)
+  "Create a temp directory holding CONTENT as one DSL source file.
+   Binds the directory pathname to VAR, executes BODY, then cleans up."
   `(let ((,var (uiop:ensure-directory-pathname
                 (merge-pathnames
                  (format nil "clgrep-dsl-~A-~A/"
@@ -332,7 +361,7 @@ Final line
            (ensure-directories-exist ,var)
            (with-open-file (out (merge-pathnames "rules.lisp" ,var)
                                 :direction :output :if-exists :supersede)
-             (write-string *dsl-file-content* out))
+             (write-string ,content out))
            ,@body)
        (when (uiop:directory-exists-p ,var)
          (uiop:delete-directory-tree ,var :validate t)))))
@@ -366,6 +395,51 @@ Final line
       (ok (null (semantic-grep dir "probe-value"
                                :form-types '("define-endpoint")
                                :include-form nil))))))
+
+(defparameter *qualified-dsl-file-content*
+  "(in-package #:clgrep-dsl-demo)
+
+(routes:define-rule non-empty (s)
+  \"value must be a non-empty string\"
+  (probe-value s))
+
+(routes::define-endpoint probe (s)
+  (probe-value s))
+
+(defun probe-value (s)
+  (and (stringp s) (plusp (length s))))
+"
+  "A DSL-style source file whose defining macros are reached through their
+   package, the way a caller outside the DSL's package must write them.")
+
+(deftest test-semantic-grep-package-qualified-form-type
+  (with-temp-dsl-project (dir *qualified-dsl-file-content*)
+    (testing "package-qualified defining macros are classified, not NIL"
+      (let ((results (semantic-grep dir "probe-value" :include-form nil)))
+        (ok (= 3 (length results)))
+        (ok (every (lambda (r) (cdr (assoc :form-type r))) results)
+            "no result has a NIL form-type")))
+    (testing "form-types matches the unqualified type name"
+      ;; The caller filters on DEFINE-RULE, not ROUTES:DEFINE-RULE: the
+      ;; qualifier is a property of the call site, not of the form's type.
+      (let ((results (semantic-grep dir "probe-value"
+                                    :form-types '("define-rule")
+                                    :include-form nil)))
+        (ok (= 1 (length results)))
+        (ok (string= "define-rule" (cdr (assoc :form-type (first results)))))
+        (ok (string= "non-empty" (cdr (assoc :form-name (first results)))))))
+    (testing "a double-colon head classifies the same way"
+      (let ((results (semantic-grep dir "probe-value"
+                                    :form-types '("define-endpoint")
+                                    :include-form nil)))
+        (ok (= 1 (length results)))
+        (ok (string= "probe" (cdr (assoc :form-name (first results)))))))
+    (testing "an unqualified head in the same file is unaffected"
+      (let ((results (semantic-grep dir "probe-value"
+                                    :form-types '("defun")
+                                    :include-form nil)))
+        (ok (= 1 (length results)))
+        (ok (string= "probe-value" (cdr (assoc :form-name (first results)))))))))
 
 (deftest test-extract-form-signature
   (testing "should extract signatures from various form types"

--- a/tests/clgrep-utils-test.lisp
+++ b/tests/clgrep-utils-test.lisp
@@ -310,8 +310,19 @@ Final line
     (let ((result (extract-form-type-and-name "(cl:defun foo (x) x)")))
       (ok (string= "defun" (cdr (assoc :type result))))
       (ok (string= "foo" (cdr (assoc :name result)))))
+    ;; Package names routinely carry slashes -- this repository is a
+    ;; package-inferred system, so every one of its own packages does -- and
+    ;; dots are just as legal a constituent character.
+    (let ((result (extract-form-type-and-name
+                   "(cl-mcp/src/dsl:define-rule foo (x) x)")))
+      (ok (string= "define-rule" (cdr (assoc :type result))))
+      (ok (string= "foo" (cdr (assoc :name result)))))
+    (let ((result (extract-form-type-and-name "(my.dsl::defthing foo 1)")))
+      (ok (string= "defthing" (cdr (assoc :type result))))
+      (ok (string= "foo" (cdr (assoc :name result)))))
     ;; A qualified head that is not a definition is still rejected.
     (ok (null (extract-form-type-and-name "(routes:apply-rules x)")))
+    (ok (null (extract-form-type-and-name "(cl-mcp/src/dsl:apply-rules x)")))
     ;; A keyword head is not a package qualifier: .asd component forms such as
     ;; (:file \"main\") must keep parsing as non-definitions.
     (ok (null (extract-form-type-and-name "(:file \"main\")")))))
@@ -406,19 +417,29 @@ Final line
 (routes::define-endpoint probe (s)
   (probe-value s))
 
+(cl-mcp/src/dsl:define-guard slashy (s)
+  (probe-value s))
+
+(cl:defun helper (s)
+  (probe-value s))
+
 (defun probe-value (s)
   (and (stringp s) (plusp (length s))))
 "
   "A DSL-style source file whose defining macros are reached through their
-   package, the way a caller outside the DSL's package must write them.")
+   package, the way a caller outside the DSL's package must write them.
+   Covers a plain package name, a double-colon head, a slash-delimited
+   package name, and a standard defining macro that is itself qualified.")
 
 (deftest test-semantic-grep-package-qualified-form-type
   (with-temp-dsl-project (dir *qualified-dsl-file-content*)
     (testing "package-qualified defining macros are classified, not NIL"
       (let ((results (semantic-grep dir "probe-value" :include-form nil)))
-        (ok (= 3 (length results)))
+        (ok (= 5 (length results)))
         (ok (every (lambda (r) (cdr (assoc :form-type r))) results)
-            "no result has a NIL form-type")))
+            "no result has a NIL form-type")
+        (ok (every (lambda (r) (cdr (assoc :signature r))) results)
+            "a row a form-types filter admits must carry a signature")))
     (testing "form-types matches the unqualified type name"
       ;; The caller filters on DEFINE-RULE, not ROUTES:DEFINE-RULE: the
       ;; qualifier is a property of the call site, not of the form's type.
@@ -434,12 +455,25 @@ Final line
                                     :include-form nil)))
         (ok (= 1 (length results)))
         (ok (string= "probe" (cdr (assoc :form-name (first results)))))))
-    (testing "an unqualified head in the same file is unaffected"
+    (testing "a slash-delimited package name classifies the same way"
+      ;; Every package in this repository is slash-delimited, so this is the
+      ;; shape a caller here would actually write.
       (let ((results (semantic-grep dir "probe-value"
-                                    :form-types '("defun")
+                                    :form-types '("define-guard")
                                     :include-form nil)))
         (ok (= 1 (length results)))
-        (ok (string= "probe-value" (cdr (assoc :form-name (first results)))))))))
+        (ok (string= "slashy" (cdr (assoc :form-name (first results)))))))
+    (testing "a qualified and a bare head share one type"
+      (let* ((results (semantic-grep dir "probe-value"
+                                     :form-types '("defun")
+                                     :include-form nil))
+             (names (sort (mapcar (lambda (r) (cdr (assoc :form-name r)))
+                                  results)
+                          #'string<)))
+        (ok (= 2 (length results)))
+        (ok (equal '("helper" "probe-value") names))
+        (ok (every (lambda (r) (cdr (assoc :signature r))) results)
+            "the qualified defun keeps its signature")))))
 
 (deftest test-extract-form-signature
   (testing "should extract signatures from various form types"
@@ -465,7 +499,27 @@ Final line
     (ok (string= "my-struct"
                  (extract-form-signature "(defstruct my-struct field1 field2)")))
     ;; Non-recognized form
-    (ok (null (extract-form-signature "(my-custom-form foo)")))))
+    (ok (null (extract-form-signature "(my-custom-form foo)"))))
+  (testing "should extract signatures from package-qualified heads"
+    ;; EXTRACT-FORM-TYPE-AND-NAME reports DEFUN for (CL:DEFUN ...), so the
+    ;; signature scan has to look past the qualifier it dropped. Otherwise a row
+    ;; that a form_types filter admits carries no signature at all.
+    (ok (string= "(foo x y)"
+                 (extract-form-signature "(cl:defun foo (x y) x)")))
+    ;; (ROVE:DEFTEST ...) is the everyday case: rove is commonly qualified
+    ;; rather than :USEd into the test package.
+    (ok (string= "(my-test ok t)"
+                 (extract-form-signature "(rove:deftest my-test (ok t))")))
+    (ok (string= "(emit (l json) e)"
+                 (extract-form-signature "(cl:defmethod emit ((l json) e) e)")))
+    ;; defclass takes a separate branch and needs the same treatment.
+    (ok (string= "(k p)" (extract-form-signature "(cl:defclass k (p) ())")))
+    ;; A package name with a dot or a slash reaches the same path.
+    (ok (string= "(my-test ok t)"
+                 (extract-form-signature "(my.lib::deftest my-test (ok t))")))
+    ;; Types outside those two branches already returned the bare name.
+    (ok (string= "foo"
+                 (extract-form-signature "(routes:define-rule foo (x) x)")))))
 
 (deftest test-semantic-grep-signature-field
   (testing "should include signature in results"

--- a/tests/clgrep-utils-test.lisp
+++ b/tests/clgrep-utils-test.lisp
@@ -519,7 +519,23 @@ Final line
                  (extract-form-signature "(my.lib::deftest my-test (ok t))")))
     ;; Types outside those two branches already returned the bare name.
     (ok (string= "foo"
-                 (extract-form-signature "(routes:define-rule foo (x) x)")))))
+                 (extract-form-signature "(routes:define-rule foo (x) x)"))))
+  (testing "should extract signatures whatever the case of the head"
+    ;; EXTRACT-FORM-TYPE-AND-NAME downcases the type it reports, so a scan
+    ;; anchored on that type has to ignore case or it cannot find the head in a
+    ;; source that spells it any other way.
+    (ok (string= "(foo x y)"
+                 (extract-form-signature "(CL:DEFUN foo (x y) x)")))
+    (ok (string= "(foo x y)"
+                 (extract-form-signature "(DEFUN foo (x y) x)")))
+    (ok (string= "(foo x)" (extract-form-signature "(Defun foo (x) x)")))
+    (ok (string= "(k p)" (extract-form-signature "(CL:DEFCLASS k (p) ())")))
+    (ok (string= "(my-test ok t)"
+                 (extract-form-signature "(ROVE:DEFTEST my-test (ok t))")))
+    ;; Only the head is matched case-insensitively: the name is reported with
+    ;; the case the source used.
+    (ok (string= "(FOO X Y)"
+                 (extract-form-signature "(DEFUN FOO (X Y) X)")))))
 
 (deftest test-semantic-grep-signature-field
   (testing "should include signature in results"

--- a/tests/project-scaffold-test.lisp
+++ b/tests/project-scaffold-test.lisp
@@ -380,7 +380,22 @@ callers do not need to reference it."
           (ok (find-if (lambda (s) (search "run-tests" s))
                        (coerce next-steps 'list)))
           (ok (find-if (lambda (s) (search "lisp-edit-form" s))
-                       (coerce next-steps 'list))))))))
+                       (coerce next-steps 'list))))
+        (testing "next_steps does not claim a bare ASDF registration"
+          ;; project-scaffold runs in the parent process, so the registration
+          ;; it performs is invisible to the session's worker where repl-eval
+          ;; and load-system run. The message must not imply otherwise.
+          (ok (notany (lambda (s) (search "Auto-registered with ASDF" s))
+                      (coerce next-steps 'list)))
+          (ok (find-if (lambda (s) (search "parent process" s))
+                       (coerce next-steps 'list))
+              "registration is scoped to the parent process")
+          (ok (find-if (lambda (s)
+                         (and (search "parent process" s)
+                              (search "load-system" s)
+                              (search "worker" s)))
+                       (coerce next-steps 'list))
+              "load-system is named as the way to register in the worker"))))))
 
 (deftest scaffold-e2e-test-system-runs-smoke-test
   (with-temp-project-root (root)

--- a/tests/response-builders-test.lisp
+++ b/tests/response-builders-test.lisp
@@ -79,7 +79,7 @@
       (ok (search "macro" text))))))
 
 (deftest build-code-find-references-response-uses-caller
- (testing "summary text shows caller name when available"
+ (testing "summary text shows path:line and the caller name when available"
   (let* ((ref (make-ht "path" "/p/a.lisp" "line" 10 "type" "call"
                        "caller" "MAIN" "context" "..."))
          (refs (vector ref))
@@ -88,6 +88,11 @@
     (ok (= 1 (gethash "count" r)))
     (ok (eq t (gethash "project_only" r)))
     (ok (search "MAIN" text) "caller appears in summary")
+    ;; The line is not an alternative to the caller name: without it the row
+    ;; is neither clickable nor sortable against the caller-less rows.
+    (ok (search "/p/a.lisp:10" text) "path:line appears alongside the caller")
+    (ok (string= "/p/a.lisp:10 (used in MAIN) [call]"
+                 (string-right-trim '(#\Newline) text)))
     (ok (search "FOO" (or (gethash "symbol" r) ""))))))
 
 (deftest build-code-find-references-response-empty

--- a/tests/utils-paths-test.lisp
+++ b/tests/utils-paths-test.lisp
@@ -19,6 +19,7 @@
                 #:allowed-read-path
                 #:ensure-write-path
                 #:resolve-path-in-project
+                #:resolve-readable-path
                 #:broad-root-p))
 
 (in-package #:cl-mcp/tests/utils-paths-test)
@@ -120,6 +121,34 @@
      (declare (ignore root))
      (ok (handler-case
              (progn (resolve-path-in-project "no-such-file" :must-exist t) nil)
+           (error () t)))))))
+
+(deftest resolve-readable-path-follows-the-read-policy
+ (testing "empty or NIL path resolves to the project root itself"
+  (call-with-temp-project-root
+   (lambda (root)
+     (ok (path-inside-p (resolve-readable-path nil) root))
+     (ok (path-inside-p (resolve-readable-path "") root)))))
+ (testing "a registered ASDF system source directory outside the root is allowed"
+  (call-with-temp-project-root
+   (lambda (root)
+     (let ((system-dir (asdf:system-source-directory :alexandria)))
+       (ok (not (path-inside-p system-dir root)))
+       (ok (resolve-readable-path (namestring system-dir) :must-exist t))))))
+ (testing "a path outside both the root and every registered system signals by name"
+  (call-with-temp-project-root
+   (lambda (root)
+     (declare (ignore root))
+     (let ((message (handler-case (progn (resolve-readable-path "/etc/passwd") nil)
+                      (error (e) (princ-to-string e)))))
+       (ok message)
+       (ok (search "/etc/passwd" message))))))
+ (testing "must-exist signals on a missing target"
+  (call-with-temp-project-root
+   (lambda (root)
+     (declare (ignore root))
+     (ok (handler-case
+             (progn (resolve-readable-path "no-such-file" :must-exist t) nil)
            (error () t)))))))
 
 (deftest broad-root-p-blocks-overly-broad-roots


### PR DESCRIPTION
Four fixes found by dogfooding cl-mcp against macro-heavy code. The first is the substantive one; the rest are message and consistency defects found along the way. Each is a separate commit and can be taken independently.

## `10de4e8` — `clgrep-search` silently returned wrong answers on any codebase with its own defining macros

`src/utils/clgrep.lisp` classified forms against a hardcoded whitelist `*known-form-types*`. A head not on that list produced no type and no name, so a DSL file did not report what it defines:

```
clgrep-search pattern="define-rule" path="<dsl project>"
  src/rules.lisp:18 [NIL] NIL
  src/rules.lisp:22 [NIL] NIL
  src/rules.lisp:26 [NIL] NIL
```

**The missing labels were the lesser symptom.** `search-in-file` filters with `(member form-type form-types :test #'string-equal)`, so with `form-type` NIL it compares `"NIL"` against the requested type and drops the form entirely:

```
form_types=["define-rule"]  ->  0 results       on a file holding three define-rule forms
```

An agent filtering for a DSL form type would conclude none exist. That is a silent wrong answer.

`src/lisp-read-file.lisp`'s `%definition-names` already handles the same forms correctly, using a prefix rule (head's `symbol-name` starts with `DEF` or `DEFINE-`) rather than a whitelist — so two tools in one family disagreed about what a form is. `extract-form-type-and-name` now accepts a head that is either on the whitelist (which also carries `in-package`, that no prefix rule would catch) or passes the same prefix rule, mirrored deliberately rather than reinvented.

After: `rules.lisp:18 [define-rule] non-empty`, and `form_types=["define-rule"]` returns 3 of 3.

The prefix rule has a known false-positive edge — a head like `default-config` starts with `def`. `%definition-names` already accepts that risk; this adopts the same one rather than diverging, and says so in a comment.

## `105953d` — `clgrep-search` could not reach a dependency's source

It resolved through `resolve-path-in-project`, which enforces containment in the project root, while the read tools go through `allowed-read-path`, which also permits the source directory of any registered ASDF system:

```
clgrep-search    path=.../quicklisp/software/hunchentoot-v1.3.1  ->  outside project root
fs-list-directory path=<same>                                    ->  29 entries
lisp-read-file    path=<same>/easy-handlers.lisp                 ->  works
```

The intended workflow for an unfamiliar macro DSL is discover-then-expand. For a third-party dependency — exactly the code you did not write — discovery was blocked while reading and expanding worked, so you had to already know the filename.

New `resolve-readable-path` in `src/utils/paths.lisp` pairs `allowed-read-path`'s containment rule with `resolve-path-in-project`'s calling contract; `resolve-path-in-project` is untouched and its other consumers are unaffected. The NIL/`""` default and `:must-exist` are reimplemented explicitly because `allowed-read-path` provides neither, and a rejected path still gets a message naming it and both bounds.

**Security scope**, stated deliberately: no new region becomes reachable — `fs-read-file` and `lisp-read-file` already return contents from those exact directories with no extension filter. What changes is bulk: one recursive search greps a whole system tree where the read tools need a call per file. Symlink traversal is still blocked (`allowed-read-path` truenames before comparing). The residual risk is inherited rather than introduced: `registered-systems` grows as a worker loads systems, and there is no `broad-root-p`-style guard on a system whose `.asd` sits in a very broad directory.

## `7e46ff0` — `project-scaffold` claimed an ASDF registration that does not hold in the worker

Scaffolding runs in the parent; `repl-eval` and `load-system` run in the worker. The success text said the `.asd` was auto-registered, so the natural next step failed:

```
project-scaffold  ->  "Auto-registered with ASDF. To re-register: (asdf:load-asd …)"
repl-eval '(asdf:find-system "mx-rules")'  ->  Component "mx-rules" not found
load-system system=mx-rules                ->  loaded; "was not on ASDF search path"
```

`load-system` recovers, so the workflow was not broken — but the message was false from the worker's point of view, and the scaffold's own suggested next step was the one that looked broken. Message only; registration behaviour untouched.

## `7baca62` — `code-find-references` dropped the line number when a caller was known

```
before:  .../src/engine.lisp (used in run-all) [call]
after:   .../src/engine.lisp:31 (used in run-all) [call]
```

The line was always in the structured `refs` payload; only the summary omitted it, and its docstring said that was deliberate. Revisited: the caller name and the line are not alternatives, and without the line the reference is not clickable and cannot be sorted with the rows that do carry one.

The old justification rested on a caveat that lived only on the Lisp docstring in `src/code-core.lisp`. Since this change surfaces the line to agents, a sentence was added to the MCP tool `:description` in `src/code.lisp` — where agents actually read — saying the line points at the start of the enclosing function's definition rather than the exact call site, and that `caller` names that function.

## Verification

Per-suite green for every touched file; `mallet` clean; `compile-system :force t` produces no new cl-mcp warnings. `rove cl-mcp.asd` exit 0 with 3051 ✓ / 0 ✗ on this branch alone, and 3231 ✓ / 0 ✗ on a merge with #122 and #124 confirming the three compose.

## Known, pre-existing, not touched

`tests/project-scaffold-test.lisp` cannot run standalone under `rove <file>` — its `defpackage` omits `cl-mcp/src/validate`, `alexandria` and `cl-mcp/src/tools/registry`, so package-inferred-system never adds those deps. Verified identical on `main`. It passes inside the full suite, where `cl-mcp` is already loaded. Worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)