### PR TITLE
fix: report code-find's on-disk check honestly; keep inspect ids at every depth

### DIFF
--- a/cl-mcp.asd
+++ b/cl-mcp.asd
@@ -21,7 +21,7 @@
   :description "Model Context Protocol server for Common Lisp"
   :author "cxxxr, Satoshi Imai"
   :license "MIT"
-  :version "2.3.0"
+  :version "2.3.1"
   :depends-on ("alexandria"
                "cl-ppcre"
                "yason"

--- a/src/code-core.lisp
+++ b/src/code-core.lisp
@@ -155,15 +155,21 @@ the offset is spurious. Returns NIL when the file cannot be read."
         nil))))
 
 (declaim (ftype (function (string &key (:package (or null package symbol string)))
-                          (values (or null string) (or null integer) &optional))
+                          (values (or null string) (or null integer) t &optional))
                 code-find-definition))
 
 (defun code-find-definition (symbol-name &key package)
   "Return the definition location for SYMBOL-NAME.
-Values are PATH (string) and LINE (integer), or NILs when not found.
-Searches multiple SB-INTROSPECT definition kinds so that classes,
+Values are PATH (string), LINE (integer) and ON-DISK (boolean), or NILs when
+not found.  Searches multiple SB-INTROSPECT definition kinds so that classes,
 structures, conditions, generic functions, macros, and variables are
-all locatable, not only ordinary functions."
+all locatable, not only ordinary functions.
+
+ON-DISK is decided here, on the absolute pathname SB-INTROSPECT returned,
+because PATH has already been made relative for display and the relativization
+is not always against the process's working directory: a worker's CWD is
+whatever it inherited, not *PROJECT-ROOT*.  Probing the relative string
+downstream therefore failed for every file that does exist."
   (let* ((qualified (position #\: symbol-name))
          (pkg (if qualified nil package))
          (sym (%parse-symbol symbol-name :package pkg)))
@@ -197,10 +203,13 @@ all locatable, not only ordinary functions."
         (let* ((pathname (funcall path-fn source))
                (char-offset (and offset (funcall offset source)))
                (line (%offset->line pathname char-offset))
+               (on-disk (and pathname
+                             (ignore-errors (probe-file pathname))
+                             t))
                (path (normalize-path-for-display pathname)))
-          (return-from code-find-definition (values path line))))
+          (return-from code-find-definition (values path line on-disk))))
       (log-event :warn "code.find.not-found" "symbol" symbol-name)
-      (values nil nil))
+      (values nil nil nil))
     #-sbcl
     (error "code-find-definition requires SBCL")))
 

--- a/src/code.lisp
+++ b/src/code.lisp
@@ -40,9 +40,9 @@ and is loaded"))
   :body
   (with-proxy-dispatch (id "worker/code-find"
                           (make-ht "symbol" symbol "package" package))
-    (multiple-value-bind (path line)
+    (multiple-value-bind (path line on-disk)
         (code-find-definition symbol :package package)
-      (result id (build-code-find-response symbol path line)))))
+      (result id (build-code-find-response symbol path line on-disk)))))
 
 (define-tool "code-describe"
   :description "Describe a symbol: type, arglist, and documentation.

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -7,7 +7,7 @@
 (in-package #:cl-mcp/src/core)
 
 (defparameter +server-version+
-  "2.3.0"
+  "2.3.1"
   "Semantic version of cl-mcp.")
 
 (declaim (ftype (function () simple-string) version))

--- a/src/inspect.lisp
+++ b/src/inspect.lisp
@@ -76,7 +76,13 @@ When CIRCULAR-P is true, returns a circular reference marker."
 
 (defun %value-repr (object seen-table active-table depth max-depth max-elements)
   "Return representation of OBJECT, registering if inspectable.
-Returns either a primitive value representation, an object-ref, or a circular-ref."
+Returns either a primitive value representation, an object-ref, or a circular-ref.
+
+An expanded result carries its \"id\" just as an object-ref does.  Without it,
+raising MAX-DEPTH removed the very handles it was raised to reach: at depth 1 a
+slot came back as an object-ref and showed [object-id: N], while at depth 2 the
+same slot was expanded in place and showed none, so the deeper view was the one
+you could not drill into."
   (if (inspectable-p object)
       (let ((child-depth (1+ depth)))
         (cond
@@ -91,9 +97,13 @@ Returns either a primitive value representation, an object-ref, or a circular-re
            (%make-object-ref object seen-table))
           ;; First time and depth allows expansion.
           (t
-           (%ensure-object-id object seen-table)
-           (%inspect-object-impl object seen-table active-table child-depth
-                                 max-depth max-elements))))
+           (let ((id (%ensure-object-id object seen-table))
+                 (expanded (%inspect-object-impl object seen-table active-table
+                                                 child-depth max-depth
+                                                 max-elements)))
+             (when (hash-table-p expanded)
+               (setf (gethash "id" expanded) id))
+             expanded))))
       (%primitive-value-repr object)))
 
 ;;; Type-specific inspection functions
@@ -451,8 +461,13 @@ If REPR is not a hash-table, return its princ-to-string."
           (loop for el in (coerce elements 'list)
                 for i from 0
                 do (if (hash-table-p el)
+                       ;; REF_ID as well as ID: a circular-ref carries its
+                       ;; handle under "ref_id", and it is the one nested kind
+                       ;; that would otherwise render with no marker at all --
+                       ;; conspicuous now that its siblings have one.
                        (format s "~&  [~D] ~A~@[ [object-id: ~A]~]"
-                               i (%repr-text el) (gethash "id" el))
+                               i (%repr-text el)
+                               (or (gethash "id" el) (gethash "ref_id" el)))
                        (format s "~&  [~D] ~A" i el)))))
       ;; Hash-table entries
       (let ((entries (gethash "entries" inspection-result)))
@@ -463,9 +478,15 @@ If REPR is not a hash-table, return its princ-to-string."
                 do (when (hash-table-p entry)
                      (let ((k (gethash "key" entry))
                            (v (gethash "value" entry)))
-                       (format s "~&  ~A => ~A~@[ [object-id: ~A]~]"
-                               (%repr-text k) (%repr-text v)
-                               (when (hash-table-p v) (gethash "id" v))))))))
+                       ;; A composite KEY is drillable too, and its handle was
+                       ;; reachable only from the JSON before.
+                       (format s "~&  ~A~@[ [key-object-id: ~A]~] => ~A~@[ [object-id: ~A]~]"
+                               (%repr-text k)
+                               (when (hash-table-p k)
+                                 (or (gethash "id" k) (gethash "ref_id" k)))
+                               (%repr-text v)
+                               (when (hash-table-p v)
+                                 (or (gethash "id" v) (gethash "ref_id" v)))))))))
       ;; CLOS slots
       (let ((slots (gethash "slots" inspection-result)))
         (when (and slots (plusp (length slots)))
@@ -476,7 +497,9 @@ If REPR is not a hash-table, return its princ-to-string."
                        (format s "~&  ~A: ~A~@[ [object-id: ~A]~]"
                                (gethash "name" slot "?")
                                (%repr-text v)
-                               (when (hash-table-p v) (gethash "id" v))))))))
+                               (when (hash-table-p v)
+                                 (or (gethash "id" v)
+                                     (gethash "ref_id" v)))))))))
       ;; Meta info (truncation)
       (let ((meta (gethash "meta" inspection-result)))
         (when (and meta (hash-table-p meta) (gethash "truncated" meta))

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -309,31 +309,45 @@ Raw stdout/stderr are kept in structured fields only (not in content text)."
           (when presentp (setf (gethash field response) value))))
       response)))
 
-(defun build-code-find-response (symbol path line)
+(defun build-code-find-response (symbol path line &optional (on-disk t on-disk-supplied-p))
   "Build the standard code-find response hash-table.
 PATH is the source file path, LINE the line number.  When PATH is
-NIL the symbol was not found and an isError payload is returned."
+NIL the symbol was not found and an isError payload is returned.
+
+ON-DISK says whether the source file exists.  The caller decides it, because
+by the time PATH reaches here it has been made relative for display, and
+relative to what is not knowable from this side: NORMALIZE-PATH-FOR-DISPLAY
+tries *PROJECT-ROOT*, then the working directory, then cl-mcp's own source
+directory.  Probing the relative string here resolved it against the process's
+CWD -- which in a worker is whatever it inherited -- so every existing file was
+annotated \"source not on disk\".
+
+The argument is optional; when it is omitted the builder falls back to probing
+PATH itself, so a caller that has not been updated keeps exactly its old
+behaviour rather than silently claiming every file is present.  Do not
+\"simplify\" this into a plain default of T: that is the direction that turns a
+missing file into a reported one."
   (if path
-      (make-ht "path" path
-               "line" line
-               "content" (text-content
-                          (let ((on-disk (ignore-errors (probe-file path))))
-                            (cond
-                              ((and line on-disk)
-                               (format nil "~A defined in ~A at line ~D"
-                                       symbol path line))
-                              (line
-                               (format nil "~A defined in ~A at line ~D (source not on disk)"
-                                       symbol path line))
-                              (on-disk
-                               (format nil "~A defined in ~A" symbol path))
-                              (t
-                               (format nil "~A defined in ~A (source not on disk)"
-                                       symbol path))))))
-      (make-ht "isError" t
-               "content" (text-content
-                          (format nil "Definition not found for ~A"
-                                  symbol)))))
+      (make-ht "path" path "line" line "content"
+               (text-content
+                (let ((on-disk (if on-disk-supplied-p
+                                   on-disk
+                                   (ignore-errors (probe-file path)))))
+                  (cond
+                   ((and line on-disk)
+                    (format nil "~A defined in ~A at line ~D" symbol path
+                            line))
+                   (line
+                    (format nil
+                            "~A defined in ~A at line ~D (source not on disk)"
+                            symbol path line))
+                   (on-disk (format nil "~A defined in ~A" symbol path))
+                   (t
+                    (format nil "~A defined in ~A (source not on disk)" symbol
+                            path))))))
+      (make-ht "isError" t "content"
+               (text-content
+                (format nil "Definition not found for ~A" symbol)))))
 
 (defun build-code-describe-response (name type arglist doc path line)
   "Build the standard code-describe response hash-table."

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -184,9 +184,9 @@ would deadlock or trip SBCL's recursive-lock check."
         (package (gethash "package" params)))
     (unless symbol
       (error "symbol is required"))
-    (multiple-value-bind (path line)
+    (multiple-value-bind (path line on-disk)
         (code-find-definition symbol :package package)
-      (build-code-find-response symbol path line))))
+      (build-code-find-response symbol path line on-disk))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; worker/code-describe

--- a/tests/inspect-test.lisp
+++ b/tests/inspect-test.lisp
@@ -98,6 +98,48 @@
            ;; Second element should be an object-ref
            (ok (string= "object-ref" (ht-get (second elems) "kind")))))))))
 
+(deftest inspect-keeps-object-ids-when-max-depth-expands
+  (testing "raising max-depth does not cost you the ids you drill with"
+    ;; At depth 1 a nested value came back as an object-ref, which carries
+    ;; "id".  At depth 2 the same value was expanded in place, and the
+    ;; expanded hash-table had no "id" at all -- so asking for the deeper
+    ;; view removed the very handles it was asked for, and the rendered text
+    ;; lost its [object-id: N] markers.  Every inspectable value carries its
+    ;; id now, expanded or not.
+    (with-fresh-registry
+     (lambda ()
+       (let* ((inner (list :inner 1 2))
+              (obj (list inner))
+              (id (register-object obj)))
+         (dolist (depth '(1 2 3))
+           (let* ((result (inspect-object-by-id id :max-depth depth))
+                  (first-element (first (ht-get result "elements"))))
+             (ok (ht-get first-element "id")
+                 (format nil "the nested value carries an id at max-depth ~D"
+                         depth))
+             (ok (integerp (ht-get first-element "id"))
+                 "and it is an integer usable as an inspect-object argument"))))))))
+
+(deftest inspect-renders-a-handle-for-a-circular-reference
+  (testing "a circular element still shows an id in the rendered text"
+    ;; A circular-ref carries its handle under "ref_id", not "id", so the text
+    ;; renderer printed nothing for it.  That was invisible while no sibling
+    ;; had a marker either; once every other nested value gained one, the
+    ;; cycle became the single element an agent could not drill into.
+    (with-fresh-registry
+     (lambda ()
+       (let* ((root (list :a nil (list :c 1)))
+              (id (register-object root)))
+         (setf (second root) root)
+         (dolist (depth '(1 2 3))
+           (let ((text (cl-mcp/src/inspect:format-inspect-elements
+                        (inspect-object-by-id id :max-depth depth))))
+             (ok (search "<circular to" text)
+                 (format nil "the cycle is still reported at max-depth ~D"
+                         depth))
+             (ok (search (format nil "[object-id: ~D]" id) text)
+                 "and carries a handle pointing back at the root"))))))))
+
 (deftest inspect-list-truncation
   (testing "inspect list respects max_elements"
     (with-fresh-registry

--- a/tests/integration-test.lisp
+++ b/tests/integration-test.lisp
@@ -101,7 +101,7 @@ project root for integration tool calls.")
            (text4 (and first4 (gethash "text" first4))))
       (ok (string= (gethash "jsonrpc" obj4) "2.0"))
       (ok (stringp text4))
-      (ok (search "2.3.0" text4)))))
+      (ok (search "2.3.1" text4)))))
 
 (deftest fs-write-then-readback
   (testing "write file then read it back via tools/call"

--- a/tests/response-builders-test.lisp
+++ b/tests/response-builders-test.lisp
@@ -46,6 +46,37 @@
       (ok (search "BAR" text))
       (ok (not (search " line " text)) "no line phrase when line is NIL")))))
 
+(deftest build-code-find-response-does-not-misreport-an-existing-file
+  (testing "a file that exists is not annotated 'source not on disk'"
+    ;; The annotation used to fire on every hit.  BUILD-CODE-FIND-RESPONSE
+    ;; probed the path it was given, but by then CODE-FIND-DEFINITION had
+    ;; already made it relative for display -- relative to *PROJECT-ROOT*,
+    ;; which is not the process's working directory in a worker.  Every
+    ;; existing file therefore probed as missing.  The caller now decides,
+    ;; from the absolute pathname, and passes the answer in.
+    ;;
+    ;; The two cases above both use /no/such/path.lisp and assert the
+    ;; annotation IS present, so neither could ever have caught this.
+    (let* ((r (build-code-find-response "FOO" "src/core.lisp" 10 t))
+           (text (gethash "text" (aref (gethash "content" r) 0))))
+      (ok (search "src/core.lisp" text) "the path is still reported")
+      (ok (search "line 10" text) "and the line")
+      (ok (not (search "not on disk" text))
+          "an on-disk file must not be annotated as missing"))
+    (let* ((r (build-code-find-response "FOO" "src/core.lisp" 10 nil))
+           (text (gethash "text" (aref (gethash "content" r) 0))))
+      (ok (search "not on disk" text)
+          "and a genuinely missing file still is"))))
+
+(deftest build-code-find-response-keeps-the-two-value-contract
+  (testing "a caller passing no on-disk flag still probes for itself"
+    ;; The argument is optional so a caller that has not been updated keeps
+    ;; the old behaviour rather than silently claiming every file is present.
+    (let* ((r (build-code-find-response "BAZ" "/no/such/path.lisp" 7))
+           (text (gethash "text" (aref (gethash "content" r) 0))))
+      (ok (search "not on disk" text)
+          "a missing file is still reported as missing without the flag"))))
+
 (deftest build-code-find-response-not-found
  (testing "NIL path produces an isError payload"
   (let ((r (build-code-find-response "BAZ" nil nil)))


### PR DESCRIPTION
Two reporting bugs found by dogfooding v2.3.0 the day it shipped. Neither was introduced by that release — both had been present for some time and were simply never exercised in a way that exposed them. Ships as **v2.3.1**.

## `code-find` reported "(source not on disk)" for files that exist

Every hit carried the annotation:

```
code-find symbol=post package=my-project/journal
→ post defined in src/journal.lisp at line 49 (source not on disk)
```

while the file was present and `probe-file` on the absolute pathname SB-INTROSPECT returned resolved fine.

`code-find-definition` hands back a path already relativized for display, and `normalize-path-for-display` relativizes against whichever of `*project-root*`, the working directory, or cl-mcp's own source directory matches first. The builder then probed that **relative** string, which resolves against the process's working directory — and a worker's working directory is whatever it inherited, not the project root. So the probe failed for every existing file.

The decision now happens in `code-find-definition`, on the absolute pathname, and travels as a third return value. The builder takes it as an optional argument and falls back to probing when absent, so an un-updated caller is unchanged.

Worth noting: `code-describe` prints the same relative path and never carried the annotation, so the two tools disagreed about the same file. The annotation was added in d1fa24c and has been inverted since.

## `inspect-object` lost its object-ids as `max_depth` rose

Raising `max_depth` removed the per-slot `[object-id: N]` markers, so asking for a deeper view cost the handles needed to drill deeper still — the direction was backwards:

```
inspect-object id=60               → FROM [object-id: 64], TO [65], AMOUNT [66]
inspect-object id=60 max_depth=2   → FROM, TO, AMOUNT — no ids at all
```

A value at the depth boundary came back as an object-ref, which carries its id. A value shallow enough to expand was registered in the object registry but the expanded result did not carry it. Every inspectable value carries its id now.

### Two follow-ups that change made visible

- **circular-ref rendered no marker.** It stores its handle under `ref_id`, not `id`. Invisible while no sibling had a marker either; conspicuous once every other nested value did, leaving the cycle as the single element an agent could not drill into. The renderer falls back to `ref_id` — for elements, slots and hash-table values alike.
- **A composite hash-table key** had an id in the JSON that the rendered text never showed. It does now.

## Verification

- `rove cl-mcp.asd`: **53 suites, 3463 assertions, 0 failures**
- `mallet src/*.lisp src/*/*.lisp tests/*.lisp`: clean
- Adversarial review of both fixes: **verdict `sound` on both, zero blocker/major**
  - `code-find` probed across every SB-INTROSPECT definition kind, Quicklisp dependencies outside the root, SBCL internals via logical pathnames, source-deleted-after-load (the case the annotation exists for — still fires), and a reverse decoy where a same-named file sits in the CWD (v2.3.0 said present, v2.3.1 correctly says missing). A sweep over **1763 definitions in three root/CWD configurations found zero disagreements** with the filesystem.
  - `inspect-object` probed across lists, vectors, hash-tables, structs and CLOS instances at depths 1/2/3/5, shared objects, circular structures, and `max_elements` truncation; ids resolve, cycles still terminate.

The existing `code-find` builder tests both used `/no/such/path.lisp` and asserted the annotation **is** present, so neither could ever have caught this. The new test uses a file that exists.

## Known limitations, deliberately out of scope

- When cl-mcp runs as a tool for some *other* project, a display path can come from `normalize-path-for-display`'s third fallback (cl-mcp's own source directory) and will not resolve for the client. That is a `normalize-path-for-display` design question, not this fix.
- Object ids can be evicted by the registry's FIFO before an agent uses them, on a large deep traversal. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)