### PR TITLE
Treat empty strings as unspecified values

### DIFF
--- a/src/lisp-patch-form.lisp
+++ b/src/lisp-patch-form.lisp
@@ -205,8 +205,8 @@ Reader macro prefixes #: and : are stripped automatically, so
          (old_text :type :string :required t
                    :description "Text to find within the matched form.
 Performs exact raw text matching (whitespace-sensitive). Must occur exactly once in the form.")
-         (new_text :type :string :required t
-                   :description "Replacement text")
+         (new_text :type :string :empty-string-is-absent nil
+                   :description "Replacement text. An empty string deletes old_text. If omitted, old_text is deleted with a warning.")
          (dry_run :type :boolean
                   :description "When true, return a preview without writing to disk")
          (readtable :type :string
@@ -220,13 +220,15 @@ is used instead of Eclector, which means comments are NOT preserved."))
            (error (e)
              (error 'arg-validation-error :arg-name "readtable"
                     :message (format nil "~A" e))))))
+    (unless new_text
+      (warn "new_text was omitted; deleting old_text. Pass new_text explicitly to silence this warning."))
     (handler-case
         (multiple-value-bind (updated changed-p)
             (lisp-patch-form :file-path file_path
                              :form-type form_type
                              :form-name form_name
                              :old-text old_text
-                             :new-text new_text
+                             :new-text (or new_text "")
                              :dry-run dry_run
                              :readtable readtable-designator)
           (if dry_run
@@ -234,7 +236,7 @@ is used instead of Eclector, which means comments are NOT preserved."))
                      (would-change (eq t (gethash "would_change" updated)))
                      (original-form (gethash "original" updated))
                      (summary (format nil "Dry-run patch on ~A ~A in ~A (~:[no change~;would change~])~
-                                      ~%~%--- original ---~%~A~%~%--- preview ---~%~A"
+                                    ~%~%--- original ---~%~A~%~%--- preview ---~%~A"
                                       form_type form_name file_path would-change
                                       original-form preview)))
                 (result id

--- a/src/tools/define-tool.lisp
+++ b/src/tools/define-tool.lisp
@@ -48,9 +48,12 @@
            :required nil
            :default nil
            :enum nil
-           :description nil))
+           :description nil
+           :empty-string-is-absent t))
     (list
-     (destructuring-bind (name &key json-name type required default enum description)
+     (destructuring-bind
+         (name &key json-name type required default enum description
+                    (empty-string-is-absent t))
          spec
        (list :name name
              :json-name (or json-name (%symbol-to-json-name name))
@@ -58,7 +61,8 @@
              :required required
              :default default
              :enum enum
-             :description description)))))
+             :description description
+             :empty-string-is-absent empty-string-is-absent)))))
 
 (defun %type-to-json-type (type)
   "Convert Lisp type keyword to JSON Schema type string."
@@ -76,12 +80,15 @@
         (json-name (getf parsed-spec :json-name))
         (type (getf parsed-spec :type))
         (required (getf parsed-spec :required))
-        (default (getf parsed-spec :default)))
+        (default (getf parsed-spec :default))
+        (empty-string-is-absent
+          (getf parsed-spec :empty-string-is-absent)))
     (if (eq type :boolean)
         `(,name (extract-boolean-arg ,args-var ,json-name :default ,default))
         `(,name (extract-arg ,args-var ,json-name
                              :type ,type
-                             :required ,required)))))
+                             :required ,required
+                             :empty-string-is-absent ,empty-string-is-absent)))))
 
 (defun %generate-schema-property (parsed-spec)
   "Generate schema property setter form for a parsed argument spec."

--- a/src/tools/helpers.lisp
+++ b/src/tools/helpers.lisp
@@ -118,7 +118,15 @@ TYPE can be :string, :integer, :number, :boolean, :array, :object, or NIL (any).
                                   (:object "an object"))))))))
 
 (declaim (ftype (function ((or hash-table null) string &key (:type (or keyword null)) (:required boolean)) t) extract-arg))
-(defun extract-arg (args name &key type required)
+
+(declaim (ftype (function ((or hash-table null) string
+                           &key (:type (or keyword null))
+                                (:required boolean)
+                                (:empty-string-is-absent boolean))
+                          t)
+                         extract-arg))
+
+(defun extract-arg (args name &key type required (empty-string-is-absent t))
   "Extract argument NAME from ARGS hash-table with optional validation.
 
 Arguments:
@@ -126,17 +134,21 @@ Arguments:
   NAME     - String key to extract
   TYPE     - Expected type (:string :integer :number :boolean :array :object)
              If NIL, no type checking is performed.
-  REQUIRED - If T, signal error when argument is missing
+  REQUIRED - If T, signal error when argument is missing.
+  EMPTY-STRING-IS-ABSENT - If T, treat an empty string as missing. Defaults to
+                           T for compatibility with clients that send defaults.
 
 Returns the argument value, or NIL if optional and not provided.
 Signals ARG-VALIDATION-ERROR on validation failure.
 
 Example:
-  (extract-arg args \"path\" :type :string :required t)
-  (extract-arg args \"limit\" :type :integer)"
+  (extract-arg args \"path\" :type :string :required t)"
   (let ((value (and args (gethash name args))))
-    ;; Treat empty string as absent — some clients send default values
-    (when (and (stringp value) (string= value ""))
+    ;; Some clients send empty defaults for every argument. A tool can opt out
+    ;; when an empty string is semantically meaningful, such as replacement text.
+    (when (and empty-string-is-absent
+               (stringp value)
+               (string= value ""))
       (setf value nil))
     (cond
       ;; Required but missing
@@ -146,6 +158,11 @@ Example:
               :message (format nil "~A is required" name)))
       ;; Present - check type
       (value
+       (%check-type-match value type name)
+       value)
+      ;; An explicitly present empty string is meaningful when requested.
+      ((and (not empty-string-is-absent)
+            (stringp value))
        (%check-type-match value type name)
        value)
       ;; Optional and missing

--- a/src/tools/helpers.lisp
+++ b/src/tools/helpers.lisp
@@ -135,6 +135,9 @@ Example:
   (extract-arg args \"path\" :type :string :required t)
   (extract-arg args \"limit\" :type :integer)"
   (let ((value (and args (gethash name args))))
+    ;; Treat empty string as absent — some clients send default values
+    (when (and (stringp value) (string= value ""))
+      (setf value nil))
     (cond
       ;; Required but missing
       ((and required (null value))

--- a/tests/lisp-patch-form-test.lisp
+++ b/tests/lisp-patch-form-test.lisp
@@ -112,6 +112,47 @@ running as root), THUNK is skipped instead."
           (ok (search "(* x 2)" updated))
           (ok (null (search "(+ x 1)" updated))))))))
 
+(deftest lisp-patch-form-empty-new-text-deletes
+  (testing "an explicit empty new_text deletes old_text"
+    (with-temp-file "tests/tmp/patch-empty-new-text.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (lisp-patch-form :file-path path
+                         :form-type "defun"
+                         :form-name "target"
+                         :old-text "(+ x 1)"
+                         :new-text "")
+        (let ((updated (fs-read-file path)))
+          (ok (null (search "(+ x 1)" updated)))
+          (ok (search "(defun target (x)" updated)))))))
+
+(deftest lisp-patch-form-handler-missing-new-text-deletes-with-warning
+  (testing "omitting new_text deletes old_text and signals a warning"
+    (with-temp-file "tests/tmp/patch-missing-new-text.lisp"
+        (format nil "(defun target (x)~%  (+ x 1))~%")
+      (lambda (path)
+        (let* ((state (cl-mcp/src/state:make-state))
+               (handler #'cl-mcp/src/lisp-patch-form::lisp-patch-form-handler)
+               (args (cl-mcp/src/tools/helpers:make-ht
+                      "file_path" path
+                      "form_type" "defun"
+                      "form_name" "target"
+                      "old_text" "(+ x 1)"))
+               (warning-message nil))
+          (handler-bind
+              ((warning (lambda (condition)
+                          (setf warning-message (princ-to-string condition))
+                          (muffle-warning condition))))
+            (let ((response (funcall handler state "test-missing-new-text" args)))
+              (ok (gethash "result" response)
+                  "omitting new_text should still produce a result")))
+          (ok (and warning-message
+                   (search "new_text was omitted" warning-message))
+              "the compatibility fallback should warn callers")
+          (let ((updated (fs-read-file path)))
+            (ok (null (search "(+ x 1)" updated))
+                "the omitted new_text fallback should delete old_text")))))))
+
 (deftest lisp-patch-form-preserves-surrounding
   (testing "patch only modifies target form, rest of file unchanged"
     (with-temp-file "tests/tmp/patch-preserve.lisp"
@@ -463,8 +504,8 @@ running as root), THUNK is skipped instead."
             "form_name should be required")
         (ok (find "old_text" required :test #'string=)
             "old_text should be required")
-        (ok (find "new_text" required :test #'string=)
-            "new_text should be required"))
+        (ok (not (find "new_text" required :test #'string=))
+            "new_text should be optional for backward-compatible deletion"))
       ;; Should NOT have structural operation params
       (let ((properties (gethash "properties" schema)))
         (ok (null (gethash "content" properties))


### PR DESCRIPTION
Some models (*cough*, ChatGPT Codex, *cough*) can't get it through their thick skulls not to send all parameters when running the `lisp-check-parens` tool. I spent *hours* trying to get Codex to just send `{"path":...}` to that tool. It finally did it at the end of testing changes for this PR, but by then I was too exhausted not to send this PR in.

This commit makes it so that if empty strings are sent in any of the arguments, it is as if they didn't set the argument at all.