### PR TITLE
test-runner: purge ghost suites from the registry, not the search path

### DIFF
--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -488,32 +488,50 @@ representation covers both Rove and FiveAM target-resolution failures."
                    (format nil "~A~%~%Hint: ~A" detail hint)
                    detail))))))
 
-(defun %extract-defpackage-names-from-file (pathname)
+(defun %extract-defpackage-names-from-file (pathname &optional scan-package)
   "Return a list of package names mentioned in `(defpackage ...)' forms
-of the Lisp source file at PATHNAME. Silently returns NIL on any error."
-  (handler-case
-      (with-open-file (stream pathname :direction :input)
-        (let ((*read-eval* nil)
-              (*package* (find-package :cl-user))
-              (names nil))
-          (loop
-           (let ((form (handler-case (read stream nil :eof)
-                         (error () :eof))))
-             (when (eq form :eof) (return))
-             (when (and (consp form)
-                        (symbolp (car form))
-                        (or (string= (symbol-name (car form)) "DEFPACKAGE")
-                            (string= (symbol-name (car form)) "DEFINE-PACKAGE"))
-                        (consp (cdr form)))
-               (let ((name-form (second form)))
-                 (push
-                  (cond
-                    ((stringp name-form) name-form)
-                    ((symbolp name-form) (symbol-name name-form))
-                    (t nil))
-                  names)))))
-          (remove-if-not #'stringp (nreverse names))))
-    (error () nil)))
+of the Lisp source file at PATHNAME. Silently returns NIL on any error.
+
+READ interns every unqualified symbol it reads into *PACKAGE*, so the scan
+must not run in CL-USER: one %ROVE-PURGE-GHOST-SUITES traversal of a large
+dependency graph reads over a thousand files and would leave every symbol
+in them behind.  SCAN-PACKAGE names a throwaway package to intern into.
+When it is NIL one is created and deleted around the read; a caller
+scanning many files should create one and pass it in.
+
+The scan package uses CL, so DEFPACKAGE, keywords, #:-prefixed uninterned
+symbols and package-qualified symbols all read exactly as they did in
+CL-USER -- only the resting place of newly created symbols changes.  The
+names returned are strings and stay valid after the package is deleted."
+  (let ((own-package (unless scan-package
+                       (make-package (gensym "CL-MCP-DEFPACKAGE-SCAN")
+                                     :use '(:cl)))))
+    (unwind-protect
+        (handler-case
+            (with-open-file (stream pathname :direction :input)
+              (let ((*read-eval* nil)
+                    (*package* (or scan-package own-package))
+                    (names nil))
+                (loop
+                 (let ((form (handler-case (read stream nil :eof)
+                               (error () :eof))))
+                   (when (eq form :eof) (return))
+                   (when (and (consp form)
+                              (symbolp (car form))
+                              (or (string= (symbol-name (car form)) "DEFPACKAGE")
+                                  (string= (symbol-name (car form)) "DEFINE-PACKAGE"))
+                              (consp (cdr form)))
+                     (let ((name-form (second form)))
+                       (push
+                        (cond
+                          ((stringp name-form) name-form)
+                          ((symbolp name-form) (symbol-name name-form))
+                          (t nil))
+                        names)))))
+                (remove-if-not #'stringp (nreverse names))))
+          (error () nil))
+      (when own-package
+        (ignore-errors (delete-package own-package))))))
 
 (defun %rove-purge-ghost-suites (system-name)
   "Remove Rove suite entries for every test package associated with
@@ -538,48 +556,70 @@ package-inferred-system and classic ASDF layouts:
      tree under SYSTEM-NAME, read each source file, and clear
      packages named in its `(defpackage ...)' forms. Catches classic
      defsystems where the package name does not match any ASDF
-     sub-system name."
+     sub-system name.
+
+Names resolve through ASDF:REGISTERED-SYSTEM, never FIND-SYSTEM -- the
+rule %TRANSITIVE-DEPENDENCY-NAMES follows, for the same two reasons.
+FIND-SYSTEM resolves a name by *loading the .asd*, which may carry
+:DEFSYSTEM-DEPENDS-ON and build whole systems as a side effect, here in
+the middle of RUN-TESTS.  It is also ruinous for latency: outside an ASDF
+session every call re-runs the source-registry search, measured at 114 ms,
+and a large package-inferred project reaches 905 systems -- 103 seconds of
+purging before a single test runs.  REGISTERED-SYSTEM makes the same
+traversal cost 0.3 seconds and loses nothing, because a system that is not
+registered has never been loaded: its packages do not exist, so Rove holds
+no suite for them and there is no ghost to purge.
+
+Nothing is walked when Rove's registry is empty, and the source scan
+interns into one throwaway package, deleted afterwards, rather than into
+CL-USER."
   (let ((pkgs-var (find-symbol "*PACKAGE-SUITES*" :rove/core/suite/package)))
     (when (and pkgs-var (boundp pkgs-var)
-               (hash-table-p (symbol-value pkgs-var)))
+               (hash-table-p (symbol-value pkgs-var))
+               (plusp (hash-table-count (symbol-value pkgs-var))))
       (let ((suites (symbol-value pkgs-var))
             (visited-systems (make-hash-table :test #'equal))
-            (visited-files (make-hash-table :test #'equal)))
-        (labels ((clear-pkg (pkg-name)
-                   (let ((pkg (and (stringp pkg-name) (find-package pkg-name))))
-                     (when pkg (remhash pkg suites))))
-                 (walk-components (component)
-                   (when component
-                     (cond
-                       ((typep component 'asdf:cl-source-file)
-                        (let ((path (ignore-errors
-                                      (asdf:component-pathname component))))
-                          (when (and path
-                                     (not (gethash (namestring path)
-                                                   visited-files))
-                                     (probe-file path))
-                            (setf (gethash (namestring path) visited-files) t)
-                            (dolist (pkg-name
-                                     (%extract-defpackage-names-from-file path))
-                              (clear-pkg pkg-name)))))
-                       ((ignore-errors (asdf:component-children component))
-                        (dolist (child (asdf:component-children component))
-                          (walk-components child))))))
-                 (walk-system (name)
-                   (when (and (stringp name)
-                              (not (gethash name visited-systems)))
-                     (setf (gethash name visited-systems) t)
-                     (clear-pkg name)
-                     (let ((sys (ignore-errors (asdf:find-system name nil))))
-                       (when sys
-                         (walk-components sys)
-                         (dolist (dep (ignore-errors
-                                        (asdf:system-depends-on sys)))
-                           (cond
-                             ((stringp dep) (walk-system dep))
-                             ((and (consp dep) (stringp (second dep)))
-                              (walk-system (second dep))))))))))
-          (walk-system system-name))))))
+            (visited-files (make-hash-table :test #'equal))
+            (scan-package (make-package (gensym "CL-MCP-DEFPACKAGE-SCAN")
+                                        :use '(:cl))))
+        (unwind-protect
+            (labels ((clear-pkg (pkg-name)
+                       (let ((pkg (and (stringp pkg-name) (find-package pkg-name))))
+                         (when pkg (remhash pkg suites))))
+                     (walk-components (component)
+                       (when component
+                         (cond
+                           ((typep component 'asdf:cl-source-file)
+                            (let ((path (ignore-errors
+                                          (asdf:component-pathname component))))
+                              (when (and path
+                                         (not (gethash (namestring path)
+                                                       visited-files))
+                                         (probe-file path))
+                                (setf (gethash (namestring path) visited-files) t)
+                                (dolist (pkg-name
+                                         (%extract-defpackage-names-from-file
+                                          path scan-package))
+                                  (clear-pkg pkg-name)))))
+                           ((ignore-errors (asdf:component-children component))
+                            (dolist (child (asdf:component-children component))
+                              (walk-components child))))))
+                     (walk-system (name)
+                       (when (and (stringp name)
+                                  (not (gethash name visited-systems)))
+                         (setf (gethash name visited-systems) t)
+                         (clear-pkg name)
+                         (let ((sys (ignore-errors (asdf:registered-system name))))
+                           (when sys
+                             (walk-components sys)
+                             (dolist (dep (ignore-errors
+                                            (asdf:system-depends-on sys)))
+                               (cond
+                                 ((stringp dep) (walk-system dep))
+                                 ((and (consp dep) (stringp (second dep)))
+                                  (walk-system (second dep))))))))))
+              (walk-system system-name))
+          (ignore-errors (delete-package scan-package)))))))
 
 (defun %ensure-rove-test-name-method ()
   "Add a TEST-NAME method for FAILED-ASSERTION if Rove is loaded and the

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -481,6 +481,90 @@
       (ignore-errors
        (uiop/filesystem:delete-directory-tree tmp-dir :validate t))))))
 
+(deftest rove-purge-ghost-suites-resolves-names-from-the-registry-only
+  (testing "%rove-purge-ghost-suites must not load a dependency's .asd"
+    ;; Resolving dependency names with ASDF:FIND-SYSTEM loads the .asd of any
+    ;; name that is merely discoverable, which both builds systems as a side
+    ;; effect (:defsystem-depends-on) and, outside an ASDF session, re-runs the
+    ;; source-registry search on every call -- 103 seconds on a project whose
+    ;; graph reaches 905 systems.  Pin the registry-only lookup by leaving a
+    ;; discoverable-but-unregistered dependency in the graph and asserting the
+    ;; purge never registers it.
+    (let* ((tmp-dir
+             (uiop:ensure-directory-pathname
+              (uiop:merge-pathnames*
+               (format nil "cl-mcp-purge-registry-~A-~A/"
+                       (get-universal-time) (random 100000))
+               (uiop:temporary-directory))))
+           (root-name "cl-mcp-purge-registry-root")
+           (leaf-name "cl-mcp-purge-registry-leaf")
+           (root-asd (uiop:merge-pathnames*
+                      (format nil "~A.asd" root-name) tmp-dir))
+           (leaf-asd (uiop:merge-pathnames*
+                      (format nil "~A.asd" leaf-name) tmp-dir))
+           (asdf:*central-registry* (cons tmp-dir asdf:*central-registry*)))
+      (unwind-protect
+           (progn
+             (ensure-directories-exist tmp-dir)
+             (with-open-file (s root-asd :direction :output :if-exists :supersede)
+               (format s "(asdf:defsystem ~S~%  :depends-on (~S))~%"
+                       root-name leaf-name))
+             (with-open-file (s leaf-asd :direction :output :if-exists :supersede)
+               (format s "(asdf:defsystem ~S)~%" leaf-name))
+             (asdf/find-system:load-asd root-asd)
+             (ok (asdf:registered-system root-name)
+                 "root system is registered before the purge")
+             (ok (null (asdf:registered-system leaf-name))
+                 "leaf system is discoverable but unregistered before the purge")
+             ;; Guard against a false pass: the purge returns immediately when
+             ;; Rove's registry is empty, which would satisfy the assertion
+             ;; below without the walk ever running.
+             (ok (plusp (hash-table-count
+                         (symbol-value
+                          (find-symbol "*PACKAGE-SUITES*"
+                                       :rove/core/suite/package))))
+                 "Rove holds at least one suite, so the purge really walks")
+             (cl-mcp/src/test-runner-core::%rove-purge-ghost-suites root-name)
+             (ok (null (asdf:registered-system leaf-name))
+                 "purge must not load a dependency's .asd to resolve its name"))
+        (ignore-errors (asdf/system-registry:clear-system root-name))
+        (ignore-errors (asdf/system-registry:clear-system leaf-name))
+        (ignore-errors
+         (uiop:delete-directory-tree tmp-dir :validate t))))))
+
+(deftest extract-defpackage-names-does-not-intern-into-cl-user
+  (testing "%extract-defpackage-names-from-file leaves CL-USER untouched"
+    ;; READ interns every unqualified symbol it reads into *PACKAGE*.  A purge
+    ;; traversal scans over a thousand files, so scanning in CL-USER dumps all
+    ;; of their symbols there.
+    (let* ((tmp-dir
+             (uiop:ensure-directory-pathname
+              (uiop:merge-pathnames*
+               (format nil "cl-mcp-scan-package-~A-~A/"
+                       (get-universal-time) (random 100000))
+               (uiop:temporary-directory))))
+           (src-path (uiop:merge-pathnames* "scan-target.lisp" tmp-dir))
+           (pkg-name "CL-MCP-SCAN-TARGET-PACKAGE")
+           (marker "CL-MCP-SCAN-MARKER-SYMBOL"))
+      (unwind-protect
+           (progn
+             (ensure-directories-exist tmp-dir)
+             (with-open-file (s src-path :direction :output :if-exists :supersede)
+               (format s "(defpackage #:~A~%  (:use #:cl))~%" pkg-name)
+               (format s "(in-package #:~A)~%" pkg-name)
+               (format s "(defun ~A (x) x)~%" marker))
+             (ok (null (find-symbol marker :cl-user))
+                 "marker symbol is absent from CL-USER before the scan")
+             (let ((names
+                     (cl-mcp/src/test-runner-core::%extract-defpackage-names-from-file
+                      src-path)))
+               (ok (member pkg-name names :test #'string-equal)
+                   "the defpackage name is still extracted"))
+             (ok (null (find-symbol marker :cl-user))
+                 "scanning must not intern the file's symbols into CL-USER"))
+        (ignore-errors
+         (uiop:delete-directory-tree tmp-dir :validate t))))))
+
 (deftest format-load-error-includes-compiler-output
   (testing "no compiler output: message is just the base error"
     (let ((msg (cl-mcp/src/test-runner-core::%format-load-error


### PR DESCRIPTION
## Problem

`run-tests` spends about **103 seconds** inside `%rove-purge-ghost-suites` before a single test runs.

The source-file scanning the function performs is not the cost. It is the `asdf:find-system` calls the walk makes: outside an ASDF session every call re-runs the source-registry search, and a large package-inferred project reaches 905 systems.

Measured against a reference system — a single-file leaf test system in a large package-inferred application (SBCL 2.1.10, ASDF 3.3.1). All numbers are warm: the image had already loaded the system under test, and `find-system` had already been called on every name in the graph.

| Quantity | Value |
| --- | --- |
| ASDF systems reached by `walk-system` | 905 |
| Source files scanned / total size | 1,705 files / 17 MB |
| `asdf:find-system` × 905 (before) | **103 s** (114 ms per call) |
| `%extract-defpackage-names-from-file` × 1,705 | **0.35 s** |
| Whole purge, after this change | **0.29 s** |

The scanning is cheap because `read` aborts at the first form it cannot read — typically an unknown package prefix a few forms in — so most files are only read at the head.

`find-system` is expensive because the source-registry search is memoised per ASDF session, and the purge runs outside one:

| Call pattern | Time |
| --- | --- |
| `find-system` × 61, no session | 6.84 s |
| `find-system` × 61, inside `with-asdf-session` | 0.44 s |
| `find-system` × 905, inside `with-asdf-session` | 2.53 s |

## Change

**Resolve names with `asdf:registered-system`, never `find-system`** — the rule `%transitive-dependency-names` already documents, for the same two reasons. Its docstring records `find-system` pulling in cffi-grovel, cffi-toolchain and four iolib systems (13 MB of fasls) as a side effect of one detection call, and concludes that detection must observe, not build. The purge is a discovery pass with the same requirements and had missed that lesson.

Nothing is lost. A system that is not registered has never been loaded in this image, so its packages do not exist, so Rove holds no suite for them and there is no ghost to purge.

Two defects in the same code path go with it:

- **The walk ran even when Rove's registry was empty.** It now returns immediately, which is equivalent by construction: every `clear-pkg` against an empty table is a `remhash` no-op.
- **`%extract-defpackage-names-from-file` read into `CL-USER`**, interning every symbol of the thousand-plus files it scanned. It gains an optional `scan-package`; the purge creates one throwaway package (`:use '(:cl)`) for the whole traversal and deletes it under `unwind-protect`. `:use '(:cl)` keeps reader behaviour identical for everything the function inspects, and the names it returns are strings that stay valid after the package is deleted.

## Behaviour change

Not strictly equivalent, and worth stating precisely. `find-system` can newly register a system by loading its `.asd`; `registered-system` returns `NIL` instead, so the walk does not recurse past an unregistered name.

If root `R` declares a dependency on `S`, `S` has never been loaded, `S` declares a dependency on `T`, `T` was loaded by some other route and holds ghosts, and `T` is not otherwise reachable from `R` through registered edges — then the old code purged `T` and this one does not. The miss lasts exactly one run: the `load-system R` that immediately follows registers `S`, so the next run reaches `T`.

The capability given up in that scenario is the one the codebase already classifies as a hazard.

## Rejected alternative

Keeping `find-system` and wrapping the walk in `asdf/session:with-asdf-session` preserves the current semantics exactly and costs 2.53 s instead of 103 s. Rejected: still ~10× slower than the registry walk, still loads `.asd` files as a side effect, and the macro is a moving target across ASDF versions (3.3.1 exports it from `asdf/session`; older releases named it `with-asdf-cache`).

## Tests

Timing assertions are flaky, so the regression is pinned by behaviour.

- **`rove-purge-ghost-suites-resolves-names-from-the-registry-only`** — leaves a *discoverable but unregistered* dependency in the graph via `asdf:*central-registry*` and asserts the purge never registers it. It also asserts `*PACKAGE-SUITES*` is non-empty first, so the new empty-registry early return cannot turn it into a false pass.
- **`extract-defpackage-names-does-not-intern-into-cl-user`** — scans a file containing a uniquely named symbol and asserts `find-symbol` for it in `CL-USER` returns `NIL`.
- **`rove-purge-ghost-suites-removes-stale-tests`** — unchanged and still passing; it covers the classic-defsystem component-scanning path.

The new regression test was verified to discriminate: with the same fixture, calling the `find-system` the old code used does register the leaf, so reverting the change fails the test.

## Verification

Run with `run-tests`:

- `cl-mcp/tests/test-runner-test` — **43 passed, 0 failed**
- `cl-mcp/tests/system-loader-test` — 17 passed, 0 failed
- `cl-mcp/tests/response-builders-test` — 12 passed, 0 failed

Side effects measured across a purge of the reference system: `CL-USER` symbol count 1460 → 1460, total package count 1741 → 1741, no scan package left behind.

End-to-end `run-tests` on the reference system went from exceeding a 60 s client timeout to **2.4 s**, repeatable across sibling test systems (2.2 s, 2.4 s).

`cl-mcp/tests/tools-test` did not complete in my environment. A backtrace shows it blocked in Quicklisp dist enumeration (`DIRECTORY #P".../dists/*/distinfo.txt"` under `QL-DIST:FIND-SYSTEM`) resolving a name belonging to the large downstream project whose registry that image carries — unrelated to this change, which `tools-test` does not reference. The full suite needs a CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
