### PR TITLE
fix: print restart names readably, and echo expanded forms from the file

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -174,6 +174,15 @@ Inputs:
   `false`; defaults to `offset=0`, `limit=500` lines. When truncated, a
   `[Showing lines A-B of N. Use offset=B to read more.]` footer is appended.
 
+An **expanded** form is echoed from the file verbatim, so its text — including
+comments inside the form — is exactly what is on disk, and the `NNN:` prefix on
+each line is that line of the file. Text copied out of an expanded form can
+therefore be used directly as `lisp-patch-form`'s `old_text`, which matches raw,
+whitespace-sensitive text. **Collapsed** signature lines are printed rather than
+quoted (a signature is a summary, not a quotation), and so is the subject of
+`content_pattern`: the pattern matches the printed form, so it describes
+structure rather than the file's whitespace.
+
 Output fields:
 - `content`: formatted text (collapsed Lisp view, raw slice, or filtered text).
 - `path`: normalized native pathname.

--- a/src/frame-inspector.lisp
+++ b/src/frame-inspector.lisp
@@ -19,10 +19,28 @@
 
 (in-package #:cl-mcp/src/frame-inspector)
 
+(defun %restart-name-string (restart)
+  "Return RESTART's name printed the way INVOKE-RESTART has to receive it.
+Printed readably and relative to *PACKAGE*, so a keyword keeps its colon and a
+symbol homed in another package keeps its qualifier.
+
+INVOKE-RESTART compares names with EQ, and cl-mcp's own prompts tell library
+authors to name restarts with keywords for that reason. Printing the name with
+~A rendered :RETURN-NIL and RETURN-NIL as the same text, so the field an agent
+reads to decide which of the two to type could not tell them apart. During
+repl-eval *PACKAGE* is the package the caller asked for, which makes the
+printed name exactly what they would have to write there."
+  (let ((name (restart-name restart)))
+    (if name
+        (prin1-to-string name)
+        "NIL")))
+
 (defun %collect-restarts ()
-  "Return list of available restarts with names and descriptions."
+  "Return list of available restarts with names and descriptions.
+Names are printed readably by %RESTART-NAME-STRING so that a keyword-named
+restart is distinguishable from a symbol-named one."
   (loop for restart in (compute-restarts)
-        collect (list :name (string (restart-name restart))
+        collect (list :name (%restart-name-string restart)
                       :description (or (ignore-errors
                                          (princ-to-string restart))
                                        ""))))

--- a/src/lisp-read-file.lisp
+++ b/src/lisp-read-file.lisp
@@ -401,8 +401,13 @@ object across multiple positions in the form tree."
              (eq reason :s-expression-comment)
              (and (consp reason) (eq (car reason) :line-comment))))))
 
-(defun %comment-text (node text)
+(defun %node-source-text (node text)
+  "Return NODE's own span of TEXT, exactly as it appears in the file."
   (subseq text (cst-node-start node) (cst-node-end node)))
+
+(defun %comment-text (node text)
+  "Return the text of comment NODE as it appears in TEXT."
+  (%node-source-text node text))
 
 (defun %line-number-width (line-count)
   (max 1 (length (write-to-string line-count))))
@@ -415,8 +420,25 @@ object across multiple positions in the form tree."
             for idx from start-line do
               (format out "~VD: ~A~%" width idx line)))))
 
-(defun %format-lisp-form (node name-scanner content-scanner line-width)
-  "Return two values: display string and whether NODE was expanded."
+(defun %format-lisp-form (node source-text name-scanner content-scanner
+                          line-width)
+  "Return two values: display string and whether NODE was expanded.
+
+An expanded form is echoed from SOURCE-TEXT rather than re-printed from the
+CST, because three things depend on the text being what is on disk:
+
+  - lisp-patch-form matches old_text as raw, whitespace-sensitive text, so an
+    agent copying an expanded line out of here has to get the file's own
+    characters back or the patch reports \"not found\";
+  - the per-line numbers only line up with the file while the line breaks do,
+    and a re-print reflows them, silently shifting every number after the
+    reflow onto the wrong line;
+  - comments sitting inside a form survive, where re-printing dropped them.
+
+Collapsed forms are still printed, since a signature is a summary rather than
+a quotation, and so is the CONTENT-SCANNER's subject: matching runs against the
+printed form so that content_pattern keeps matching structure rather than
+whitespace."
   (let* ((form (cst-node-value node))
          (head (and (consp form) (car form)))
          (names (%definition-names form))
@@ -431,7 +453,7 @@ object across multiple positions in the form tree."
          (start-line (cst-node-start-line node))
          (display (cond
                     (expand?
-                     (%add-line-numbers (or full-string (%form->string form))
+                     (%add-line-numbers (%node-source-text node source-text)
                                         start-line line-width))
                     ((member head '(defun defmacro defvar defparameter defconstant defclass
                                      defstruct defgeneric defmethod))
@@ -500,7 +522,7 @@ object across multiple positions in the form tree."
                          (write-string comment out))
                        (setf pending-comments nil))
                      (multiple-value-bind (line expanded?)
-                         (%format-lisp-form node name-scanner
+                         (%format-lisp-form node text name-scanner
                                             content-scanner line-width)
                        (when expanded? (incf expanded))
                        (write-string (ensure-trailing-newline line) out))
@@ -704,6 +726,12 @@ Use 'name_pattern' to locate specific definitions (e.g., functions, classes)
 without reading the entire file.
 Use 'collapsed=true' (default) to see only signatures, or 'collapsed=false'
 for full source.
+A form expanded by name_pattern or content_pattern is echoed from the file
+verbatim, comments inside it included, and each 'NNN:' prefix is that line of
+the file -- so text copied out of an expanded form can be used directly as
+lisp-patch-form's 'old_text', which matches raw text exactly. Collapsed
+signature lines are printed rather than quoted, as is the form
+content_pattern matches against.
 When reading in raw mode (collapsed=false) and output is truncated, a
 '[Showing lines A-B of N. Use offset=B to read more.]' footer is appended
 to guide pagination. Use the suggested offset value in a follow-up call."

--- a/tests/frame-inspector-test.lisp
+++ b/tests/frame-inspector-test.lisp
@@ -37,6 +37,51 @@
         (ok (stringp (getf first-restart :name)))
         (ok (stringp (getf first-restart :description)))))))
 
+(defun %probe-restart-names (package)
+  "Return the captured restart names for a probe signalled with *PACKAGE* bound.
+HANDLER-BIND rather than HANDLER-CASE: the restarts have to still be
+established when the context is captured, and HANDLER-CASE unwinds first."
+  (let (context)
+    (ignore-errors
+     (let ((*package* package))
+       (handler-bind ((error (lambda (condition)
+                               (setf context (capture-error-context condition)))))
+         (restart-case (error "restart naming probe")
+           (:keyword-named () :report "keyword" nil)
+           (symbol-named () :report "symbol" nil)))))
+    (mapcar (lambda (restart) (getf restart :name))
+            (getf context :restarts))))
+
+(deftest capture-error-context-restart-names-are-readable
+  ;; INVOKE-RESTART compares restart names with EQ, and cl-mcp's own prompts
+  ;; tell library authors to name restarts with keywords for exactly that
+  ;; reason.  Printing the name with ~A rendered :KEYWORD-NAMED and
+  ;; KEYWORD-NAMED as the same text, so the field an agent reads to decide
+  ;; which spelling to type could not tell them apart.
+  (let ((names (%probe-restart-names
+                (find-package '#:cl-mcp/tests/frame-inspector-test))))
+    (testing "a keyword-named restart keeps its colon"
+      (ok (member ":KEYWORD-NAMED" names :test #'string=)))
+    (testing "a symbol named in the current package carries no qualifier"
+      (ok (member "SYMBOL-NAMED" names :test #'string=)))
+    (testing "the two spellings are no longer the same string"
+      (ok (not (member ":SYMBOL-NAMED" names :test #'string=)))
+      (ok (not (member "KEYWORD-NAMED" names :test #'string=))))))
+
+(deftest capture-error-context-restart-names-qualify-foreign-symbols
+  ;; The names are printed relative to *PACKAGE*, which during repl-eval is the
+  ;; package the caller asked for -- so what comes back is what they would have
+  ;; to type there. From a package that does not home the symbol, that means a
+  ;; qualifier.
+  (let ((names (%probe-restart-names (find-package '#:cl-user))))
+    (testing "a symbol from another package comes back qualified"
+      (ok (find-if (lambda (name)
+                     (and (search "SYMBOL-NAMED" name)
+                          (search "::" name)))
+                   names)))
+    (testing "a keyword needs no qualifier and gets none"
+      (ok (member ":KEYWORD-NAMED" names :test #'string=)))))
+
 (deftest capture-error-context-frames
   (testing "captures stack frames (SBCL specific)"
     (let ((ctx (handler-case

--- a/tests/lisp-read-file-test.lisp
+++ b/tests/lisp-read-file-test.lisp
@@ -974,3 +974,87 @@ not reader output: no backquote encloses it, so it must print as a list.")
         (setf cl-mcp/src/lisp-read-file::*source-pprint-dispatch* saved
               cl-mcp/src/lisp-read-file::*signature-pprint-dispatch*
               saved-signature)))))
+
+(deftest lisp-read-file-expanded-form-echoes-the-file
+  ;; Expanded forms used to be re-printed from the CST rather than echoed, and
+  ;; two things broke because of it.  lisp-patch-form matches old_text as raw,
+  ;; whitespace-sensitive text, so an agent copying an expanded line straight
+  ;; out of this tool got "not found" whenever the printer had reflowed it.
+  ;; And each printed line still carried a number that read as a file line, so
+  ;; a form the printer reflowed shifted every number after it -- silently.
+  (with-temp-lisp-file
+   "tests/tmp/raw-echo-demo.lisp"
+   (format nil "~{~A~%~}"
+           (list "(defgeneric raw-echo-demo (x)"
+                 "  (:documentation \"Doc.\"))"
+                 ""
+                 "(defun raw-echo-caller (x)"
+                 "  ;; an inner comment"
+                 "  (restart-case (raw-echo-demo x)"
+                 "    (:give-up ()"
+                 "      :report \"stop\""
+                 "      nil)))"))
+   (lambda (path)
+     (let ((content (gethash "content"
+                             (lisp-read-file path
+                                             :name-pattern "^raw-echo-caller$"))))
+       (testing "the file's own text is echoed, not a re-print of it"
+         (ok (search "(:give-up ()" content)
+             "an empty lambda list stays () rather than becoming NIL")
+         (ok (null (search "(:give-up nil" content))))
+       (testing "a comment inside the form survives expansion"
+         (ok (search ";; an inner comment" content)))
+       (testing "each numbered line is that line of the file"
+         (ok (search "4: (defun raw-echo-caller (x)" content))
+         (ok (search "5:   ;; an inner comment" content))
+         (ok (search "7:     (:give-up ()" content))
+         (ok (search "9:       nil)))" content)))))))
+
+(deftest lisp-read-file-expanded-form-keeps-numbers-aligned-with-the-file
+  ;; The regression that motivated the previous test: a defgeneric the printer
+  ;; splits across three lines where the file uses two.  Every number after the
+  ;; split pointed one line too far -- here at a line the file leaves blank.
+  (with-temp-lisp-file
+   "tests/tmp/raw-echo-defgeneric.lisp"
+   (format nil "~{~A~%~}"
+           (list "(defgeneric spanning-demo (x)"
+                 "  (:documentation \"Doc.\"))"
+                 ""
+                 "(defun after-the-generic () 42)"))
+   (lambda (path)
+     (let ((content (gethash "content"
+                             (lisp-read-file path
+                                             :name-pattern "^spanning-demo$"))))
+       (testing "the two source lines stay two lines, numbered 1 and 2"
+         (ok (search "1: (defgeneric spanning-demo (x)" content))
+         (ok (search "2:   (:documentation \"Doc.\"))" content)))
+       (testing "nothing is reported on line 3, which the file leaves blank"
+         (ok (null (search "3:   (:documentation" content))))))))
+
+(deftest lisp-read-file-content-pattern-sees-backquote-reader-syntax
+  ;; Now that expanded forms are echoed rather than printed, the display no
+  ;; longer exercises the source printer -- the three tests above pass by
+  ;; construction. content_pattern still matches against the *printed* form,
+  ;; so that a pattern describes structure rather than the file's whitespace,
+  ;; and that is the path a quasiquote-printing regression would break: the
+  ;; body would render as eclector.reader internals and stop matching.
+  (with-temp-lisp-file
+   "tests/tmp/backquote-content-match.lisp"
+   (format nil "~{~A~%~}"
+           (list "(defmacro bq-content-demo (a b &body forms)"
+                 "  `(let ((,a ,b)) ,@forms))"
+                 ""
+                 "(defun bq-content-other () :unrelated)"))
+   (lambda (path)
+     (testing "a comma-at in a macro body is matchable through content_pattern"
+       (let ((content (gethash "content"
+                               (lisp-read-file path :content-pattern ",@forms"))))
+         (ok (search "bq-content-demo" content))
+         (ok (search ",@forms" content)
+             "the matched form is echoed with its reader syntax intact")))
+     (testing "a pattern naming eclector internals matches nothing"
+       (let ((content (gethash "content"
+                               (lisp-read-file path
+                                               :content-pattern "eclector"))))
+         (ok (null (search "`(let" content))
+             "no form expanded, so the macro body is not shown"))))))


### PR DESCRIPTION
Two P2 defects found in the second dogfooding cycle (`experiments/rv-scheduler`, Rove). Both sit in fields an agent reads to decide what to do next, and both were quiet.

## 1. `error_context.restarts` could not distinguish `:return-nil` from `return-nil`

Names were rendered with `~A`, so a keyword and an interned symbol came back as the same text:

```lisp
(restart-case (error "probe")
  (:keyword-named () :k)
  (symbol-named  () :s))
;; before: Restarts: KEYWORD-NAMED, SYMBOL-NAMED, CONTINUE, ABORT, ABORT, EXIT
```

`invoke-restart` compares names with `EQ`, and `prompts/repl-driven-development.md` tells library authors to name restarts with keywords *for that reason* — so the field an agent consults to pick a spelling hid the very distinction the guidance is about. Only one of those two lines can actually be invoked as written.

Names are now printed readably and relative to `*PACKAGE*`, which during `repl-eval` is the package the caller asked for — so what comes back is what they would have to type there:

```
(":KEYWORD-NAMED" "SYMBOL-NAMED" "CONTINUE" "ABORT" "ABORT" "EXIT")
```

A symbol homed elsewhere comes back qualified. The familiar CL restarts are unchanged.

## 2. `lisp-read-file` re-printed expanded forms, then numbered them as file lines

Expanded forms were rendered from the CST rather than echoed. The printer reflows, but each line still carried an `NNN:` prefix that reads as a file line. Measured on a real file:

| file | before |
|---|---|
| 78 `(defgeneric next-task (scheduler)`<br>79 `  (:documentation "..."))`<br>80 *(blank)* | `78: (defgeneric next-task`<br>`79:     (scheduler)`<br>`80:   (:documentation "...")` |

`(:documentation ...)` reported on a line the file leaves blank, and every number after the reflow off by one. `(:give-up ()` came back as `(:give-up nil :report`.

**This is worse than cosmetic.** `lisp-patch-form` matches `old_text` as raw, whitespace-sensitive text. An agent copying a line out of `lisp-read-file` to patch it got `not found` whenever the printer had touched it — two tools meant to be used together disagreed about what the file says. Re-printing also dropped comments sitting *inside* a form.

Expanded forms are echoed verbatim now. Verified against the same file:

```
78: (defgeneric next-task (scheduler)
79:   (:documentation "Remove and return SCHEDULER's next task."))
81: (defmethod next-task ((sched scheduler))
...
91:     (:return-nil ()
```

Collapsed signatures are still *printed* — a signature is a summary, not a quotation — and so is `content_pattern`'s subject, so a pattern keeps describing structure rather than the file's whitespace.

### One consequence worth flagging to reviewers

The three backquote-**rendering** tests assert on the display, which no longer goes through the source printer, so they now pass by construction. The printer is still reached through `content_pattern`, and `lisp-read-file-content-pattern-sees-backquote-reader-syntax` covers it there: a quasiquote regression shows up as a macro body that stops matching `,@forms`.

## Verification

- `rove cl-mcp.asd` → **All 53 tests passed**
- `mallet src/*.lisp` and both changed test files → clean
- `(asdf:compile-system :cl-mcp :force t)` → no warnings from the changed files
- Both fixes re-checked end to end in a fresh process against the exact cases that produced the reports

`docs/tools.md` and the `lisp-read-file` tool description now state which output is quoted and which is printed, since the distinction is what makes the output safe to feed to `lisp-patch-form`.

Found alongside #129, which is a separate and larger problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)