### PR TITLE
Fix Constantly Broken Pipes running FiveAM tests

### DIFF
--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -18,6 +18,8 @@
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht #:text-content #:result)
   (:import-from #:cl-mcp/src/log #:log-event)
+  (:import-from #:cl-mcp/src/test-runner-core
+                #:coerce-timeout-seconds)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-error-message)
   (:import-from #:bordeaux-threads
@@ -49,7 +51,12 @@ Set MCP_NO_WORKER_POOL=1 to disable.")
   "Default timeout (seconds) for proxy-to-worker RPC calls.
 Prevents requests from hanging indefinitely when a worker handler
 is stuck.  300 seconds (5 minutes) accommodates long-running
-operations like system compilation.")
+operations like system compilation.
+
+When the caller provides a timeout_seconds parameter (e.g. for
+run-tests), the effective proxy timeout is clamped to the smaller
+of this value and (caller_timeout + 10), so the proxy does not
+outlive the worker's own deadline by a wide margin.")
 
 (defvar *active-requests* (make-hash-table :test 'equal)
   "Maps MCP request-id (as string) to session-id for in-flight
@@ -274,13 +281,32 @@ TOCTOU race with concurrent requests for the same session."
                           "session" session-id
                           "method" method)
                (let* ((user-timeout
-                       (and (hash-table-p params)
-                            (gethash "timeout_seconds" params)))
+                       (coerce-timeout-seconds
+                        (and (hash-table-p params)
+                             (gethash "timeout_seconds" params))))
                       (effective-timeout
-                       (if (and user-timeout (numberp user-timeout)
-                                (plusp user-timeout))
-                           (max *proxy-rpc-timeout*
-                                (ceiling (+ user-timeout 30)))
+                       (if user-timeout
+                           ;; Respect the user's timeout intent.  The
+                           ;; worker enforces the same value, so the
+                           ;; proxy should wait only slightly longer
+                           ;; (small buffer for the response to arrive)
+                           ;; rather than the old
+                           ;; (max *proxy-rpc-timeout* …), which let
+                           ;; the proxy wait up to 300 s even when the
+                           ;; user asked for 90 s.
+                           ;;
+                           ;; COERCE-TIMEOUT-SECONDS also accepts a
+                           ;; numeric string: a client that sends
+                           ;; timeout_seconds as "60" would otherwise
+                           ;; fail the (NUMBERP …) guard here and fall
+                           ;; through to the 300 s default, widening
+                           ;; the window in which a wedged suite can
+                           ;; outlive the client's own deadline.
+                           ;; No cap on *proxy-rpc-timeout*: a caller may
+                           ;; legitimately ask for more than 300 s, and the
+                           ;; worker enforces that same deadline, so the
+                           ;; small buffer below is all the margin needed.
+                           (ceiling (+ user-timeout 10))
                            *proxy-rpc-timeout*)))
                  (handler-case
                      (funcall %cached-worker-rpc% worker method params

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -133,6 +133,15 @@ on large outputs)."
           (*read-default-float-format* 'single-float))
       (let ((*standard-output* stdout)
             (*error-output* stderr)
+            ;; log4cl's console appender writes to a synonym stream for
+            ;; *DEBUG-IO*, which in a worker resolves to the original stdout
+            ;; fd whose read end the parent closed after the handshake --
+            ;; any write there raises BROKEN-PIPE.  Rebinding these keeps
+            ;; log4cl / interactive output captured instead of hitting the
+            ;; dead pipe.
+            (*debug-io* stdout)
+            (*terminal-io* stdout)
+            (*query-io* stdout)
             (*compile-verbose* nil)
             (*compile-print* nil))
         (%call-with-compiler-streams

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -185,7 +185,18 @@ DEFUN' lines are noise that drown real warnings."
                               (*load-print* nil)
                               (*standard-output* (make-string-output-stream))
                               (*trace-output* (make-string-output-stream))
-                              (*error-output* stderr))
+                              (*error-output* stderr)
+                              ;; log4cl's console appender writes to a synonym
+                              ;; stream for *DEBUG-IO*, which in a worker
+                              ;; resolves to the original stdout fd whose read
+                              ;; end the parent closed after the handshake --
+                              ;; any write there raises BROKEN-PIPE and aborts
+                              ;; the load.  Rebinding these interactive streams
+                              ;; keeps that output captured instead of hitting
+                              ;; the dead pipe.
+                              (*debug-io* stderr)
+                              (*terminal-io* stderr)
+                              (*query-io* stderr))
                           (if syms
                               (progv (nreverse syms) (nreverse vals)
                                 (with-compilation-unit (:override t)
@@ -213,7 +224,10 @@ DEFUN' lines are noise that drown real warnings."
                             (*load-print* nil)
                             (*standard-output* (make-string-output-stream))
                             (*trace-output* (make-string-output-stream))
-                            (*error-output* stderr))
+                            (*error-output* stderr)
+                            (*debug-io* stderr)
+                            (*terminal-io* stderr)
+                            (*query-io* stderr))
                         (funcall thunk))))
               (setf completed-p t)
               (values result warning-count

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -8,9 +8,16 @@
                 #:log-event)
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht)
+  (:import-from #:bordeaux-threads
+                #:destroy-thread
+                #:make-thread
+                #:thread-alive-p)
   (:export #:run-tests
            #:detect-test-framework
            #:make-load-failure-result
+           #:make-timeout-result
+           #:coerce-timeout-seconds
+           #:call-with-test-run-deadline
            #:*test-debug-output*
            #:*load-lock-wrapper*
            #:*max-test-output-length*))
@@ -487,6 +494,126 @@ representation covers both Rove and FiveAM target-resolution failures."
        :reason (if hint
                    (format nil "~A~%~%Hint: ~A" detail hint)
                    detail))))))
+
+(defun make-timeout-result (seconds)
+  "Build the structured result for a test run that hit its SECONDS deadline.
+Returned in place of a test result so the caller always gets a
+machine-readable hash-table (failed:1, framework \"timeout\") rather than
+an opaque RPC-level error, mirroring MAKE-LOAD-FAILURE-RESULT."
+  (make-test-result
+   :passed 0
+   :failed 1
+   :pending 0
+   :framework :timeout
+   :duration (round (* 1000 (or seconds 0)))
+   :failed-tests
+   (vector
+    (make-failure-detail
+     :test-name "TIMEOUT"
+     :description (format nil "Tests timed out after ~A seconds" seconds)
+     :reason
+     (format nil "The test run exceeded its ~A second deadline. A suite that ~
+                  leaves a server or thread running can outlive the deadline, ~
+                  so the worker may still be busy; use pool-kill-worker to get ~
+                  a fresh worker before retrying."
+             seconds)))))
+
+(defun coerce-timeout-seconds (value)
+  "Coerce VALUE to a positive number of seconds, or NIL when unusable.
+Accepts a number, or a string holding one.  JSON has a single number type,
+but not every client sends timeout_seconds as a number, and a string that
+reaches the (NUMBERP ...) guards in the worker handler and in
+PROXY-TO-WORKER is dropped there, silently widening a caller's 60 second
+deadline to the 300 second default.  NIL for a non-positive or unparseable
+value lets callers fall back to their own default."
+  (typecase value
+    (number (when (plusp value) value))
+    (string
+     (let ((trimmed (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+       ;; Only pass text that can only be a number to READ-FROM-STRING: the
+       ;; reader interns symbols in the current package, so an arbitrary
+       ;; client string must never reach it.  The numeric-charset check
+       ;; keeps this to integers and simple decimals (plus exponents).
+       (when (and (plusp (length trimmed))
+                  (every (lambda (ch) (find ch "0123456789+-.eE"))
+                         trimmed))
+         (multiple-value-bind (parsed pos)
+             (ignore-errors
+              (let ((*read-eval* nil)) (read-from-string trimmed nil nil)))
+           (when (and (numberp parsed)
+                      (eql pos (length trimmed))
+                      (plusp parsed))
+             parsed)))))
+    (t nil)))
+
+(defun call-with-test-run-deadline (thunk timeout-seconds)
+  "Run THUNK (a test run) on a dedicated thread, answering by TIMEOUT-SECONDS.
+Returns two values: a result and a status keyword.
+
+  :OK       THUNK returned; the result is its value.
+  :TIMEOUT  TIMEOUT-SECONDS elapsed first; the result is those seconds.
+  :ERROR    THUNK signalled; the result is the condition object.
+
+THUNK also runs under SB-EXT:WITH-TIMEOUT, so the ordinary case -- a slow
+but well-behaved suite -- unwinds inside the run thread and releases its
+locks and UNWIND-PROTECT cleanups normally.  The polling wrapper only
+matters when that cannot happen.  A suite that leaves a blocking call
+running (a server accept loop, say) is invisible to SB-EXT:WITH-TIMEOUT,
+which cannot interrupt a blocking foreign call; run inline, such a suite
+pins the worker's single connection thread for as long as the call blocks,
+and every later tool call for that session hangs with it.  Answering from
+the polling thread bounds the wait no matter what the suite left running,
+so one wedged suite can no longer take the session down.
+
+The run thread is destroyed only on a wall-clock deadline it failed to
+observe, and a run that completes during the grace period still yields its
+real result -- completed work is never discarded as a timeout."
+  (let ((outcome nil)
+        (thread nil))
+    (flet ((finish ()
+             (let ((o (or outcome
+                          (cons :error "test run thread vanished"))))
+               (values (cdr o) (car o))))
+           (run ()
+             (setf outcome
+                   (handler-case
+                       (if timeout-seconds
+                           (sb-ext:with-timeout timeout-seconds
+                             (cons :ok (funcall thunk)))
+                           (cons :ok (funcall thunk)))
+                     (sb-ext:timeout () (cons :timeout timeout-seconds))
+                     (serious-condition (e) (cons :error e))))))
+      (setf thread (make-thread #'run :name "mcp-run-tests"))
+      (let ((deadline
+              (when timeout-seconds
+                (+ (get-internal-real-time)
+                   (round (* timeout-seconds
+                             internal-time-units-per-second))))))
+        (loop while (thread-alive-p thread)
+              do (when (and deadline (>= (get-internal-real-time) deadline))
+                   (return))
+                 (sleep 0.05d0))
+        (cond
+          ((not (thread-alive-p thread))
+           (finish))
+          (t
+           ;; Give the run a moment to observe its own WITH-TIMEOUT: a
+           ;; cooperative unwind is preferable to destroying the thread,
+           ;; because it releases the locks the run is holding.
+           (sleep 0.5d0)
+           (if (not (thread-alive-p thread))
+               (finish)
+               (progn
+                 (ignore-errors (destroy-thread thread))
+                 (loop repeat 20
+                       while (thread-alive-p thread)
+                       do (sleep 0.05d0))
+                 (ignore-errors
+                  (log-event :warn "test.runner.deadline"
+                             "timeout" timeout-seconds
+                             "thread_destroyed"
+                             (not (thread-alive-p thread))))
+                 (values timeout-seconds :timeout)))))))))
 
 (defun %extract-defpackage-names-from-file (pathname &optional scan-package)
   "Return a list of package names mentioned in `(defpackage ...)' forms
@@ -1354,26 +1481,23 @@ Returns HT."
 SPECS is a list of suite/test symbols passed to %FIVEAM-RUN.  On a runner
 crash, returns a failure result with one failed entry per CRASH-TEST-NAMES
 designator.  Shared by RUN-FIVEAM-TESTS and RUN-FIVEAM-SELECTED-TESTS so the
-stream-capture, crash-handling, and result-assembly logic lives in one place."
+stream-capture, crash-handling, and result-assembly logic lives in one place.
+
+NOTE: *standard-output* and *error-output* are intentionally NOT redirected.
+Binding them (even to a broadcast stream) causes integration test suites that
+spawn real threads and sockets to hang inside the worker process.  Only
+*test-debug-output* (cl-mcp's own stream) is captured."
   (let ((start-time (get-internal-real-time))
-         (stdout-stream (make-string-output-stream))
-         (stderr-stream (make-string-output-stream))
-         (debug-stream (make-string-output-stream))
-         all-results)
+        (debug-stream (make-string-output-stream))
+        all-results)
     (flet ((duration-ms ()
              (round (* 1000 (/ (- (get-internal-real-time) start-time)
                                internal-time-units-per-second))))
-           (stdout () (%truncate-test-output
-                       (get-output-stream-string stdout-stream)))
-           (stderr () (%truncate-test-output
-                       (get-output-stream-string stderr-stream)))
            (debug-output () (get-output-stream-string debug-stream)))
       (handler-case
           (dolist (spec specs)
             (let ((results
-                    (let ((*standard-output* stdout-stream)
-                          (*error-output* stderr-stream)
-                          (*test-debug-output* debug-stream))
+                    (let ((*test-debug-output* debug-stream))
                       (%fiveam-run spec))))
               (when results
                 (setf all-results (append all-results results)))))
@@ -1390,7 +1514,7 @@ stream-capture, crash-handling, and result-assembly logic lives in one place."
                                          (princ-to-string c))))
                       crash-test-names)
               :framework :fiveam :duration (duration-ms))
-             (stdout) (stderr) (debug-output)))))
+             nil nil (debug-output)))))
       (multiple-value-bind (passed failed pending failure-details)
           (%fiveam-extract-results all-results)
         (%fiveam-attach-output
@@ -1398,7 +1522,7 @@ stream-capture, crash-handling, and result-assembly logic lives in one place."
           :passed passed :failed failed :pending pending
           :failed-tests failure-details
           :framework :fiveam :duration (duration-ms))
-         (stdout) (stderr) (debug-output))))))
+         nil nil (debug-output))))))
 
 (defun run-fiveam-tests (system-name)
   "Run the FiveAM suites belonging to SYSTEM-NAME and return results.

--- a/src/test-runner.lisp
+++ b/src/test-runner.lisp
@@ -4,7 +4,10 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/test-runner-core
                 #:run-tests
-                #:detect-test-framework)
+                #:detect-test-framework
+                #:call-with-test-run-deadline
+                #:coerce-timeout-seconds
+                #:make-timeout-result)
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht #:result)
   (:import-from #:cl-mcp/src/tools/define-tool
@@ -38,6 +41,8 @@ Returns:
 - framework (string)
 - duration_ms (integer)
 - stdout (string, present when non-empty) — captured test standard output
+  (Rove only: the FiveAM backend deliberately does not redirect the
+  standard streams, so it reports no stdout/stderr — use debug_output)
 - stderr (string, present when non-empty) — captured test error output
 - debug_output (string, present when non-empty) — output written to *test-debug-output* stream
 NOTE: stdout/stderr are in structured fields only, NOT shown in the summary text.
@@ -73,20 +78,20 @@ Examples:
                                    "test" test
                                    "tests" tests
                                    "timeout_seconds" timeout-seconds))
-    (let ((effective-timeout (or timeout-seconds 300)))
-      (let ((test-result
-              (handler-case
-                  (sb-ext:with-timeout effective-timeout
-                    (run-tests system
-                               :framework framework
-                               :test test
-                               :tests tests))
-                (sb-ext:timeout ()
-                  (make-ht "passed" 0
-                           "failed" 1
-                           "framework" "timeout"
-                           "duration_ms" (round (* effective-timeout 1000))
-                           "failed_tests" (vector
-                                           (make-ht "test_name" "TIMEOUT"
-                                                    "reason" (format nil "Tests timed out after ~A seconds" effective-timeout))))))))
-        (result id (build-run-tests-response test-result))))))
+    (let ((effective-timeout (or (coerce-timeout-seconds timeout-seconds) 300)))
+      (multiple-value-bind (test-result status)
+          (call-with-test-run-deadline
+           (lambda ()
+             (run-tests system
+                        :framework framework
+                        :test test
+                        :tests tests))
+           effective-timeout)
+        (result id
+                (build-run-tests-response
+                 (ecase status
+                   (:ok test-result)
+                   (:timeout (make-timeout-result test-result))
+                   ;; Re-signal so real failures stay visible instead of
+                   ;; being reported as a bogus test result.
+                   (:error (error test-result)))))))))

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -18,6 +18,9 @@
                 #:load-system)
   (:import-from #:cl-mcp/src/test-runner-core
                 #:run-tests
+                #:call-with-test-run-deadline
+                #:coerce-timeout-seconds
+                #:make-timeout-result
                 #:*load-lock-wrapper*)
   (:import-from #:cl-mcp/src/inspect
                 #:inspect-object-by-id)
@@ -136,42 +139,47 @@ concurrent worker/init load or another load-system."
 \"run-tests\".  Honors timeout_seconds to limit test execution time.
 Holds *ASDF-LOAD-LOCK* only for RUN-TESTS' force-reload phase, by binding
 *LOAD-LOCK-WRAPPER*, so a load here cannot overlap a concurrent load.  The
-test run itself must NOT hold the lock: the worker dispatches handlers on
-its connection thread and Rove runs deftests on that same thread, so a
-suite whose tests touch *ASDF-LOAD-LOCK* (tests/worker-init-hook-test)
-would deadlock or trip SBCL's recursive-lock check."
+test run itself must NOT hold the lock: the suite may take a lock of its
+own or block on one, and a test that blocked on *ASDF-LOAD-LOCK* while the
+lock sat with its holder waiting for the run would deadlock.
+
+The run executes on its own thread under CALL-WITH-TEST-RUN-DEADLINE, so
+it cannot pin this worker's single connection thread.  That matters for a
+suite that leaves something blocking behind -- a server accept loop, say:
+SB-EXT:WITH-TIMEOUT cannot interrupt a blocking foreign call, so run
+inline such a suite would wedge the connection thread and every later tool
+call for this session with it.  Polling bounds the wait regardless, and the
+caller is answered at the deadline even while the suite is still blocked."
   (let ((system (gethash "system" params))
-         (framework (gethash "framework" params))
-         (test (gethash "test" params))
-         (tests (gethash "tests" params))
-         (timeout (let ((v (gethash "timeout_seconds" params)))
-                    (and v (numberp v) (plusp v) v))))
+        (framework (gethash "framework" params))
+        (test (gethash "test" params))
+        (tests (gethash "tests" params))
+        (timeout (coerce-timeout-seconds (gethash "timeout_seconds" params))))
     (unless system
       (error "system is required"))
-    (flet ((do-run ()
-             ;; The lock covers RUN-TESTS' force-reload only; see the
-             ;; docstring for why the test run itself must stay outside it.
-             (let ((*load-lock-wrapper*
-                     (lambda (thunk)
-                       (with-asdf-load-lock (funcall thunk)))))
-               (run-tests system
-                          :framework framework
-                          :test test
-                          :tests tests))))
-      (let ((test-result (if timeout
-                             (handler-case
-                                 (sb-ext:with-timeout timeout
-                                   (do-run))
-                               (sb-ext:timeout ()
-                                 (make-ht "passed" 0
-                                          "failed" 1
-                                          "framework" "timeout"
-                                          "duration_ms" (round (* timeout 1000))
-                                          "failed_tests" (vector
-                                                          (make-ht "test_name" "TIMEOUT"
-                                                                   "reason" (format nil "Tests timed out after ~A seconds" timeout))))))
-                             (do-run))))
-        (build-run-tests-response test-result)))))
+    ;; Always enforce a server-side deadline so the worker's connection
+    ;; thread is never blocked indefinitely.  Use the documented default
+    ;; (300 s) when the client omits timeout_seconds.
+    (let ((effective-timeout (or timeout 300)))
+      (flet ((do-run ()
+               ;; The lock covers RUN-TESTS' force-reload only; see the
+               ;; docstring for why the test run itself must stay outside it.
+               (let ((*load-lock-wrapper*
+                       (lambda (thunk)
+                         (with-asdf-load-lock (funcall thunk)))))
+                 (run-tests system
+                            :framework framework
+                            :test test
+                            :tests tests))))
+        (multiple-value-bind (result status)
+            (call-with-test-run-deadline #'do-run effective-timeout)
+          (build-run-tests-response
+           (ecase status
+             (:ok result)
+             (:timeout (make-timeout-result result))
+             ;; Re-signal so genuine failures still surface as JSON-RPC
+             ;; errors instead of being reported as a bogus test result.
+             (:error (error result)))))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; worker/code-find

--- a/src/worker/main.lisp
+++ b/src/worker/main.lisp
@@ -203,7 +203,21 @@ Roswell REPL."
             (%output-handshake tcp-port swank-port)
             (let ((devnull (open #P"/dev/null" :direction :output
                                                :if-exists :append)))
-              (setf *standard-output* devnull))
+              (setf *standard-output* devnull)
+              ;; Also redirect *DEBUG-IO* and the other interactive streams.
+              ;; log4cl's console appender writes to a synonym stream for
+              ;; *DEBUG-IO*, which in this pipe-spawned worker resolves to
+              ;; the ORIGINAL stdout fd -- whose read end the parent closed
+              ;; after reading the handshake.  Any write there raises
+              ;; BROKEN-PIPE and aborts the load/eval in progress.  Bordeaux
+              ;; threads inherit these values as their defaults, so this one
+              ;; redirect covers every thread the worker later spawns.  The
+              ;; output-suppression helpers (%call-with-suppressed-output,
+              ;; repl-eval) rebind them to capture streams, so logging inside
+              ;; load-system/repl-eval is still returned in tool results.
+              (setf *debug-io* devnull
+                    *terminal-io* devnull
+                    *query-io* devnull))
             (%start-parent-watchdog)
             (start-accept-loop server))))
     (serious-condition (e)

--- a/tests.lisp
+++ b/tests.lisp
@@ -26,6 +26,7 @@
   (:import-from #:cl-mcp/tests/response-builders-test)
   (:import-from #:cl-mcp/tests/timeout-test)
   (:import-from #:cl-mcp/tests/test-runner-test)
+  (:import-from #:cl-mcp/tests/test-runner-deadline-test)
   (:import-from #:cl-mcp/tests/tools-helpers-test)
   (:import-from #:cl-mcp/tests/utils-paths-test)
   (:import-from #:cl-mcp/tests/validate-test)

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -1,0 +1,115 @@
+;;;; tests/test-runner-deadline-test.lisp
+;;;;
+;;;; Covers the deadline machinery that keeps a slow or wedged test run from
+;;;; pinning its caller: numeric-string timeout coercion, and the three
+;;;; outcomes of CALL-WITH-TEST-RUN-DEADLINE.
+
+(defpackage #:cl-mcp/tests/test-runner-deadline-test
+  (:use #:cl)
+  (:import-from #:rove
+                #:deftest #:testing #:ok)
+  (:import-from #:bordeaux-threads
+                #:current-thread)
+  (:import-from #:cl-mcp/src/test-runner-core
+                #:call-with-test-run-deadline
+                #:coerce-timeout-seconds
+                #:make-timeout-result))
+
+(in-package #:cl-mcp/tests/test-runner-deadline-test)
+
+(deftest coerce-timeout-seconds-accepts-numbers-and-strings
+  (testing "a number passes through"
+    (ok (= 60 (coerce-timeout-seconds 60)))
+    (ok (= 60 (coerce-timeout-seconds 60.0))))
+  (testing "a numeric string is accepted rather than silently dropped"
+    ;; A client that sends timeout_seconds as "60" used to fail the
+    ;; (NUMBERP ...) guards in the worker handler and in PROXY-TO-WORKER,
+    ;; and so silently fell back to the 300 s default.
+    (ok (= 60 (coerce-timeout-seconds "60")))
+    (ok (= 60 (coerce-timeout-seconds " 60 "))))
+  (testing "unusable values yield NIL so callers keep their own default"
+    (ok (null (coerce-timeout-seconds nil)))
+    (ok (null (coerce-timeout-seconds "abc")))
+    (ok (null (coerce-timeout-seconds "60s")))
+    (ok (null (coerce-timeout-seconds "")))
+    (ok (null (coerce-timeout-seconds 0)))
+    (ok (null (coerce-timeout-seconds -5)))
+    (ok (null (coerce-timeout-seconds :sixty)))))
+
+(deftest deadline-returns-the-runs-value
+  (testing "a run that finishes in time yields :OK and its value"
+    (multiple-value-bind (result status)
+        (call-with-test-run-deadline (lambda () :done) 5)
+      (ok (eq :ok status))
+      (ok (eq :done result)))))
+
+(deftest deadline-runs-off-the-calling-thread
+  (testing "the run executes on its own thread"
+    (let ((caller (current-thread)))
+      (multiple-value-bind (result status)
+          (call-with-test-run-deadline
+           (lambda () (not (eq caller (current-thread))))
+           5)
+        (ok (eq :ok status))
+        (ok result "the thunk did not run on the caller's thread")))))
+
+(deftest deadline-reports-a-slow-run-as-timeout
+  (testing "a run slower than the deadline yields :TIMEOUT, bounded in time"
+    (let ((start (get-internal-real-time)))
+      (multiple-value-bind (result status)
+          (call-with-test-run-deadline (lambda () (sleep 30) :done) 1)
+        (let ((elapsed (/ (- (get-internal-real-time) start)
+                          internal-time-units-per-second)))
+          (ok (eq :timeout status))
+          (ok (eql 1 result) "the timeout result carries the deadline")
+          (ok (< elapsed 10)
+              (format nil "answered in ~,2Fs, not after the 30s sleep"
+                      elapsed)))))))
+
+(deftest deadline-answers-even-when-the-run-cannot-be-interrupted
+  (testing "a run that swallows the interrupt still cannot hold the caller"
+    ;; Stands in for a suite blocked in something SB-EXT:WITH-TIMEOUT cannot
+    ;; unwind -- a server accept loop left behind by the tests, say.  Run
+    ;; inline, that wedges the worker's single connection thread and every
+    ;; later tool call for the session with it; here the caller is answered
+    ;; at the deadline regardless, and the blocked thread is torn down.
+    (let ((start (get-internal-real-time)))
+      (multiple-value-bind (result status)
+          (call-with-test-run-deadline
+           (lambda ()
+             (let ((stop (+ (get-internal-real-time)
+                            (* 60 internal-time-units-per-second))))
+               (loop while (< (get-internal-real-time) stop)
+                     do (handler-case (sleep 0.05)
+                          ;; Swallow the deadline unwind and keep going:
+                          ;; exactly the uninterruptible case.
+                          (serious-condition () nil)))
+               :finished))
+           1)
+        (let ((elapsed (/ (- (get-internal-real-time) start)
+                          internal-time-units-per-second)))
+          (ok (eq :timeout status))
+          (ok (eql 1 result))
+          (ok (< elapsed 10)
+              (format nil "answered in ~,2Fs despite the run still blocking"
+                      elapsed)))))))
+
+(deftest deadline-reports-a-signalling-run-as-error
+  (testing "a run that signals yields :ERROR and the condition"
+    (multiple-value-bind (result status)
+        (call-with-test-run-deadline (lambda () (error "boom")) 5)
+      (ok (eq :error status))
+      (ok (typep result 'condition))
+      (ok (search "boom" (princ-to-string result))))))
+
+(deftest make-timeout-result-is-machine-readable
+  (testing "the timeout payload names itself and carries one failed entry"
+    (let ((ht (make-timeout-result 42)))
+      (ok (eql 0 (gethash "passed" ht)))
+      (ok (eql 1 (gethash "failed" ht)))
+      (ok (equal "timeout" (gethash "framework" ht)))
+      (ok (eql 42000 (gethash "duration_ms" ht)))
+      (ok (eql 1 (length (gethash "failed_tests" ht))))
+      (ok (equal "TIMEOUT"
+                 (gethash "test_name"
+                          (aref (gethash "failed_tests" ht) 0)))))))


### PR DESCRIPTION
I made these changes because I was constantly getting broken pipes when running tests with FiveAM.

## Summary

- `run-tests` now enforces its deadline from a dedicated thread
  (`call-with-test-run-deadline` in `test-runner-core.lisp`) instead of
  `sb-ext:with-timeout` inline on the worker's connection thread. A slow
  but cooperative suite unwinds inside its own thread (releasing locks /
  `unwind-protect` cleanups); a suite that blocks where `with-timeout`
  cannot interrupt (e.g. a server accept loop) can no longer pin the
  connection thread and wedge every later tool call for the session — the
  polling wrapper answers the caller at the deadline regardless. A 300 s
  default is enforced server-side even when the client omits
  `timeout_seconds`.
- New `coerce-timeout-seconds` accepts a numeric string as well as a
  number, so `timeout_seconds: "60"` no longer slips past `(numberp ...)`
  guards and silently widens a caller's deadline to the 300 s default. The
  proxy now waits for the worker's own deadline plus a small buffer
  instead of `(max *proxy-rpc-timeout* ...)`, which outlived the worker by
  up to 300 s — and which, when clamped to `*proxy-rpc-timeout*`, would
  have cut off callers asking for more than 300 s.
- FiveAM runs no longer redirect `*standard-output*`/`*error-output*`;
  redirecting them (even to a broadcast stream) hangs suites that spawn
  real threads and sockets. Only `*test-debug-output*` is captured there.
  Tool docs updated to say stdout/stderr capture is Rove-only.
- Worker startup and the load/eval output-suppression helpers now also
  rebind `*debug-io*`/`*terminal-io*`/`*query-io*` away from the dead
  stdout pipe, fixing `BROKEN-PIPE` aborts from log4cl's console appender.

## Tests

Run and passing on the final tree:
- `cl-mcp/tests/test-runner-deadline-test` — 7/7 (new: timeout coercion,
  the `:ok`/`:timeout`/`:error` outcomes of the deadline helper)
- `cl-mcp/tests/test-runner-test` — 43/43
- `cl-mcp/tests/tools-test` — 68/68
- `cl-mcp/tests/proxy-test` — 6/6
- `cl-mcp/tests/repl-test` — 50/50
- `cl-mcp/tests/system-loader-test` — 17/17
- Full-tree compile via `asdf:test-system` equivalent load: only
  pre-existing warnings (unrelated `pool`/`worker-client`/Rove-shim code)

Note: the aggregate `cl-mcp/tests` run does not complete inside a single
worker session here (client transport timeout), so the suites above are
the directly affected paths.

## Commits

- `fix: redirect interactive streams in workers to avoid broken-pipe`
  (`src/worker/main.lisp`, `src/repl-core.lisp`, `src/system-loader-core.lisp`)
- `test-runner: run suites on a deadline thread and honor string timeouts`
  (`src/proxy.lisp`, `src/test-runner-core.lisp`, `src/test-runner.lisp`,
  `src/worker/handlers.lisp`, `tests.lisp`,
  `tests/test-runner-deadline-test.lisp`)