### PR TITLE
Make the run-tests deadline deliverable, and correct its side effects

### DIFF
--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -48,15 +48,21 @@ Set MCP_NO_WORKER_POOL=1 to disable.")
     (setf *use-worker-pool* nil)))
 
 (defvar *proxy-rpc-timeout* 300
-  "Default timeout (seconds) for proxy-to-worker RPC calls.
-Prevents requests from hanging indefinitely when a worker handler
-is stuck.  300 seconds (5 minutes) accommodates long-running
-operations like system compilation.
+  "Deadline (seconds) the worker is assumed to enforce when the caller names
+none.  Tools that take a timeout_seconds argument default to this same value
+on the worker side, so it is the figure the proxy has to outlast.")
 
-When the caller provides a timeout_seconds parameter (e.g. for
-run-tests), the effective proxy timeout is clamped to the smaller
-of this value and (caller_timeout + 10), so the proxy does not
-outlive the worker's own deadline by a wide margin.")
+(defvar *proxy-rpc-buffer* 30
+  "Seconds the proxy waits beyond the deadline the worker enforces.
+
+The worker owns the deadline; this is only the margin for its answer to
+arrive.  The margin has to cover everything that happens *after* the worker's
+own timer fires -- the cooperative unwind, DESTROY-THREAD's grace period,
+building the response, and serializing it across the socket, which for
+repl-eval can be max_output_length bytes.  Too small a margin and the proxy
+gives up first, and a proxy timeout is not a timeout report: WORKER-RPC marks
+the worker crashed and kills it, so the session's whole Lisp state is reset
+for what was merely a slow answer.")
 
 (defvar *active-requests* (make-hash-table :test 'equal)
   "Maps MCP request-id (as string) to session-id for in-flight
@@ -230,6 +236,28 @@ image or pool lifecycle are cleared before re-verification."
         %cached-worker-last-exit-status% nil
         %cached-worker-last-exit-code% nil))
 
+(defun %effective-rpc-timeout (params)
+  "Seconds to wait for the worker's answer to a call carrying PARAMS.
+
+One rule, with no per-method knowledge: wait out the deadline the worker will
+enforce, then the margin for its answer to arrive.  The caller's
+timeout_seconds is that deadline when given; when the caller is silent the
+worker falls back to the same default this proxy does.
+
+Adding the margin in BOTH cases is what keeps the two from expiring together.
+With the caller silent, worker and proxy would otherwise both sit on 300 s,
+the proxy would give up a moment before the worker finished building its own
+timeout result, and the graceful timeout report that path exists to deliver
+would be replaced by a killed worker and a reset session.
+
+No cap: a caller may legitimately ask for more than 300 s, and the worker
+enforces that same deadline."
+  (ceiling (+ (or (coerce-timeout-seconds
+                   (and (hash-table-p params)
+                        (gethash "timeout_seconds" params)))
+                  *proxy-rpc-timeout*)
+              *proxy-rpc-buffer*)))
+
 (defun proxy-to-worker (id method params)
   "Proxy a tool call to the session's dedicated worker process.
 Returns the worker's JSON-RPC result hash-table directly.
@@ -280,34 +308,7 @@ TOCTOU race with concurrent requests for the same session."
                (log-event :debug "proxy.forward"
                           "session" session-id
                           "method" method)
-               (let* ((user-timeout
-                       (coerce-timeout-seconds
-                        (and (hash-table-p params)
-                             (gethash "timeout_seconds" params))))
-                      (effective-timeout
-                       (if user-timeout
-                           ;; Respect the user's timeout intent.  The
-                           ;; worker enforces the same value, so the
-                           ;; proxy should wait only slightly longer
-                           ;; (small buffer for the response to arrive)
-                           ;; rather than the old
-                           ;; (max *proxy-rpc-timeout* …), which let
-                           ;; the proxy wait up to 300 s even when the
-                           ;; user asked for 90 s.
-                           ;;
-                           ;; COERCE-TIMEOUT-SECONDS also accepts a
-                           ;; numeric string: a client that sends
-                           ;; timeout_seconds as "60" would otherwise
-                           ;; fail the (NUMBERP …) guard here and fall
-                           ;; through to the 300 s default, widening
-                           ;; the window in which a wedged suite can
-                           ;; outlive the client's own deadline.
-                           ;; No cap on *proxy-rpc-timeout*: a caller may
-                           ;; legitimately ask for more than 300 s, and the
-                           ;; worker enforces that same deadline, so the
-                           ;; small buffer below is all the margin needed.
-                           (ceiling (+ user-timeout 10))
-                           *proxy-rpc-timeout*)))
+               (let ((effective-timeout (%effective-rpc-timeout params)))
                  (handler-case
                      (funcall %cached-worker-rpc% worker method params
                               :timeout effective-timeout)

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -251,6 +251,15 @@ image or pool lifecycle are cleared before re-verification."
         %cached-worker-last-exit-status% nil
         %cached-worker-last-exit-code% nil))
 
+(defun %requested-worker-deadline (params)
+  "The deadline the worker will enforce for a call carrying PARAMS, clamped.
+The caller's timeout_seconds when it names one, the shared default otherwise."
+  (min +max-proxy-rpc-timeout+
+       (or (coerce-timeout-seconds
+            (and (hash-table-p params)
+                 (gethash "timeout_seconds" params)))
+           *proxy-rpc-timeout*)))
+
 (defun %effective-rpc-timeout (params)
   "Seconds to wait for the worker's answer to a call carrying PARAMS.
 
@@ -266,17 +275,27 @@ the proxy would give up a moment before the worker finished building its own
 timeout result, and the graceful timeout report that path exists to deliver
 would be replaced by a killed worker and a reset session.
 
-Clamped at the top because the result is handed to SB-EXT:WITH-TIMEOUT, which
-takes a (SIGNED-BYTE 64) of internal time units: a caller sending 1e20 would
-otherwise produce a bignum, a TYPE-ERROR on the read, and a worker killed for
-a protocol error it did not commit.  A day is far past any legitimate call and
-well inside the range."
-  (let ((requested (or (coerce-timeout-seconds
-                        (and (hash-table-p params)
-                             (gethash "timeout_seconds" params)))
-                       *proxy-rpc-timeout*)))
-    (min +max-proxy-rpc-timeout+
-         (ceiling (+ requested *proxy-rpc-buffer*)))))
+A request beyond +MAX-PROXY-RPC-TIMEOUT+ is clamped in PARAMS as well, by
+%CLAMP-TIMEOUT-PARAM, so the worker enforces the same figure this budget is
+built on.  Clamping only here would invert the very ordering above: the proxy
+would wait less than the worker's own deadline and kill it for still working."
+  (ceiling (+ (%requested-worker-deadline params) *proxy-rpc-buffer*)))
+
+(defun %clamp-timeout-param (params)
+  "Lower PARAMS' timeout_seconds to +MAX-PROXY-RPC-TIMEOUT+ when it exceeds it.
+
+The worker reads that key to set its own deadline, so clamping the proxy's
+wait without clamping this would leave the worker enforcing the larger figure
+and the proxy giving up first -- killing a worker that is still legitimately
+working, which is the one outcome this whole budget exists to avoid.  PARAMS
+is built fresh per call by WITH-PROXY-DISPATCH, so rewriting it is local to
+this request."
+  (let ((requested (and (hash-table-p params)
+                        (coerce-timeout-seconds
+                         (gethash "timeout_seconds" params)))))
+    (when (and requested (> requested +max-proxy-rpc-timeout+))
+      (setf (gethash "timeout_seconds" params) +max-proxy-rpc-timeout+))
+    params))
 
 (defun proxy-to-worker (id method params)
   "Proxy a tool call to the session's dedicated worker process.
@@ -328,7 +347,9 @@ TOCTOU race with concurrent requests for the same session."
                (log-event :debug "proxy.forward"
                           "session" session-id
                           "method" method)
-               (let ((effective-timeout (%effective-rpc-timeout params)))
+               (let ((effective-timeout
+                       (%effective-rpc-timeout
+                        (%clamp-timeout-param params))))
                  (handler-case
                      (funcall %cached-worker-rpc% worker method params
                               :timeout effective-timeout)

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -48,9 +48,16 @@ Set MCP_NO_WORKER_POOL=1 to disable.")
     (setf *use-worker-pool* nil)))
 
 (defvar *proxy-rpc-timeout* 300
-  "Deadline (seconds) the worker is assumed to enforce when the caller names
-none.  Tools that take a timeout_seconds argument default to this same value
-on the worker side, so it is the figure the proxy has to outlast.")
+  "Deadline (seconds) the proxy assumes the worker enforces when the caller
+names none.
+
+The tools that take a timeout_seconds argument all default to a server-side
+deadline of their own: run-tests and repl-eval to this same 300, load-system
+to 120.  Anything smaller than this figure is covered by waiting for it, so
+one number is enough here -- but a tool that ever ran without a deadline would
+not be, since the proxy would give up on a worker that is merely still
+working, and a proxy timeout kills the worker rather than reporting a
+timeout.")
 
 (defvar *proxy-rpc-buffer* 30
   "Seconds the proxy waits beyond the deadline the worker enforces.
@@ -63,6 +70,14 @@ repl-eval can be max_output_length bytes.  Too small a margin and the proxy
 gives up first, and a proxy timeout is not a timeout report: WORKER-RPC marks
 the worker crashed and kills it, so the session's whole Lisp state is reset
 for what was merely a slow answer.")
+
+(defconstant +max-proxy-rpc-timeout+ 86400
+  "Upper bound (seconds) on how long the proxy will wait for one worker call.
+SB-EXT:WITH-TIMEOUT converts its argument to internal time units in a
+(SIGNED-BYTE 64), so an unclamped caller-supplied value -- JSON's 1e20 reads
+as a double -- becomes a bignum and a TYPE-ERROR, which WORKER-RPC reports as
+a protocol error and kills the worker for.  A day is far beyond any legitimate
+call.")
 
 (defvar *active-requests* (make-hash-table :test 'equal)
   "Maps MCP request-id (as string) to session-id for in-flight
@@ -242,7 +257,8 @@ image or pool lifecycle are cleared before re-verification."
 One rule, with no per-method knowledge: wait out the deadline the worker will
 enforce, then the margin for its answer to arrive.  The caller's
 timeout_seconds is that deadline when given; when the caller is silent the
-worker falls back to the same default this proxy does.
+worker falls back to a default of its own, and *PROXY-RPC-TIMEOUT* is the
+largest of those.
 
 Adding the margin in BOTH cases is what keeps the two from expiring together.
 With the caller silent, worker and proxy would otherwise both sit on 300 s,
@@ -250,13 +266,17 @@ the proxy would give up a moment before the worker finished building its own
 timeout result, and the graceful timeout report that path exists to deliver
 would be replaced by a killed worker and a reset session.
 
-No cap: a caller may legitimately ask for more than 300 s, and the worker
-enforces that same deadline."
-  (ceiling (+ (or (coerce-timeout-seconds
-                   (and (hash-table-p params)
-                        (gethash "timeout_seconds" params)))
-                  *proxy-rpc-timeout*)
-              *proxy-rpc-buffer*)))
+Clamped at the top because the result is handed to SB-EXT:WITH-TIMEOUT, which
+takes a (SIGNED-BYTE 64) of internal time units: a caller sending 1e20 would
+otherwise produce a bignum, a TYPE-ERROR on the read, and a worker killed for
+a protocol error it did not commit.  A day is far past any legitimate call and
+well inside the range."
+  (let ((requested (or (coerce-timeout-seconds
+                        (and (hash-table-p params)
+                             (gethash "timeout_seconds" params)))
+                       *proxy-rpc-timeout*)))
+    (min +max-proxy-rpc-timeout+
+         (ceiling (+ requested *proxy-rpc-buffer*)))))
 
 (defun proxy-to-worker (id method params)
   "Proxy a tool call to the session's dedicated worker process.

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -148,6 +148,10 @@ on large outputs)."
              (*debug-io* interactive)
              (*terminal-io* interactive)
              (*query-io* interactive)
+             ;; (TIME ...) and TRACE write here, and its default is a synonym
+             ;; for the process's stdout.  Captured rather than redirected, so
+             ;; a caller who asks for timings gets them back in the result.
+             (*trace-output* stdout)
              (*compile-verbose* nil)
              (*compile-print* nil))
         (%call-with-compiler-streams

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -129,19 +129,27 @@ on large outputs)."
           (*print-array* t)
           (*print-pretty* t)
           (*read-default-float-format* 'single-float))
-      (let ((*standard-output* stdout)
-            (*error-output* stderr)
-            ;; log4cl's console appender writes to a synonym stream for
-            ;; *DEBUG-IO*, which in a worker resolves to the original stdout
-            ;; fd whose read end the parent closed after the handshake --
-            ;; any write there raises BROKEN-PIPE.  Rebinding these keeps
-            ;; log4cl / interactive output captured instead of hitting the
-            ;; dead pipe.
-            (*debug-io* stdout)
-            (*terminal-io* stdout)
-            (*query-io* stdout)
-            (*compile-verbose* nil)
-            (*compile-print* nil))
+      (let* ((interactive
+               (make-two-way-stream (make-concatenated-stream) stdout))
+             (*standard-output* stdout)
+             (*error-output* stderr)
+             ;; log4cl's console appender writes to a synonym stream for
+             ;; *DEBUG-IO*, which in a worker resolves to the original stdout
+             ;; fd whose read end the parent closed after the handshake --
+             ;; any write there raises BROKEN-PIPE.  Rebinding these keeps
+             ;; log4cl / interactive output captured instead of hitting the
+             ;; dead pipe.
+             ;;
+             ;; A two-way stream rather than STDOUT itself: ANSI requires
+             ;; these three to be bidirectional, and code that reads from
+             ;; them -- a stray Y-OR-N-P in evaluated code, say -- would
+             ;; otherwise get "not an input stream" rather than the empty
+             ;; input it should see in a non-interactive process.
+             (*debug-io* interactive)
+             (*terminal-io* interactive)
+             (*query-io* interactive)
+             (*compile-verbose* nil)
+             (*compile-print* nil))
         (%call-with-compiler-streams
          stdout
          stderr

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -6,10 +6,8 @@
 
 (defpackage #:cl-mcp/src/repl-core
   (:use #:cl)
-  (:import-from #:bordeaux-threads
-                #:thread-alive-p
-                #:make-thread
-                #:destroy-thread)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:call-with-deadline-thread)
   (:import-from #:cl-mcp/src/frame-inspector #:capture-error-context)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-for-json)
@@ -290,53 +288,45 @@ stdout, stderr, error-context."
                 :frames nil))))
 
 (defun %repl-eval-with-timeout (thunk timeout-seconds)
-  "Execute THUNK with a polling-based timeout (50ms granularity).
-If the worker completes during the final polling interval, returns
-the result as success -- completed work is never discarded as a timeout."
-  (if (and timeout-seconds (plusp timeout-seconds))
-      (let* ((result-box nil)
-             (worker (bordeaux-threads:make-thread
-                      (lambda ()
-                        ;; Nothing raised by THUNK -- evaluation *or* printing --
-                        ;; may reach the debugger hook: a worker process runs
-                        ;; under SB-EXT:DISABLE-DEBUGGER, where an unhandled
-                        ;; condition in this thread aborts the whole process and
-                        ;; destroys the session's state.  Degrade to an error
-                        ;; result instead.  Thread termination on timeout is a
-                        ;; THROW, not a condition, so this does not defeat it.
-                        (setf result-box
-                              (handler-case (multiple-value-list (funcall thunk))
-                                (serious-condition (e)
-                                  (ignore-errors
-                                   (cl-mcp/src/log:log-event
-                                    :warn "repl.eval.condition-escaped"
-                                    "type" (princ-to-string (type-of e))))
-                                  (%thunk-error-result e)))))
-                      :name "mcp-repl-eval")))
-        (loop repeat (ceiling (/ timeout-seconds 0.05d0))
-              when (not (bordeaux-threads:thread-alive-p worker))
-              do (return-from %repl-eval-with-timeout (values-list result-box))
-              do (sleep 0.05d0))
-        ;; Worker may have completed during the last sleep window.
-        ;; Re-check before declaring timeout.
-        (cond
-          ((not (bordeaux-threads:thread-alive-p worker))
-           (values-list result-box))
-          (t
-           (ignore-errors (bordeaux-threads:destroy-thread worker))
-           ;; Verify thread actually died; log if it leaked
-           (loop repeat 20
-                 while (bordeaux-threads:thread-alive-p worker)
-                 do (sleep 0.05d0))
-           (when (bordeaux-threads:thread-alive-p worker)
-             (ignore-errors
-              (cl-mcp/src/log:log-event :warn "repl.timeout.thread-leaked"
-                                        "name" "mcp-repl-eval"
-                                        "timeout" timeout-seconds)))
+  "Execute THUNK, enforcing TIMEOUT-SECONDS on a dedicated thread.
+Without a usable deadline THUNK runs inline, exactly as before: there is
+nothing to enforce, and the caller's handlers and backtrace stay intact.
+If the evaluation completes while the deadline is being enforced, its real
+result is returned -- completed work is never discarded as a timeout."
+  (if (not (and timeout-seconds (realp timeout-seconds) (plusp timeout-seconds)))
+      (funcall thunk)
+      (multiple-value-bind (result status leaked)
+          (call-with-deadline-thread
+           (lambda ()
+             ;; Nothing raised by THUNK -- evaluation *or* printing -- may
+             ;; reach the debugger hook: a worker process runs under
+             ;; SB-EXT:DISABLE-DEBUGGER, where an unhandled condition in this
+             ;; thread aborts the whole process and destroys the session's
+             ;; state.  Degrade to an error result instead.  The deadline
+             ;; unwind is a THROW, not a condition, so this does not defeat it.
+             (handler-case (funcall thunk)
+               (serious-condition (e)
+                 (ignore-errors
+                  (cl-mcp/src/log:log-event
+                   :warn "repl.eval.condition-escaped"
+                   "type" (princ-to-string (type-of e))))
+                 (values-list (%thunk-error-result e)))))
+           timeout-seconds
+           :name "mcp-repl-eval")
+        (when leaked
+          (ignore-errors
+           (cl-mcp/src/log:log-event :warn "repl.timeout.thread-leaked"
+                                     "name" "mcp-repl-eval"
+                                     "timeout" timeout-seconds)))
+        (ecase status
+          (:ok (values-list result))
+          ;; The wrapper above converts every SERIOUS-CONDITION, so :ERROR can
+          ;; only mean the conversion itself failed.  Report it the same way.
+          (:error (values-list (%thunk-error-result result)))
+          (:timeout
            (values
             (format nil "Evaluation timed out after ~,2F seconds" timeout-seconds)
-            :timeout "" "" nil))))
-      (funcall thunk)))
+            :timeout "" "" nil))))))
 
 (defun repl-eval (input &key (package *default-eval-package*)
                              (print-level nil) (print-length nil)

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -333,7 +333,17 @@ result is returned -- completed work is never discarded as a timeout."
           (:error (values-list (%thunk-error-result result)))
           (:timeout
            (values
-            (format nil "Evaluation timed out after ~,2F seconds" timeout-seconds)
+            (if leaked
+                ;; The evaluation is still running: it can still print, still
+                ;; consume CPU, and still mutate this session's state under
+                ;; later requests, so say so rather than implying it stopped.
+                (format nil "Evaluation timed out after ~,2F seconds and ~
+                             could not be stopped: it is still running in ~
+                             this worker. Use pool-kill-worker to get a ~
+                             fresh worker."
+                        timeout-seconds)
+                (format nil "Evaluation timed out after ~,2F seconds"
+                        timeout-seconds))
             :timeout "" "" nil))))))
 
 (defun repl-eval (input &key (package *default-eval-package*)

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -10,7 +10,7 @@
                 #:repl-eval
                 #:*default-eval-package*)
   (:import-from #:cl-mcp/src/tools/helpers
-                #:make-ht #:result)
+                #:make-ht #:result #:arg-validation-error)
   (:import-from #:cl-mcp/src/tools/define-tool
                 #:define-tool)
   (:import-from #:cl-mcp/src/tools/response-builders
@@ -107,9 +107,19 @@ read in the original package. Use separate repl-eval calls or specify the
                                   "locals_preview_max_elements" locals-preview-max-elements
                                   "locals_preview_skip_internal" locals-preview-skip-internal))
    ;; Fallback: inline execution (default when *use-worker-pool* is nil)
+   ;;
+   ;; Validated and defaulted here to match what the worker handler does, so
+   ;; the same input means the same thing with and without the worker pool:
+   ;; without this a zero ran unbounded here while the worker rejected it, and
+   ;; an omitted value ran unbounded here while the worker enforced 300 s.
+   (when (and timeout-seconds (not (plusp timeout-seconds)))
+     (error 'arg-validation-error
+            :arg-name "timeout_seconds"
+            :message "timeout_seconds must be a positive number"))
    (multiple-value-bind (printed raw-value stdout stderr error-context)
        (repl-eval code :package (or package *package*) :print-level print-level
-        :print-length print-length :timeout-seconds timeout-seconds
+        :print-length print-length
+        :timeout-seconds (or timeout-seconds 300)
         :max-output-length max-output-length :safe-read safe-read
         :locals-preview-frames locals-preview-frames :locals-preview-max-depth
         locals-preview-max-depth :locals-preview-max-elements

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -26,7 +26,8 @@
                           (values boolean &optional))
                 run))
 
-(defun run (&key (transport :stdio) (in *standard-input*) (out *standard-output*)
+(defun run (&key (transport :stdio) (in *standard-input*)
+                 (out *standard-output* out-supplied-p)
                  (host "127.0.0.1") (port 0) (accept-once t) on-listening
                  (worker-pool nil worker-pool-supplied-p))
   "Start the MCP server loop. For :stdio, reads newline-delimited JSON from IN
@@ -40,6 +41,17 @@ NIL runs all tools in-process.  When not supplied, the current value of
   (%warn-if-init-without-pool *use-worker-pool*)
   (ecase transport
     (:stdio
+     ;; When the process's own stdout is the protocol channel, nothing else in
+     ;; this image may write to it: with the worker pool disabled every tool
+     ;; runs here, and a stray (FORMAT T ...) -- from an inline tool, or from a
+     ;; thread a test suite spawned, which sees only the global value -- puts
+     ;; raw text between JSON-RPC lines and desynchronizes the client.  Move
+     ;; the global aside; responses keep going to OUT, which still names the
+     ;; real stream.  Logging is unaffected: *LOG-STREAM* follows
+     ;; *ERROR-OUTPUT*.  Skipped when the caller supplied its own OUT, where
+     ;; the process's stdout is not the channel and is not ours to redirect.
+     (unless out-supplied-p
+       (setf *standard-output* (make-broadcast-stream)))
      (when *use-worker-pool* (initialize-pool))
      (unwind-protect
          (let ((state (make-state))

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -45,7 +45,7 @@ that passes nothing, and both need the same protection."
          (eql 1 (sb-sys:fd-stream-fd base)))))
 
 (defun %call-with-stdout-isolated (out thunk)
-  "Call THUNK with this image's global output streams kept off OUT.
+  "Call THUNK with this image's global standard streams kept off OUT.
 
 Only when OUT really is the process's own stdout.  That descriptor is then the
 JSON-RPC channel, and nothing else in the image may write to it: with the
@@ -55,17 +55,28 @@ test suite spawns sees only the GLOBAL value of a special -- so a stray
 client.  Being invisible to spawned threads is exactly why these are SETF and
 not bound.
 
-*DEBUG-IO*, *TERMINAL-IO* and *QUERY-IO* move with it: they default to the
-terminal, which is the same descriptor.  They get a two-way stream so they
-keep the bidirectional contract ANSI requires of them, the same shape the
-worker process uses.  Logging is untouched -- *LOG-STREAM* follows
-*ERROR-OUTPUT* on fd 2.
+Every stream SBCL points at that descriptor by default moves, not just
+*STANDARD-OUTPUT*: *TRACE-OUTPUT* is where (TIME ...) and TRACE write and is a
+synonym for the same fd, and *DEBUG-IO*, *TERMINAL-IO* and *QUERY-IO* default
+to the terminal.  The three interactive ones get a two-way stream so they keep
+the bidirectional contract ANSI requires of them, the same shape the worker
+process uses.  *STANDARD-INPUT* moves too: a stray READ in evaluated code
+would otherwise eat the client's next request line.  Logging is untouched --
+*LOG-STREAM* follows *ERROR-OUTPUT* on fd 2.
 
 The globals are restored on the way out, so a second RUN in this image does
-not pick the sink up as its own OUT and silently discard every response."
+not pick the sink up as its own OUT and silently discard every response.
+
+One caveat for embedders: SETF assigns to the innermost binding, so a caller
+that wraps RUN in its own (LET ((*STANDARD-OUTPUT* ...)) ...) gets its binding
+rewritten and leaves the global -- the value spawned threads actually see --
+untouched.  Both documented entry points call RUN at toplevel, where there is
+no such binding."
   (if (not (%process-stdout-p out))
       (funcall thunk)
       (let ((saved-output *standard-output*)
+            (saved-trace *trace-output*)
+            (saved-input *standard-input*)
             (saved-debug *debug-io*)
             (saved-terminal *terminal-io*)
             (saved-query *query-io*)
@@ -75,11 +86,15 @@ not pick the sink up as its own OUT and silently discard every response."
           (unwind-protect
                (progn
                  (setf *standard-output* sink
+                       *trace-output* sink
+                       *standard-input* (make-concatenated-stream)
                        *debug-io* (interactive)
                        *terminal-io* (interactive)
                        *query-io* (interactive))
                  (funcall thunk))
             (setf *standard-output* saved-output
+                  *trace-output* saved-trace
+                  *standard-input* saved-input
                   *debug-io* saved-debug
                   *terminal-io* saved-terminal
                   *query-io* saved-query))))))

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -26,8 +26,65 @@
                           (values boolean &optional))
                 run))
 
-(defun run (&key (transport :stdio) (in *standard-input*)
-                 (out *standard-output* out-supplied-p)
+(defun %resolve-output-stream (stream)
+  "Follow synonym and two-way streams down to the stream that really writes."
+  (typecase stream
+    (synonym-stream (%resolve-output-stream
+                     (symbol-value (synonym-stream-symbol stream))))
+    (two-way-stream (%resolve-output-stream
+                     (two-way-stream-output-stream stream)))
+    (t stream)))
+
+(defun %process-stdout-p (stream)
+  "True when STREAM ultimately writes to this process's own stdout (fd 1).
+Asked of the stream itself rather than of how RUN was called: a caller that
+passes :OUT *STANDARD-OUTPUT* explicitly is using the same descriptor as one
+that passes nothing, and both need the same protection."
+  (let ((base (%resolve-output-stream stream)))
+    (and (typep base 'sb-sys:fd-stream)
+         (eql 1 (sb-sys:fd-stream-fd base)))))
+
+(defun %call-with-stdout-isolated (out thunk)
+  "Call THUNK with this image's global output streams kept off OUT.
+
+Only when OUT really is the process's own stdout.  That descriptor is then the
+JSON-RPC channel, and nothing else in the image may write to it: with the
+worker pool disabled every tool runs in this process, and a thread a tool or a
+test suite spawns sees only the GLOBAL value of a special -- so a stray
+(FORMAT T ...) there lands between JSON-RPC lines and desynchronizes the
+client.  Being invisible to spawned threads is exactly why these are SETF and
+not bound.
+
+*DEBUG-IO*, *TERMINAL-IO* and *QUERY-IO* move with it: they default to the
+terminal, which is the same descriptor.  They get a two-way stream so they
+keep the bidirectional contract ANSI requires of them, the same shape the
+worker process uses.  Logging is untouched -- *LOG-STREAM* follows
+*ERROR-OUTPUT* on fd 2.
+
+The globals are restored on the way out, so a second RUN in this image does
+not pick the sink up as its own OUT and silently discard every response."
+  (if (not (%process-stdout-p out))
+      (funcall thunk)
+      (let ((saved-output *standard-output*)
+            (saved-debug *debug-io*)
+            (saved-terminal *terminal-io*)
+            (saved-query *query-io*)
+            (sink (make-broadcast-stream)))
+        (flet ((interactive ()
+                 (make-two-way-stream (make-concatenated-stream) sink)))
+          (unwind-protect
+               (progn
+                 (setf *standard-output* sink
+                       *debug-io* (interactive)
+                       *terminal-io* (interactive)
+                       *query-io* (interactive))
+                 (funcall thunk))
+            (setf *standard-output* saved-output
+                  *debug-io* saved-debug
+                  *terminal-io* saved-terminal
+                  *query-io* saved-query))))))
+
+(defun run (&key (transport :stdio) (in *standard-input*) (out *standard-output*)
                  (host "127.0.0.1") (port 0) (accept-once t) on-listening
                  (worker-pool nil worker-pool-supplied-p))
   "Start the MCP server loop. For :stdio, reads newline-delimited JSON from IN
@@ -41,60 +98,55 @@ NIL runs all tools in-process.  When not supplied, the current value of
   (%warn-if-init-without-pool *use-worker-pool*)
   (ecase transport
     (:stdio
-     ;; When the process's own stdout is the protocol channel, nothing else in
-     ;; this image may write to it: with the worker pool disabled every tool
-     ;; runs here, and a stray (FORMAT T ...) -- from an inline tool, or from a
-     ;; thread a test suite spawned, which sees only the global value -- puts
-     ;; raw text between JSON-RPC lines and desynchronizes the client.  Move
-     ;; the global aside; responses keep going to OUT, which still names the
-     ;; real stream.  Logging is unaffected: *LOG-STREAM* follows
-     ;; *ERROR-OUTPUT*.  Skipped when the caller supplied its own OUT, where
-     ;; the process's stdout is not the channel and is not ours to redirect.
-     (unless out-supplied-p
-       (setf *standard-output* (make-broadcast-stream)))
-     (when *use-worker-pool* (initialize-pool))
-     (unwind-protect
-         (let ((state (make-state))
-               (cl-mcp/src/protocol:*current-session-id* "stdio"))
-           (log-event :info "stdio.start")
-           (loop for line = (handler-case
-                                 (%read-line-limited in :eof +max-json-line-bytes+)
-                               (line-too-long (e)
-                                 (log-event :warn "stdio.read.line-too-long"
-                                            "error" (princ-to-string e))
-                                 ;; Drain remaining bytes on the current line
-                                 ;; so the next read-line starts fresh.
-                                 (loop for ch = (read-char in nil nil)
-                                       while (and ch (not (char= ch #\Newline))))
-                                 :read-error))
-                 until (eq line :eof)
-                 do (cond
-                      ((eq line :read-error)
-                       ;; Return JSON-RPC error for the oversized line
-                       (handler-case
-                           (progn
-                             (write-line
-                              "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Request too large\"}}"
-                              out)
-                             (force-output out))
-                         (stream-error (e)
-                           (log-event :warn "stdio.write.error"
-                                      "error" (princ-to-string e))
-                           (return))))
-                      (t
-                       (let ((resp (process-json-line line state)))
-                         (when resp
+     (%call-with-stdout-isolated
+      out
+      (lambda ()
+        (when *use-worker-pool* (initialize-pool))
+        (unwind-protect
+             (let ((state (make-state))
+                   (cl-mcp/src/protocol:*current-session-id* "stdio"))
+               (log-event :info "stdio.start")
+               (loop for line = (handler-case
+                                    (%read-line-limited in :eof
+                                                        +max-json-line-bytes+)
+                                  (line-too-long (e)
+                                    (log-event :warn "stdio.read.line-too-long"
+                                               "error" (princ-to-string e))
+                                    ;; Drain remaining bytes on the current line
+                                    ;; so the next read-line starts fresh.
+                                    (loop for ch = (read-char in nil nil)
+                                          while (and ch
+                                                     (not (char= ch #\Newline))))
+                                    :read-error))
+                     until (eq line :eof)
+                     do (cond
+                          ((eq line :read-error)
+                           ;; Return JSON-RPC error for the oversized line
                            (handler-case
                                (progn
-                                 (write-line resp out)
+                                 (write-line
+                                  "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Request too large\"}}"
+                                  out)
                                  (force-output out))
                              (stream-error (e)
                                (log-event :warn "stdio.write.error"
                                           "error" (princ-to-string e))
-                               (return))))))))
-           (log-event :info "stdio.stop")
-           t)
-       (when *use-worker-pool* (ignore-errors (shutdown-pool)))))
+                               (return))))
+                          (t
+                           (let ((resp (process-json-line line state)))
+                             (when resp
+                               (handler-case
+                                   (progn
+                                     (write-line resp out)
+                                     (force-output out))
+                                 (stream-error (e)
+                                   (log-event :warn "stdio.write.error"
+                                              "error" (princ-to-string e))
+                                   (return))))))))
+               (log-event :info "stdio.stop")
+               t)
+          (when *use-worker-pool* (ignore-errors (shutdown-pool)))))))
     (:tcp
      (log-event :info "tcp.start" "host" host "port" port)
-     (serve-tcp :host host :port port :accept-once accept-once :on-listening on-listening))))
+     (serve-tcp :host host :port port :accept-once accept-once
+                :on-listening on-listening))))

--- a/src/run.lisp
+++ b/src/run.lisp
@@ -26,23 +26,37 @@
                           (values boolean &optional))
                 run))
 
-(defun %resolve-output-stream (stream)
-  "Follow synonym and two-way streams down to the stream that really writes."
-  (typecase stream
-    (synonym-stream (%resolve-output-stream
-                     (symbol-value (synonym-stream-symbol stream))))
-    (two-way-stream (%resolve-output-stream
-                     (two-way-stream-output-stream stream)))
-    (t stream)))
-
 (defun %process-stdout-p (stream)
   "True when STREAM ultimately writes to this process's own stdout (fd 1).
+
 Asked of the stream itself rather than of how RUN was called: a caller that
 passes :OUT *STANDARD-OUTPUT* explicitly is using the same descriptor as one
-that passes nothing, and both need the same protection."
-  (let ((base (%resolve-output-stream stream)))
-    (and (typep base 'sb-sys:fd-stream)
-         (eql 1 (sb-sys:fd-stream-fd base)))))
+that passes nothing, and both need the same protection.
+
+Every composite the standard defines is followed, not just the two SBCL
+happens to use for *STANDARD-OUTPUT*.  A broadcast stream reaches fd 1 if any
+of its components does, so RUN over (MAKE-BROADCAST-STREAM SB-SYS:*STDOUT*
+log) is the protocol channel just as much as the bare stream is -- and missing
+that leaves the image writing to it."
+  (labels ((fd1-p (s depth)
+             ;; The depth bound is only against a pathological cycle -- a
+             ;; synonym stream naming a variable holding itself.  Nothing here
+             ;; builds one, and without the bound such a stream would hang the
+             ;; server at startup rather than fail.
+             (when (and s (< depth 32))
+               (typecase s
+                 (synonym-stream
+                  (fd1-p (symbol-value (synonym-stream-symbol s)) (1+ depth)))
+                 (two-way-stream
+                  (fd1-p (two-way-stream-output-stream s) (1+ depth)))
+                 (echo-stream
+                  (fd1-p (echo-stream-output-stream s) (1+ depth)))
+                 (broadcast-stream
+                  (some (lambda (component) (fd1-p component (1+ depth)))
+                        (broadcast-stream-streams s)))
+                 (t (and (typep s 'sb-sys:fd-stream)
+                         (eql 1 (sb-sys:fd-stream-fd s))))))))
+    (and (fd1-p stream 0) t)))
 
 (defun %call-with-stdout-isolated (out thunk)
   "Call THUNK with this image's global standard streams kept off OUT.

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -5,10 +5,8 @@
 
 (defpackage #:cl-mcp/src/system-loader-core
   (:use #:cl)
-  (:import-from #:bordeaux-threads
-                #:thread-alive-p
-                #:make-thread
-                #:destroy-thread)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:call-with-deadline-thread)
   (:import-from #:cl-mcp/src/log
                 #:log-event)
   (:import-from #:cl-mcp/src/tools/helpers
@@ -26,49 +24,33 @@
                 %load-with-timeout))
 
 (defun %load-with-timeout (thunk timeout-seconds)
-  "Execute THUNK in a worker thread with TIMEOUT-SECONDS limit.
+  "Execute THUNK under a TIMEOUT-SECONDS deadline on its own thread.
 Returns (values result-list timed-out-p errored-p).
 RESULT-LIST is a list of the thunk's multiple return values on success,
 or a single-element list containing the error condition on failure.
-TIMED-OUT-P is T if the worker was still running when the deadline passed.
-ERRORED-P is T if the thunk signaled an error.
+TIMED-OUT-P is T if the load was still running when the deadline passed.
+ERRORED-P is T if the thunk signaled.
 
-NOTE: This is a polling-based safety net, not a strict deadline enforcer.
-The worker is polled every 50ms, so the effective granularity is 50ms.
-If the worker completes during the final polling interval, the result is
-returned as a success -- completed work is never discarded as a timeout."
-  (if (and timeout-seconds (plusp timeout-seconds))
-      (let* ((result-box nil)
-             (error-box nil)
-             (worker
-               (make-thread
-                (lambda ()
-                  (handler-case
-                      (setf result-box (multiple-value-list (funcall thunk)))
-                    (error (c)
-                      (setf error-box c))))
-                :name "mcp-load-system")))
-        (loop repeat (ceiling (/ timeout-seconds 0.05d0))
-              when (not (thread-alive-p worker))
-                do (return-from %load-with-timeout
-                     (if error-box
-                         (values (list error-box) nil t)
-                         (values result-box nil nil)))
-              do (sleep 0.05d0))
-        ;; Worker may have completed during the last sleep window.
-        ;; Re-check before declaring timeout.
-        (cond
-          ((not (thread-alive-p worker))
-           (if error-box
-               (values (list error-box) nil t)
-               (values result-box nil nil)))
-          (t
-           (ignore-errors (destroy-thread worker))
-           (values nil t nil))))
-      (handler-case
-          (values (multiple-value-list (funcall thunk)) nil nil)
-        (error (c)
-          (values (list c) nil t)))))
+If the load completes while the deadline is being enforced, the result is
+returned as a success -- completed work is never discarded as a timeout.
+See CALL-WITH-DEADLINE-THREAD for how the deadline is enforced."
+  (handler-case
+      (multiple-value-bind (result status leaked)
+          (call-with-deadline-thread thunk timeout-seconds
+                                     :name "mcp-load-system")
+        (when leaked
+          (ignore-errors
+           (log-event :warn "load.timeout.thread-leaked"
+                      "name" "mcp-load-system"
+                      "timeout" timeout-seconds)))
+        (ecase status
+          (:ok (values result nil nil))
+          (:timeout (values nil t nil))
+          (:error (values (list result) nil t))))
+    ;; Only reachable on the inline path (no deadline), where
+    ;; CALL-WITH-DEADLINE-THREAD lets conditions propagate.
+    (error (c)
+      (values (list c) nil t))))
 
 (defvar *last-compiler-stderr* nil
   "Captured compiler stderr from the most recent %call-with-suppressed-output call.

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -10,7 +10,8 @@
   (:import-from #:cl-mcp/src/log
                 #:log-event)
   (:import-from #:cl-mcp/src/tools/helpers
-                #:make-ht)
+                #:make-ht
+                #:transient-error)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-for-json)
   (:import-from #:cl-mcp/src/project-root
@@ -398,6 +399,12 @@ registering it."
                  (compiler-stderr *last-compiler-stderr*))
              (setf (gethash "status" ht) "error")
              (setf (gethash "duration_ms" ht) elapsed-ms)
+             ;; Carried so the response builder can withhold its standing
+             ;; advice to replace the worker: for a failure that leaves the
+             ;; image intact -- another load still holding the lock -- that
+             ;; advice would destroy work about to finish.
+             (when (typep err 'transient-error)
+               (setf (gethash "worker_healthy" ht) t))
              (setf (gethash "message" ht)
                    (sanitize-for-json
                     (or (ignore-errors (princ-to-string err))

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -161,24 +161,31 @@ DEFUN' lines are noise that drown real warnings."
               (progn
                 (setf result
                       (handler-bind ((warning #'handle-warning))
-                        (let ((*compile-verbose* nil)
-                              (*compile-print* nil)
-                              (*load-verbose* nil)
-                              (*load-print* nil)
-                              (*standard-output* (make-string-output-stream))
-                              (*trace-output* (make-string-output-stream))
-                              (*error-output* stderr)
-                              ;; log4cl's console appender writes to a synonym
-                              ;; stream for *DEBUG-IO*, which in a worker
-                              ;; resolves to the original stdout fd whose read
-                              ;; end the parent closed after the handshake --
-                              ;; any write there raises BROKEN-PIPE and aborts
-                              ;; the load.  Rebinding these interactive streams
-                              ;; keeps that output captured instead of hitting
-                              ;; the dead pipe.
-                              (*debug-io* stderr)
-                              (*terminal-io* stderr)
-                              (*query-io* stderr))
+                        (let* ((interactive
+                                 (make-two-way-stream
+                                  (make-concatenated-stream) stderr))
+                               (*compile-verbose* nil)
+                               (*compile-print* nil)
+                               (*load-verbose* nil)
+                               (*load-print* nil)
+                               (*standard-output* (make-string-output-stream))
+                               (*trace-output* (make-string-output-stream))
+                               (*error-output* stderr)
+                               ;; log4cl's console appender writes to a synonym
+                               ;; stream for *DEBUG-IO*, which in a worker
+                               ;; resolves to the original stdout fd whose read
+                               ;; end the parent closed after the handshake --
+                               ;; any write there raises BROKEN-PIPE and aborts
+                               ;; the load.  Rebinding these interactive streams
+                               ;; keeps that output captured instead of hitting
+                               ;; the dead pipe.  A two-way stream, because ANSI
+                               ;; requires these three to be bidirectional: a
+                               ;; system whose load-time code asks Y-OR-N-P
+                               ;; should read EOF, not fail on "not an input
+                               ;; stream".
+                               (*debug-io* interactive)
+                               (*terminal-io* interactive)
+                               (*query-io* interactive))
                           (if syms
                               (progv (nreverse syms) (nreverse vals)
                                 (with-compilation-unit (:override t)
@@ -200,16 +207,19 @@ DEFUN' lines are noise that drown real warnings."
             (progn
               (setf result
                     (handler-bind ((warning #'handle-warning))
-                      (let ((*compile-verbose* nil)
-                            (*compile-print* nil)
-                            (*load-verbose* nil)
-                            (*load-print* nil)
-                            (*standard-output* (make-string-output-stream))
-                            (*trace-output* (make-string-output-stream))
-                            (*error-output* stderr)
-                            (*debug-io* stderr)
-                            (*terminal-io* stderr)
-                            (*query-io* stderr))
+                      (let* ((interactive
+                               (make-two-way-stream
+                                (make-concatenated-stream) stderr))
+                             (*compile-verbose* nil)
+                             (*compile-print* nil)
+                             (*load-verbose* nil)
+                             (*load-print* nil)
+                             (*standard-output* (make-string-output-stream))
+                             (*trace-output* (make-string-output-stream))
+                             (*error-output* stderr)
+                             (*debug-io* interactive)
+                             (*terminal-io* interactive)
+                             (*query-io* interactive))
                         (funcall thunk))))
               (setf completed-p t)
               (values result warning-count

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -16,12 +16,28 @@
   (:import-from #:cl-mcp/src/project-root
                 #:*project-root*)
   (:export #:load-system
+           #:*system-load-lock-wrapper*
            #:*last-compiler-stderr*))
 
 (in-package #:cl-mcp/src/system-loader-core)
 
 (declaim (ftype (function (function (or number null)) (values t &rest t))
                 %load-with-timeout))
+
+(defvar *system-load-lock-wrapper* ()
+  "Optional function of one argument (a thunk) wrapping the ASDF work.
+
+Bound by the worker handler to WITH-ASDF-LOAD-LOCK.  It is read on the
+caller's thread but applied INSIDE the deadline thread, which is the whole
+point: the thread that performs the ASDF work is then the thread that owns the
+lock.  A load that outlives its deadline keeps the lock it is still using, so
+the next load gets that lock's own timeout error instead of quietly starting a
+second ASDF operation alongside the first.  Wrapping outside the deadline
+thread would release the lock the moment the caller was answered, while ASDF
+was still running.
+
+It also puts the time spent waiting for the lock inside the caller's deadline,
+rather than ahead of it.")
 
 (defun %load-with-timeout (thunk timeout-seconds)
   "Execute THUNK under a TIMEOUT-SECONDS deadline on its own thread.
@@ -35,26 +51,37 @@ DESTROY-THREAD.  It matters to the caller: that thread is still inside ASDF,
 so the load this call gave up on keeps mutating the image's ASDF, package and
 compiler state while later requests run against it.
 
+*SYSTEM-LOAD-LOCK-WRAPPER*, when installed, is applied around THUNK on the
+deadline thread rather than around this call, so the lock and the work it
+protects share a thread.  See its docstring.
+
 If the load completes while the deadline is being enforced, the result is
 returned as a success -- completed work is never discarded as a timeout.
 See CALL-WITH-DEADLINE-THREAD for how the deadline is enforced."
-  (handler-case
-      (multiple-value-bind (result status leaked)
-          (call-with-deadline-thread thunk timeout-seconds
-                                     :name "mcp-load-system")
-        (when leaked
-          (ignore-errors
-           (log-event :warn "load.timeout.thread-leaked"
-                      "name" "mcp-load-system"
-                      "timeout" timeout-seconds)))
-        (ecase status
-          (:ok (values result nil nil nil))
-          (:timeout (values nil t nil leaked))
-          (:error (values (list result) nil t nil))))
-    ;; Only reachable on the inline path (no deadline), where
-    ;; CALL-WITH-DEADLINE-THREAD lets conditions propagate.
-    (error (c)
-      (values (list c) nil t nil))))
+  (let* ((wrapper *system-load-lock-wrapper*)
+         ;; Read here, on the caller's thread, and applied there, on the
+         ;; deadline thread: a dynamic binding made by the caller is not
+         ;; visible inside a thread it spawns.
+         (wrapped (if wrapper
+                      (lambda () (funcall wrapper thunk))
+                      thunk)))
+    (handler-case
+        (multiple-value-bind (result status leaked)
+            (call-with-deadline-thread wrapped timeout-seconds
+                                       :name "mcp-load-system")
+          (when leaked
+            (ignore-errors
+             (log-event :warn "load.timeout.thread-leaked"
+                        "name" "mcp-load-system"
+                        "timeout" timeout-seconds)))
+          (ecase status
+            (:ok (values result nil nil nil))
+            (:timeout (values nil t nil leaked))
+            (:error (values (list result) nil t nil))))
+      ;; Only reachable on the inline path (no deadline), where
+      ;; CALL-WITH-DEADLINE-THREAD lets conditions propagate.
+      (error (c)
+        (values (list c) nil t nil)))))
 
 (defvar *last-compiler-stderr* nil
   "Captured compiler stderr from the most recent %call-with-suppressed-output call.

--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -25,11 +25,15 @@
 
 (defun %load-with-timeout (thunk timeout-seconds)
   "Execute THUNK under a TIMEOUT-SECONDS deadline on its own thread.
-Returns (values result-list timed-out-p errored-p).
+Returns (values result-list timed-out-p errored-p leaked-p).
 RESULT-LIST is a list of the thunk's multiple return values on success,
 or a single-element list containing the error condition on failure.
 TIMED-OUT-P is T if the load was still running when the deadline passed.
 ERRORED-P is T if the thunk signaled.
+LEAKED-P is T when the load thread outlived both the cooperative unwind and
+DESTROY-THREAD.  It matters to the caller: that thread is still inside ASDF,
+so the load this call gave up on keeps mutating the image's ASDF, package and
+compiler state while later requests run against it.
 
 If the load completes while the deadline is being enforced, the result is
 returned as a success -- completed work is never discarded as a timeout.
@@ -44,13 +48,13 @@ See CALL-WITH-DEADLINE-THREAD for how the deadline is enforced."
                       "name" "mcp-load-system"
                       "timeout" timeout-seconds)))
         (ecase status
-          (:ok (values result nil nil))
-          (:timeout (values nil t nil))
-          (:error (values (list result) nil t))))
+          (:ok (values result nil nil nil))
+          (:timeout (values nil t nil leaked))
+          (:error (values (list result) nil t nil))))
     ;; Only reachable on the inline path (no deadline), where
     ;; CALL-WITH-DEADLINE-THREAD lets conditions propagate.
     (error (c)
-      (values (list c) nil t))))
+      (values (list c) nil t nil))))
 
 (defvar *last-compiler-stderr* nil
   "Captured compiler stderr from the most recent %call-with-suppressed-output call.
@@ -294,7 +298,7 @@ registering it."
     (setf *auto-discovered-asd* nil)
     (log-event :info "load-system" "system" system-name "force" force
                "clear_fasls" clear-fasls "timeout" timeout-seconds)
-    (multiple-value-bind (result-list timed-out-p errored-p)
+    (multiple-value-bind (result-list timed-out-p errored-p leaked-p)
         (%load-with-timeout
          (lambda ()
            (flet ((%do-load ()
@@ -351,10 +355,17 @@ registering it."
           (timed-out-p (setf (gethash "status" ht) "timeout")
            (setf (gethash "duration_ms" ht) elapsed-ms)
            (setf (gethash "message" ht)
-                 (format nil "Load timed out after ~,2F seconds"
-                         timeout-seconds))
+                 (if leaked-p
+                     (format nil "Load timed out after ~,2F seconds and could ~
+                                  not be stopped: it is still running in this ~
+                                  worker and may hold the ASDF load lock. Use ~
+                                  pool-kill-worker to get a fresh worker."
+                             timeout-seconds)
+                     (format nil "Load timed out after ~,2F seconds"
+                             timeout-seconds)))
            (log-event :warn "load-system-timeout" "system" system-name
-                      "timeout" timeout-seconds))
+                      "timeout" timeout-seconds
+                      "thread_leaked" (if leaked-p "true" "false")))
           (errored-p
            (let ((err (first result-list))
                  (compiler-stderr *last-compiler-stderr*))

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -8,10 +8,8 @@
                 #:log-event)
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht)
-  (:import-from #:bordeaux-threads
-                #:destroy-thread
-                #:make-thread
-                #:thread-alive-p)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:call-with-deadline-thread)
   (:export #:run-tests
            #:detect-test-framework
            #:make-load-failure-result
@@ -495,11 +493,17 @@ representation covers both Rove and FiveAM target-resolution failures."
                    (format nil "~A~%~%Hint: ~A" detail hint)
                    detail))))))
 
-(defun make-timeout-result (seconds)
+(defun make-timeout-result (seconds &key thread-leaked)
   "Build the structured result for a test run that hit its SECONDS deadline.
 Returned in place of a test result so the caller always gets a
 machine-readable hash-table (failed:1, framework \"timeout\") rather than
-an opaque RPC-level error, mirroring MAKE-LOAD-FAILURE-RESULT."
+an opaque RPC-level error, mirroring MAKE-LOAD-FAILURE-RESULT.
+
+THREAD-LEAKED says whether the run thread could actually be stopped.  The two
+cases need different advice: a run that unwound left the worker healthy and
+can simply be retried with a longer timeout, whereas a leaked thread is still
+executing in the worker -- holding whatever locks it had -- and the session
+will not recover until the worker is replaced."
   (make-test-result
    :passed 0
    :failed 1
@@ -512,108 +516,107 @@ an opaque RPC-level error, mirroring MAKE-LOAD-FAILURE-RESULT."
      :test-name "TIMEOUT"
      :description (format nil "Tests timed out after ~A seconds" seconds)
      :reason
-     (format nil "The test run exceeded its ~A second deadline. A suite that ~
-                  leaves a server or thread running can outlive the deadline, ~
-                  so the worker may still be busy; use pool-kill-worker to get ~
-                  a fresh worker before retrying."
-             seconds)))))
+     (if thread-leaked
+         (format nil "The test run exceeded its ~A second deadline and could ~
+                      not be stopped: the run is still executing in this ~
+                      worker and may hold locks that block later loads. Use ~
+                      pool-kill-worker to get a fresh worker before retrying."
+                 seconds)
+         (format nil "The test run exceeded its ~A second deadline and was ~
+                      stopped. The worker is healthy; retry with a larger ~
+                      timeout_seconds if the suite legitimately needs longer."
+                 seconds))))))
+
+(defun %parse-plain-decimal (text)
+  "Parse TEXT as a plain decimal number, or return NIL.
+Accepts an optional sign, digits, and at most one fractional part: \"60\",
+\"+60\", \"1.5\".  Nothing else -- no exponent, no ratio, no trailing unit.
+
+Deliberately avoids READ-FROM-STRING, which an earlier implementation used
+behind a character-set filter.  No filter makes the reader safe here: one
+permissive enough to admit \"1.5e2\" also admits \"e12\" and \"--\", which the
+reader INTERNS as symbols in this package, so a client controlling
+timeout_seconds could grow the package without bound in a long-lived process.
+The reader also honours the global *READ-BASE*, under which \"60\" reads as 96."
+  (let* ((len (length text))
+         (signed (and (plusp len) (find (char text 0) "+-")))
+         (start (if signed 1 0))
+         (dot (position #\. text :start start)))
+    (when (and (< start len)
+               ;; At most one fractional point.
+               (not (find #\. text :start (if dot (1+ dot) len))))
+      (let ((int-text (subseq text start (or dot len)))
+            (frac-text (if dot (subseq text (1+ dot)) "")))
+        (when (and (plusp (+ (length int-text) (length frac-text)))
+                   (every #'digit-char-p int-text)
+                   (every #'digit-char-p frac-text))
+          (let* ((int (if (plusp (length int-text))
+                          (parse-integer int-text)
+                          0))
+                 (frac (if (plusp (length frac-text))
+                           (/ (parse-integer frac-text)
+                              (expt 10 (length frac-text)))
+                           0))
+                 (magnitude (+ int frac))
+                 (value (if (eql signed #\-) (- magnitude) magnitude)))
+            ;; A ratio would print as "3/2" in the timeout messages built from
+            ;; this value; a float reads back the way the caller wrote it.
+            (if (zerop frac) value (float value 1.0))))))))
 
 (defun coerce-timeout-seconds (value)
   "Coerce VALUE to a positive number of seconds, or NIL when unusable.
-Accepts a number, or a string holding one.  JSON has a single number type,
-but not every client sends timeout_seconds as a number, and a string that
-reaches the (NUMBERP ...) guards in the worker handler and in
-PROXY-TO-WORKER is dropped there, silently widening a caller's 60 second
-deadline to the 300 second default.  NIL for a non-positive or unparseable
-value lets callers fall back to their own default."
+Accepts a real number, or a string holding a plain decimal one.
+
+The string case exists for values arriving over raw JSON-RPC, where nothing
+has validated them: the worker handlers read timeout_seconds straight out of
+the params hash, and a string there fails their (NUMBERP ...) guards, silently
+widening a caller's 60 second deadline to the 300 second default.  Tool
+arguments are a separate matter and stay strict -- DEFINE-TOOL's :type :number
+rejects a string outright, with a message naming the argument, before any of
+this runs.
+
+NIL for a non-positive or unparseable value lets callers fall back to their
+own default."
   (typecase value
-    (number (when (plusp value) value))
+    (real (when (plusp value) value))
     (string
-     (let ((trimmed (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
-       ;; Only pass text that can only be a number to READ-FROM-STRING: the
-       ;; reader interns symbols in the current package, so an arbitrary
-       ;; client string must never reach it.  The numeric-charset check
-       ;; keeps this to integers and simple decimals (plus exponents).
-       (when (and (plusp (length trimmed))
-                  (every (lambda (ch) (find ch "0123456789+-.eE"))
-                         trimmed))
-         (multiple-value-bind (parsed pos)
-             (ignore-errors
-              (let ((*read-eval* nil)) (read-from-string trimmed nil nil)))
-           (when (and (numberp parsed)
-                      (eql pos (length trimmed))
-                      (plusp parsed))
-             parsed)))))
+     (let ((parsed (%parse-plain-decimal
+                    (string-trim '(#\Space #\Tab #\Newline #\Return) value))))
+       (when (and parsed (plusp parsed)) parsed)))
     (t nil)))
 
 (defun call-with-test-run-deadline (thunk timeout-seconds)
   "Run THUNK (a test run) on a dedicated thread, answering by TIMEOUT-SECONDS.
-Returns two values: a result and a status keyword.
+Returns three values: a result, a status keyword, and whether the run thread
+was left behind.
 
   :OK       THUNK returned; the result is its value.
   :TIMEOUT  TIMEOUT-SECONDS elapsed first; the result is those seconds.
   :ERROR    THUNK signalled; the result is the condition object.
 
-THUNK also runs under SB-EXT:WITH-TIMEOUT, so the ordinary case -- a slow
-but well-behaved suite -- unwinds inside the run thread and releases its
-locks and UNWIND-PROTECT cleanups normally.  The polling wrapper only
-matters when that cannot happen.  A suite that leaves a blocking call
-running (a server accept loop, say) is invisible to SB-EXT:WITH-TIMEOUT,
-which cannot interrupt a blocking foreign call; run inline, such a suite
-pins the worker's single connection thread for as long as the call blocks,
-and every later tool call for that session hangs with it.  Answering from
-the polling thread bounds the wait no matter what the suite left running,
-so one wedged suite can no longer take the session down.
+Running off the caller's thread is what keeps one wedged suite from taking the
+session down.  A suite that leaves a blocking call running -- a server accept
+loop, say -- cannot be interrupted; run inline it pins the worker's single
+connection thread, and every later tool call for that session hangs with it.
+Here the caller is answered at the deadline no matter what the suite left
+running.
 
-The run thread is destroyed only on a wall-clock deadline it failed to
-observe, and a run that completes during the grace period still yields its
-real result -- completed work is never discarded as a timeout."
-  (let ((outcome nil)
-        (thread nil))
-    (flet ((finish ()
-             (let ((o (or outcome
-                          (cons :error "test run thread vanished"))))
-               (values (cdr o) (car o))))
-           (run ()
-             (setf outcome
-                   (handler-case
-                       (if timeout-seconds
-                           (sb-ext:with-timeout timeout-seconds
-                             (cons :ok (funcall thunk)))
-                           (cons :ok (funcall thunk)))
-                     (sb-ext:timeout () (cons :timeout timeout-seconds))
-                     (serious-condition (e) (cons :error e))))))
-      (setf thread (make-thread #'run :name "mcp-run-tests"))
-      (let ((deadline
-              (when timeout-seconds
-                (+ (get-internal-real-time)
-                   (round (* timeout-seconds
-                             internal-time-units-per-second))))))
-        (loop while (thread-alive-p thread)
-              do (when (and deadline (>= (get-internal-real-time) deadline))
-                   (return))
-                 (sleep 0.05d0))
-        (cond
-          ((not (thread-alive-p thread))
-           (finish))
-          (t
-           ;; Give the run a moment to observe its own WITH-TIMEOUT: a
-           ;; cooperative unwind is preferable to destroying the thread,
-           ;; because it releases the locks the run is holding.
-           (sleep 0.5d0)
-           (if (not (thread-alive-p thread))
-               (finish)
-               (progn
-                 (ignore-errors (destroy-thread thread))
-                 (loop repeat 20
-                       while (thread-alive-p thread)
-                       do (sleep 0.05d0))
-                 (ignore-errors
-                  (log-event :warn "test.runner.deadline"
-                             "timeout" timeout-seconds
-                             "thread_destroyed"
-                             (not (thread-alive-p thread))))
-                 (values timeout-seconds :timeout)))))))))
+The third value is true when the run thread outlived both the cooperative
+unwind and DESTROY-THREAD.  Such a thread is still executing: it may hold
+*ASDF-LOAD-LOCK* or a lock of the suite's own, so the caller should tell the
+user the worker needs replacing rather than present a plain timeout.
+
+See CALL-WITH-DEADLINE-THREAD for how the deadline is enforced, and for why a
+run that completes while the deadline is being enforced still yields its real
+result instead of a timeout."
+  (multiple-value-bind (result status leaked)
+      (call-with-deadline-thread thunk timeout-seconds :name "mcp-run-tests")
+    (when leaked
+      (ignore-errors
+       (log-event :warn "test.runner.deadline.thread-leaked"
+                  "timeout" timeout-seconds
+                  "thread" "mcp-run-tests")))
+    (values (if (eq status :ok) (first result) result) status leaked)))
 
 (defun %extract-defpackage-names-from-file (pathname &optional scan-package)
   "Return a list of package names mentioned in `(defpackage ...)' forms

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -522,9 +522,11 @@ will not recover until the worker is replaced."
                       worker and may hold locks that block later loads. Use ~
                       pool-kill-worker to get a fresh worker before retrying."
                  seconds)
-         (format nil "The test run exceeded its ~A second deadline and was ~
-                      stopped. The worker is healthy; retry with a larger ~
-                      timeout_seconds if the suite legitimately needs longer."
+         (format nil "The test run exceeded its ~A second deadline and its ~
+                      run thread was stopped. Threads the suite started of ~
+                      its own are not tracked and may still be running; ~
+                      retry with a larger timeout_seconds if the suite ~
+                      legitimately needs longer."
                  seconds))))))
 
 (defun %parse-plain-decimal (text)

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -7,7 +7,8 @@
   (:import-from #:cl-mcp/src/log
                 #:log-event)
   (:import-from #:cl-mcp/src/tools/helpers
-                #:make-ht)
+                #:make-ht
+                #:transient-error)
   (:import-from #:cl-mcp/src/utils/deadline
                 #:call-with-deadline-thread)
   (:export #:run-tests
@@ -460,11 +461,18 @@ opaque RPC-level error.  Mirrors the timeout pattern used by
      :test-name "SYSTEM-LOAD"
      :description (format nil "Could not load test system ~A" system-name)
      :reason
-     (format nil "~A~%~%Hint: the worker process may have a broken ~
-                  package state. Use pool-kill-worker to get a fresh ~
-                  worker, then retry run-tests."
-             (or (ignore-errors (princ-to-string condition))
-                 "unprintable condition"))))))
+     (let ((text (or (ignore-errors (princ-to-string condition))
+                     "unprintable condition")))
+       ;; The hint is withheld for a failure that left the image intact -- a
+       ;; concurrent load still holding the ASDF lock, say.  There it is
+       ;; actively harmful: following it aborts work about to finish, and
+       ;; such a condition carries its own, correct advice.
+       (if (typep condition 'transient-error)
+           text
+           (format nil "~A~%~%Hint: the worker process may have a broken ~
+                        package state. Use pool-kill-worker to get a fresh ~
+                        worker, then retry run-tests."
+                   text)))))))
 
 (defun make-resolution-failure-result (condition)
   "Convert a TEST-RESOLUTION-ERROR into a structured test-result so RUN-TESTS

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -919,7 +919,8 @@ without testing wrappers crash Rove's internals with NO-APPLICABLE-METHOD)."
                 (/ (- end-time start-time) internal-time-units-per-second))))
            (stdout (%truncate-test-output (get-output-stream-string stdout-stream)))
            (stderr (%truncate-test-output (get-output-stream-string stderr-stream)))
-           (debug-output (get-output-stream-string debug-stream)))
+           (debug-output
+            (%truncate-test-output (get-output-stream-string debug-stream))))
       (if rove-error
           ;; Rove crashed (e.g., direct assertions without testing wrapper)
           (let ((ht (make-test-result
@@ -1031,7 +1032,8 @@ detects test sub-systems from ASDF dependencies and runs each individually."
             (%truncate-test-output (get-output-stream-string stdout-stream)))
            (stderr
             (%truncate-test-output (get-output-stream-string stderr-stream)))
-           (debug-output (get-output-stream-string debug-stream)))
+           (debug-output
+            (%truncate-test-output (get-output-stream-string debug-stream))))
       (if rove-error
           (let ((ht
                  (make-test-result :passed 0 :failed 1 :failed-tests
@@ -1205,7 +1207,8 @@ the surrounding passed/failed/pending/failure-details bindings."
         (setf (gethash "stdout" ht) stdout))
       (when (plusp (length stderr))
         (setf (gethash "stderr" ht) stderr))
-      (let ((debug-output (get-output-stream-string debug-stream)))
+      (let ((debug-output
+              (%truncate-test-output (get-output-stream-string debug-stream))))
         (when (plusp (length debug-output))
           (setf (gethash "debug_output" ht) debug-output)))
       ht)))
@@ -1486,21 +1489,30 @@ crash, returns a failure result with one failed entry per CRASH-TEST-NAMES
 designator.  Shared by RUN-FIVEAM-TESTS and RUN-FIVEAM-SELECTED-TESTS so the
 stream-capture, crash-handling, and result-assembly logic lives in one place.
 
-NOTE: *standard-output* and *error-output* are intentionally NOT redirected.
-Binding them (even to a broadcast stream) causes integration test suites that
-spawn real threads and sockets to hang inside the worker process.  Only
-*test-debug-output* (cl-mcp's own stream) is captured."
+Capture covers the thread the suite runs on.  Output from threads the suite
+spawns is not captured and reaches the process's own stdout: in SBCL a new
+thread starts from the GLOBAL value of a special, so these bindings are
+invisible to it.  The Rove backend has the same property."
   (let ((start-time (get-internal-real-time))
+        (stdout-stream (make-string-output-stream))
+        (stderr-stream (make-string-output-stream))
         (debug-stream (make-string-output-stream))
         all-results)
     (flet ((duration-ms ()
              (round (* 1000 (/ (- (get-internal-real-time) start-time)
                                internal-time-units-per-second))))
-           (debug-output () (get-output-stream-string debug-stream)))
+           (stdout () (%truncate-test-output
+                       (get-output-stream-string stdout-stream)))
+           (stderr () (%truncate-test-output
+                       (get-output-stream-string stderr-stream)))
+           (debug-output () (%truncate-test-output
+                             (get-output-stream-string debug-stream))))
       (handler-case
           (dolist (spec specs)
             (let ((results
-                    (let ((*test-debug-output* debug-stream))
+                    (let ((*test-debug-output* debug-stream)
+                          (*standard-output* stdout-stream)
+                          (*error-output* stderr-stream))
                       (%fiveam-run spec))))
               (when results
                 (setf all-results (append all-results results)))))
@@ -1517,7 +1529,7 @@ spawn real threads and sockets to hang inside the worker process.  Only
                                          (princ-to-string c))))
                       crash-test-names)
               :framework :fiveam :duration (duration-ms))
-             nil nil (debug-output)))))
+             (stdout) (stderr) (debug-output)))))
       (multiple-value-bind (passed failed pending failure-details)
           (%fiveam-extract-results all-results)
         (%fiveam-attach-output
@@ -1525,7 +1537,7 @@ spawn real threads and sockets to hang inside the worker process.  Only
           :passed passed :failed failed :pending pending
           :failed-tests failure-details
           :framework :fiveam :duration (duration-ms))
-         nil nil (debug-output))))))
+         (stdout) (stderr) (debug-output))))))
 
 (defun run-fiveam-tests (system-name)
   "Run the FiveAM suites belonging to SYSTEM-NAME and return results.

--- a/src/test-runner.lisp
+++ b/src/test-runner.lisp
@@ -41,8 +41,6 @@ Returns:
 - framework (string)
 - duration_ms (integer)
 - stdout (string, present when non-empty) — captured test standard output
-  (Rove only: the FiveAM backend deliberately does not redirect the
-  standard streams, so it reports no stdout/stderr — use debug_output)
 - stderr (string, present when non-empty) — captured test error output
 - debug_output (string, present when non-empty) — output written to *test-debug-output* stream
 NOTE: stdout/stderr are in structured fields only, NOT shown in the summary text.

--- a/src/test-runner.lisp
+++ b/src/test-runner.lisp
@@ -79,7 +79,7 @@ Examples:
                                    "tests" tests
                                    "timeout_seconds" timeout-seconds))
     (let ((effective-timeout (or (coerce-timeout-seconds timeout-seconds) 300)))
-      (multiple-value-bind (test-result status)
+      (multiple-value-bind (test-result status thread-leaked)
           (call-with-test-run-deadline
            (lambda ()
              (run-tests system
@@ -91,7 +91,8 @@ Examples:
                 (build-run-tests-response
                  (ecase status
                    (:ok test-result)
-                   (:timeout (make-timeout-result test-result))
+                   (:timeout (make-timeout-result test-result
+                                                  :thread-leaked thread-leaked))
                    ;; Re-signal so real failures stay visible instead of
                    ;; being reported as a bogus test result.
                    (:error (error test-result)))))))))

--- a/src/tools/helpers.lisp
+++ b/src/tools/helpers.lisp
@@ -16,6 +16,8 @@
            #:tool-error
            ;; JSON serialization helpers
            #:json-bool
+           ;; Failures that leave the worker usable
+           #:transient-error
            ;; Argument extraction helpers
            #:arg-validation-error
            #:validation-message
@@ -84,6 +86,19 @@ Typical usage in MCP tool responses:
 ;;;;
 ;;;; These helpers simplify the common pattern of extracting and validating
 ;;;; arguments from the MCP tool call args hash-table.
+
+(define-condition transient-error (simple-error)
+  ()
+  (:documentation "An error whose cause leaves this worker usable.
+
+Signalled when an operation could not proceed for a reason that will pass on
+its own -- a concurrent load holding a lock, say -- rather than because the
+image is damaged.  Response builders check for it before appending their
+standing advice to replace the worker: for these failures that advice is
+actively harmful, because it destroys work that was about to finish.
+
+A subtype of SIMPLE-ERROR so that handlers written for the ordinary case,
+which is what most callers have, still catch it."))
 
 (define-condition arg-validation-error (error)
   ((arg-name :initarg :arg-name :reader arg-name)

--- a/src/tools/response-builders.lisp
+++ b/src/tools/response-builders.lisp
@@ -231,8 +231,13 @@ Use pool-kill-worker to get a fresh worker, then re-run load-system.")))))))
                                      co)))
                       (format s "~%~%Compiler output:~%~A"
                               (string-right-trim '(#\Newline) body)))))
-                (format s "~%~%Hint: the worker process may now have a broken package state. ~
-Use pool-kill-worker to get a fresh worker, then retry load-system."))))))
+                ;; Withheld when the failure left the image intact -- a
+                ;; concurrent load still holding the ASDF lock, say.  There
+                ;; the advice is actively harmful: following it aborts work
+                ;; that was about to finish.
+                (unless (gethash "worker_healthy" ht)
+                  (format s "~%~%Hint: the worker process may now have a broken package state. ~
+Use pool-kill-worker to get a fresh worker, then retry load-system.")))))))
     (setf (gethash "content" ht) (text-content summary))
     ht))
 

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -68,38 +68,64 @@ A throw also cannot be swallowed by a HANDLER-CASE inside the thunk, which a
 condition can.  Only when the interrupt goes unobserved -- a blocking foreign
 call cannot run it -- is the thread destroyed.
 
-Completed work is never discarded: the thunk records its outcome before the
-throw can unwind past it, and that outcome is preferred over the deadline on
-return, so a run that finishes while the deadline is being enforced still
-yields its real value."
+Completed work survives a deadline that expires alongside it, which takes two
+guards rather than one.  The thunk runs with interrupts enabled inside a
+WITHOUT-INTERRUPTS, so once it returns, delivery of the deadline throw is
+deferred until its values have been published -- a naked assignment would let
+the throw land after the thunk returned but before its result was stored.  And
+the interrupt function re-reads OUTCOME in the interrupted thread before
+throwing, where publication cannot be half-done, so a run that finished just
+as the deadline expired is left to return normally instead of being unwound
+out of its own result."
   (if (not (and timeout-seconds (realp timeout-seconds) (plusp timeout-seconds)))
       (values (multiple-value-list (funcall thunk)) :ok nil)
       (let* ((tag (list :deadline))
              (outcome nil)
              (thread (make-thread
                       (lambda ()
-                        ;; OUTCOME is assigned inside the CATCH so a result
-                        ;; that landed before the interrupt survives it; the
-                        ;; thrown value is deliberately dropped.
                         (catch tag
-                          (handler-case
-                              (setf outcome
-                                    (cons :ok (multiple-value-list
-                                               (funcall thunk))))
-                            (serious-condition (e)
-                              (setf outcome (cons :error e))))))
+                          (sb-sys:without-interrupts
+                            (handler-case
+                                (setf outcome
+                                      (cons :ok
+                                            (multiple-value-list
+                                             (sb-sys:with-local-interrupts
+                                               (funcall thunk)))))
+                              (serious-condition (e)
+                                (setf outcome (cons :error e)))))))
                       :name name)))
-        (flet ((finish (leaked)
+        (flet ((stop ()
+                 ;; Cooperative unwind first: it runs the thread's
+                 ;; UNWIND-PROTECT cleanups and releases the locks it holds.
+                 (when (thread-alive-p thread)
+                   (ignore-errors
+                    (interrupt-thread
+                     thread
+                     ;; Checked in the interrupted thread, where publication
+                     ;; cannot be in progress: it runs under
+                     ;; WITHOUT-INTERRUPTS, so an OUTCOME seen here is
+                     ;; complete.  A run that finished just as the deadline
+                     ;; expired is therefore left to return normally instead
+                     ;; of being unwound out of its own result.
+                     (lambda () (unless outcome (throw tag :deadline)))))
+                   (%wait-until-dead thread *unwind-grace-seconds*))
+                 (when (thread-alive-p thread)
+                   (ignore-errors (destroy-thread thread))
+                   (%wait-until-dead thread *destroy-grace-seconds*)))
+               (finish (leaked)
                  (let ((settled outcome))
                    (if settled
                        (values (cdr settled) (car settled) leaked)
                        (values timeout-seconds :timeout leaked)))))
-          (%wait-until-dead thread timeout-seconds)
-          (when (thread-alive-p thread)
-            (ignore-errors
-             (interrupt-thread thread (lambda () (throw tag :deadline))))
-            (%wait-until-dead thread *unwind-grace-seconds*))
-          (when (thread-alive-p thread)
-            (ignore-errors (destroy-thread thread))
-            (%wait-until-dead thread *destroy-grace-seconds*))
-          (finish (thread-alive-p thread))))))
+          (let ((answered nil))
+            (unwind-protect
+                 (progn
+                   (%wait-until-dead thread timeout-seconds)
+                   (stop)
+                   (multiple-value-prog1 (finish (thread-alive-p thread))
+                     (setf answered t)))
+              ;; A non-local exit from the caller -- an outer deadline, a
+              ;; kill -- must not leave the run thread executing unnoticed.
+              ;; Guarded so the normal path does not pay for a second
+              ;; interrupt-and-destroy cycle it has already completed.
+              (unless answered (stop))))))))

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -117,14 +117,19 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                                  "the ~A thread exited without a result"
                                  :format-arguments (list name))
                                 :error leaked))))))
-          (unwind-protect
-               (progn
-                 ;; Spawned with interrupts deferred, and inside the
-                 ;; UNWIND-PROTECT, so no asynchronous exit can land between
-                 ;; the thread existing and THREAD naming it -- the cleanup
-                 ;; would then have nothing to stop and the thread would run
-                 ;; on unnoticed.
-                 (sb-sys:without-interrupts
+          ;; The whole UNWIND-PROTECT sits under WITHOUT-INTERRUPTS, with only
+          ;; the waiting re-enabled: SBCL requires that for a cleanup to be
+          ;; safe against an asynchronous unwind.  Nested calls make it
+          ;; concrete -- a run thread may itself run a deadline of its own --
+          ;; and an outer DESTROY-THREAD landing mid-cleanup would drop the
+          ;; inner one, leaving its thread running with nobody tracking it.
+          (sb-sys:without-interrupts
+            (unwind-protect
+                 (progn
+                   ;; Spawned with interrupts deferred, so no asynchronous
+                   ;; exit can land between the thread existing and THREAD
+                   ;; naming it -- the cleanup would then have nothing to stop
+                   ;; and the thread would run on unnoticed.
                    (setf thread
                          (make-thread
                           (lambda ()
@@ -138,15 +143,16 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                                                    (funcall thunk)))))
                                   (serious-condition (e)
                                     (setf outcome (cons :error e)))))))
-                          :name name)))
-                 (%wait-until-dead thread timeout-seconds)
-                 (let ((timed-out (thread-alive-p thread)))
-                   (stop)
-                   (multiple-value-prog1 (finish timed-out
-                                                 (thread-alive-p thread))
-                     (setf answered t))))
-            ;; A non-local exit from the caller -- an outer deadline, a
-            ;; kill -- must not leave the run thread executing unnoticed.
-            ;; Guarded so the normal path does not pay for a second
-            ;; interrupt-and-destroy cycle it has already completed.
-            (unless answered (stop)))))))
+                          :name name))
+                   (sb-sys:with-local-interrupts
+                     (%wait-until-dead thread timeout-seconds)
+                     (let ((timed-out (thread-alive-p thread)))
+                       (stop)
+                       (multiple-value-prog1 (finish timed-out
+                                                     (thread-alive-p thread))
+                         (setf answered t)))))
+              ;; A non-local exit from the caller -- an outer deadline, a
+              ;; kill -- must not leave the run thread executing unnoticed.
+              ;; Guarded so the normal path does not pay for a second
+              ;; interrupt-and-destroy cycle it has already completed.
+              (unless answered (stop))))))))

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -95,13 +95,30 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                    (ignore-errors
                     (interrupt-thread
                      thread
-                     ;; Checked in the interrupted thread, where publication
-                     ;; cannot be in progress: it runs under
+                     ;; OUTCOME is checked in the interrupted thread, where
+                     ;; publication cannot be in progress: it runs under
                      ;; WITHOUT-INTERRUPTS, so an OUTCOME seen here is
                      ;; complete.  A run that finished just as the deadline
                      ;; expired is therefore left to return normally instead
                      ;; of being unwound out of its own result.
-                     (lambda () (unless outcome (throw tag :deadline)))))
+                     ;;
+                     ;; IGNORE-ERRORS around the throw, and not only around
+                     ;; INTERRUPT-THREAD: this closure runs later, on the run
+                     ;; thread, outside any handler of ours.  A thread can be
+                     ;; alive with the CATCH already gone -- an earlier throw
+                     ;; consumed it and the thread is still winding down --
+                     ;; and a throw to a tag that no longer exists is an
+                     ;; unhandled CONTROL-ERROR there.  The worker runs under
+                     ;; SB-EXT:DISABLE-DEBUGGER, where that kills the process
+                     ;; outright: the session would lose all its state to a
+                     ;; deadline whose whole purpose is to answer gracefully.
+                     ;; The window is narrow -- STOP has to run twice, which
+                     ;; takes a non-local exit between FINISH and ANSWERED --
+                     ;; but the guard costs nothing and the failure it
+                     ;; prevents is total.
+                     (lambda ()
+                       (unless outcome
+                         (ignore-errors (throw tag :deadline))))))
                    (%wait-until-dead thread *unwind-grace-seconds*))
                  (when (and thread (thread-alive-p thread))
                    (ignore-errors (destroy-thread thread))

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -1,0 +1,105 @@
+;;;; src/utils/deadline.lisp
+;;;;
+;;;; One implementation of "run this on its own thread and answer by a
+;;;; deadline", shared by repl-eval, load-system and run-tests.  Each of the
+;;;; three grew its own copy of the spawn/poll/destroy sequence and the copies
+;;;; drifted: only one logged a leaked thread, only one re-read the result
+;;;; after the deadline, and each named the outcome differently.
+
+(defpackage #:cl-mcp/src/utils/deadline
+  (:use #:cl)
+  (:import-from #:bordeaux-threads
+                #:make-thread
+                #:thread-alive-p
+                #:destroy-thread
+                #:interrupt-thread)
+  (:export #:call-with-deadline-thread
+           #:*poll-interval*
+           #:*unwind-grace-seconds*
+           #:*destroy-grace-seconds*))
+
+(in-package #:cl-mcp/src/utils/deadline)
+
+(defparameter *poll-interval* 0.05d0
+  "Seconds between liveness checks while waiting on a deadline thread.")
+
+(defparameter *unwind-grace-seconds* 0.5d0
+  "Seconds allowed for a cooperative unwind before the thread is destroyed.
+An unwind releases the locks the run holds and runs its UNWIND-PROTECT
+cleanups, so it is always preferable to DESTROY-THREAD.")
+
+(defparameter *destroy-grace-seconds* 1.0d0
+  "Seconds allowed for DESTROY-THREAD to take effect before the thread is
+reported as leaked.")
+
+(defun %wait-until-dead (thread seconds)
+  "Poll until THREAD is gone or SECONDS elapse.  Returns true when it is gone."
+  (let ((deadline (+ (get-internal-real-time)
+                     (round (* seconds internal-time-units-per-second)))))
+    (loop while (and (thread-alive-p thread)
+                     (< (get-internal-real-time) deadline))
+          do (sleep *poll-interval*))
+    (not (thread-alive-p thread))))
+
+(defun call-with-deadline-thread (thunk timeout-seconds &key (name "mcp-deadline"))
+  "Run THUNK on a dedicated thread and answer within TIMEOUT-SECONDS.
+
+Returns three values:
+  RESULT  the list of THUNK's values on :OK, TIMEOUT-SECONDS on :TIMEOUT,
+          the condition on :ERROR.
+  STATUS  :OK, :TIMEOUT or :ERROR.
+  LEAKED  true when the run thread was still alive on return, i.e. neither the
+          cooperative unwind nor DESTROY-THREAD could stop it.  The caller is
+          answered either way, but a leaked thread is still running: it may
+          hold locks and it will contend with later work in this image.
+
+Without a usable TIMEOUT-SECONDS the thunk runs inline on the caller's thread
+and any condition propagates -- a thread buys nothing when there is no
+deadline to enforce, and running inline keeps the caller's own handlers and
+backtrace intact.
+
+At the deadline the thread is first asked to unwind cooperatively, by
+INTERRUPT-THREAD throwing to a tag private to this call.  The private tag,
+rather than SB-EXT:WITH-TIMEOUT, is what makes the outcome unambiguous:
+WITH-TIMEOUT signals SB-EXT:TIMEOUT, which the thunk may also signal on its
+own -- a test suite exercising timeout behaviour, say -- leaving the two
+indistinguishable and reporting the suite's own timeout as a deadline breach.
+A throw also cannot be swallowed by a HANDLER-CASE inside the thunk, which a
+condition can.  Only when the interrupt goes unobserved -- a blocking foreign
+call cannot run it -- is the thread destroyed.
+
+Completed work is never discarded: the thunk records its outcome before the
+throw can unwind past it, and that outcome is preferred over the deadline on
+return, so a run that finishes while the deadline is being enforced still
+yields its real value."
+  (if (not (and timeout-seconds (realp timeout-seconds) (plusp timeout-seconds)))
+      (values (multiple-value-list (funcall thunk)) :ok nil)
+      (let* ((tag (list :deadline))
+             (outcome nil)
+             (thread (make-thread
+                      (lambda ()
+                        ;; OUTCOME is assigned inside the CATCH so a result
+                        ;; that landed before the interrupt survives it; the
+                        ;; thrown value is deliberately dropped.
+                        (catch tag
+                          (handler-case
+                              (setf outcome
+                                    (cons :ok (multiple-value-list
+                                               (funcall thunk))))
+                            (serious-condition (e)
+                              (setf outcome (cons :error e))))))
+                      :name name)))
+        (flet ((finish (leaked)
+                 (let ((settled outcome))
+                   (if settled
+                       (values (cdr settled) (car settled) leaked)
+                       (values timeout-seconds :timeout leaked)))))
+          (%wait-until-dead thread timeout-seconds)
+          (when (thread-alive-p thread)
+            (ignore-errors
+             (interrupt-thread thread (lambda () (throw tag :deadline))))
+            (%wait-until-dead thread *unwind-grace-seconds*))
+          (when (thread-alive-p thread)
+            (ignore-errors (destroy-thread thread))
+            (%wait-until-dead thread *destroy-grace-seconds*))
+          (finish (thread-alive-p thread))))))

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -52,6 +52,7 @@ Returns three values:
           cooperative unwind nor DESTROY-THREAD could stop it.  The caller is
           answered either way, but a leaked thread is still running: it may
           hold locks and it will contend with later work in this image.
+          Threads THUNK spawns are not tracked -- only the run thread is.
 
 Without a usable TIMEOUT-SECONDS the thunk runs inline on the caller's thread
 and any condition propagates -- a thread buys nothing when there is no
@@ -76,28 +77,21 @@ the throw land after the thunk returned but before its result was stored.  And
 the interrupt function re-reads OUTCOME in the interrupted thread before
 throwing, where publication cannot be half-done, so a run that finished just
 as the deadline expired is left to return normally instead of being unwound
-out of its own result."
+out of its own result.
+
+A thread that dies before the deadline without publishing anything -- THUNK
+called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
+:TIMEOUT, so a deadline that never elapsed is not blamed for it."
   (if (not (and timeout-seconds (realp timeout-seconds) (plusp timeout-seconds)))
       (values (multiple-value-list (funcall thunk)) :ok nil)
-      (let* ((tag (list :deadline))
-             (outcome nil)
-             (thread (make-thread
-                      (lambda ()
-                        (catch tag
-                          (sb-sys:without-interrupts
-                            (handler-case
-                                (setf outcome
-                                      (cons :ok
-                                            (multiple-value-list
-                                             (sb-sys:with-local-interrupts
-                                               (funcall thunk)))))
-                              (serious-condition (e)
-                                (setf outcome (cons :error e)))))))
-                      :name name)))
+      (let ((tag (list :deadline))
+            (outcome nil)
+            (thread nil)
+            (answered nil))
         (flet ((stop ()
                  ;; Cooperative unwind first: it runs the thread's
                  ;; UNWIND-PROTECT cleanups and releases the locks it holds.
-                 (when (thread-alive-p thread)
+                 (when (and thread (thread-alive-p thread))
                    (ignore-errors
                     (interrupt-thread
                      thread
@@ -109,23 +103,50 @@ out of its own result."
                      ;; of being unwound out of its own result.
                      (lambda () (unless outcome (throw tag :deadline)))))
                    (%wait-until-dead thread *unwind-grace-seconds*))
-                 (when (thread-alive-p thread)
+                 (when (and thread (thread-alive-p thread))
                    (ignore-errors (destroy-thread thread))
                    (%wait-until-dead thread *destroy-grace-seconds*)))
-               (finish (leaked)
+               (finish (timed-out leaked)
                  (let ((settled outcome))
-                   (if settled
-                       (values (cdr settled) (car settled) leaked)
-                       (values timeout-seconds :timeout leaked)))))
-          (let ((answered nil))
-            (unwind-protect
-                 (progn
-                   (%wait-until-dead thread timeout-seconds)
+                   (cond
+                     (settled (values (cdr settled) (car settled) leaked))
+                     (timed-out (values timeout-seconds :timeout leaked))
+                     (t (values (make-condition
+                                 'simple-error
+                                 :format-control
+                                 "the ~A thread exited without a result"
+                                 :format-arguments (list name))
+                                :error leaked))))))
+          (unwind-protect
+               (progn
+                 ;; Spawned with interrupts deferred, and inside the
+                 ;; UNWIND-PROTECT, so no asynchronous exit can land between
+                 ;; the thread existing and THREAD naming it -- the cleanup
+                 ;; would then have nothing to stop and the thread would run
+                 ;; on unnoticed.
+                 (sb-sys:without-interrupts
+                   (setf thread
+                         (make-thread
+                          (lambda ()
+                            (catch tag
+                              (sb-sys:without-interrupts
+                                (handler-case
+                                    (setf outcome
+                                          (cons :ok
+                                                (multiple-value-list
+                                                 (sb-sys:with-local-interrupts
+                                                   (funcall thunk)))))
+                                  (serious-condition (e)
+                                    (setf outcome (cons :error e)))))))
+                          :name name)))
+                 (%wait-until-dead thread timeout-seconds)
+                 (let ((timed-out (thread-alive-p thread)))
                    (stop)
-                   (multiple-value-prog1 (finish (thread-alive-p thread))
-                     (setf answered t)))
-              ;; A non-local exit from the caller -- an outer deadline, a
-              ;; kill -- must not leave the run thread executing unnoticed.
-              ;; Guarded so the normal path does not pay for a second
-              ;; interrupt-and-destroy cycle it has already completed.
-              (unless answered (stop))))))))
+                   (multiple-value-prog1 (finish timed-out
+                                                 (thread-alive-p thread))
+                     (setf answered t))))
+            ;; A non-local exit from the caller -- an outer deadline, a
+            ;; kill -- must not leave the run thread executing unnoticed.
+            ;; Guarded so the normal path does not pay for a second
+            ;; interrupt-and-destroy cycle it has already completed.
+            (unless answered (stop)))))))

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -47,6 +47,7 @@
                 #:register-method)
   (:import-from #:cl-mcp/src/worker/init-hook
                 #:with-asdf-load-lock
+                #:*asdf-load-lock-timeout*
                 #:handle-init-start
                 #:handle-init-status)
   (:export #:register-all-handlers))
@@ -114,7 +115,15 @@ result_preview, and error_context."
 (defun %handle-load-system (params)
   "Load an ASDF system.  Returns the same structure as define-tool
 \"load-system\".  Holds *ASDF-LOAD-LOCK* so it cannot overlap a
-concurrent worker/init load or another load-system."
+concurrent worker/init load or another load-system.
+
+The caller's timeout_seconds bounds the whole call, waiting for that lock
+included.  Acquisition happens outside LOAD-SYSTEM's own deadline, so leaving
+it unbounded let a request with a small timeout sit far past the budget the
+proxy allows it -- and a proxy timeout kills the worker instead of reporting
+anything.  What the wait consumes is therefore subtracted from the deadline
+given to the load itself.  RUN-TESTS needs none of this: it takes the lock
+from inside its own deadline thread, which bounds the wait already."
   (let* ((system (gethash "system" params))
          (force (%bool-default params "force" t))
          (clear-fasls (gethash "clear_fasls" params))
@@ -127,11 +136,18 @@ concurrent worker/init load or another load-system."
       (error "system is required"))
     (when (and raw-timeout (null timeout-seconds))
       (error "timeout_seconds must be a positive number"))
-    (let ((ht (with-asdf-load-lock
-                (load-system system
-                             :force force
-                             :clear-fasls clear-fasls
-                             :timeout-seconds (or timeout-seconds 120)))))
+    (let* ((budget (or timeout-seconds 120))
+           (started (get-internal-real-time))
+           (ht (let ((*asdf-load-lock-timeout* budget))
+                 (with-asdf-load-lock
+                   (let ((remaining
+                           (- budget
+                              (/ (- (get-internal-real-time) started)
+                                 internal-time-units-per-second))))
+                     (load-system system
+                                  :force force
+                                  :clear-fasls clear-fasls
+                                  :timeout-seconds (max 1 remaining)))))))
       (build-load-system-response system ht))))
 
 ;;; ---------------------------------------------------------------------------

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -104,7 +104,13 @@ result_preview, and error_context."
                    :package (or package *package*)
                    :print-level print-level
                    :print-length print-length
-                   :timeout-seconds timeout-seconds
+                   ;; Always a server-side deadline, as run-tests has: without
+                   ;; one an accidental (loop) pins this worker's single
+                   ;; connection thread, and the proxy -- which budgets for
+                   ;; this same default -- eventually gives up and kills the
+                   ;; worker, resetting the session for what should have been
+                   ;; a timeout report.
+                   :timeout-seconds (or timeout-seconds 300)
                    :max-output-length max-output-length
                    :safe-read safe-read
                    :locals-preview-frames locals-preview-frames
@@ -153,7 +159,13 @@ it gives up and kills the worker."
                          ;; Bound inside the lambda, not around it: this runs
                          ;; on the deadline thread, which does not inherit
                          ;; bindings made here.
-                         (let ((*asdf-load-lock-timeout* budget))
+                         ;; A margin below the load's own budget, so which of
+                       ;; the two fires is settled by design rather than by
+                       ;; the deadline poller's 50 ms granularity.  The lock
+                       ;; message names the thread holding it and what to do;
+                       ;; the load's generic timeout does not.
+                       (let ((*asdf-load-lock-timeout*
+                               (max 1 (- budget 1))))
                            (with-asdf-load-lock (funcall thunk))))))
                  (load-system system
                               :force force
@@ -197,7 +209,14 @@ caller is answered at the deadline even while the suite is still blocked."
                ;; docstring for why the test run itself must stay outside it.
                (let ((*load-lock-wrapper*
                        (lambda (thunk)
-                         (with-asdf-load-lock (funcall thunk)))))
+                         ;; Bound to the caller's budget, as %HANDLE-LOAD-SYSTEM
+                         ;; does, so the lock's own diagnostic can actually be
+                         ;; reached: left at the global default a caller asking
+                         ;; for less than that always meets the run deadline
+                         ;; first and never sees which thread held the lock.
+                         (let ((*asdf-load-lock-timeout*
+                                 (max 1 (- effective-timeout 1))))
+                           (with-asdf-load-lock (funcall thunk))))))
                  (run-tests system
                             :framework framework
                             :test test

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -15,7 +15,8 @@
                 #:code-describe-symbol
                 #:code-find-references)
   (:import-from #:cl-mcp/src/system-loader-core
-                #:load-system)
+                #:load-system
+                #:*system-load-lock-wrapper*)
   (:import-from #:cl-mcp/src/test-runner-core
                 #:run-tests
                 #:call-with-test-run-deadline
@@ -114,16 +115,18 @@ result_preview, and error_context."
 
 (defun %handle-load-system (params)
   "Load an ASDF system.  Returns the same structure as define-tool
-\"load-system\".  Holds *ASDF-LOAD-LOCK* so it cannot overlap a
-concurrent worker/init load or another load-system.
+\"load-system\".  Serializes against every other cl-mcp-mediated ASDF load
+through *ASDF-LOAD-LOCK*.
 
-The caller's timeout_seconds bounds the whole call, waiting for that lock
-included.  Acquisition happens outside LOAD-SYSTEM's own deadline, so leaving
-it unbounded let a request with a small timeout sit far past the budget the
-proxy allows it -- and a proxy timeout kills the worker instead of reporting
-anything.  What the wait consumes is therefore subtracted from the deadline
-given to the load itself.  RUN-TESTS needs none of this: it takes the lock
-from inside its own deadline thread, which bounds the wait already."
+The lock is taken from inside LOAD-SYSTEM's own deadline thread rather than
+around the call, by way of *SYSTEM-LOAD-LOCK-WRAPPER*, so the thread doing the
+ASDF work is the thread holding the lock.  Wrapping the call instead would
+release the lock the moment this handler was answered -- and a load that
+outlived its deadline is still running inside ASDF, so the next load would
+start a second ASDF operation alongside the first.  It also keeps the wait for
+the lock inside the caller's timeout_seconds instead of ahead of it, which
+matters because the proxy only allows that timeout plus a small margin before
+it gives up and kills the worker."
   (let* ((system (gethash "system" params))
          (force (%bool-default params "force" t))
          (clear-fasls (gethash "clear_fasls" params))
@@ -137,17 +140,17 @@ from inside its own deadline thread, which bounds the wait already."
     (when (and raw-timeout (null timeout-seconds))
       (error "timeout_seconds must be a positive number"))
     (let* ((budget (or timeout-seconds 120))
-           (started (get-internal-real-time))
-           (ht (let ((*asdf-load-lock-timeout* budget))
-                 (with-asdf-load-lock
-                   (let ((remaining
-                           (- budget
-                              (/ (- (get-internal-real-time) started)
-                                 internal-time-units-per-second))))
-                     (load-system system
-                                  :force force
-                                  :clear-fasls clear-fasls
-                                  :timeout-seconds (max 1 remaining)))))))
+           (ht (let ((*system-load-lock-wrapper*
+                       (lambda (thunk)
+                         ;; Bound inside the lambda, not around it: this runs
+                         ;; on the deadline thread, which does not inherit
+                         ;; bindings made here.
+                         (let ((*asdf-load-lock-timeout* budget))
+                           (with-asdf-load-lock (funcall thunk))))))
+                 (load-system system
+                              :force force
+                              :clear-fasls clear-fasls
+                              :timeout-seconds budget))))
       (build-load-system-response system ht))))
 
 ;;; ---------------------------------------------------------------------------

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -163,9 +163,11 @@ it gives up and kills the worker."
                        ;; the two fires is settled by design rather than by
                        ;; the deadline poller's 50 ms granularity.  The lock
                        ;; message names the thread holding it and what to do;
-                       ;; the load's generic timeout does not.
-                       (let ((*asdf-load-lock-timeout*
-                               (max 1 (- budget 1))))
+                       ;; the load's generic timeout does not.  Proportional
+                       ;; rather than "one second less": timeout_seconds
+                       ;; accepts fractions, and a fixed second inverts the
+                       ;; ordering for anything under two.
+                       (let ((*asdf-load-lock-timeout* (* budget 9/10)))
                            (with-asdf-load-lock (funcall thunk))))))
                  (load-system system
                               :force force
@@ -215,7 +217,7 @@ caller is answered at the deadline even while the suite is still blocked."
                          ;; for less than that always meets the run deadline
                          ;; first and never sees which thread held the lock.
                          (let ((*asdf-load-lock-timeout*
-                                 (max 1 (- effective-timeout 1))))
+                                 (* effective-timeout 9/10)))
                            (with-asdf-load-lock (funcall thunk))))))
                  (run-tests system
                             :framework framework

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -115,13 +115,17 @@ result_preview, and error_context."
   "Load an ASDF system.  Returns the same structure as define-tool
 \"load-system\".  Holds *ASDF-LOAD-LOCK* so it cannot overlap a
 concurrent worker/init load or another load-system."
-  (let ((system (gethash "system" params))
+  (let* ((system (gethash "system" params))
          (force (%bool-default params "force" t))
          (clear-fasls (gethash "clear_fasls" params))
-         (timeout-seconds (gethash "timeout_seconds" params)))
+         (raw-timeout (gethash "timeout_seconds" params))
+         ;; Params arrive straight off the wire here, so the value has had no
+         ;; type check: calling PLUSP on it directly turns a string into a raw
+         ;; TYPE-ERROR reported as "Internal error during load-system".
+         (timeout-seconds (coerce-timeout-seconds raw-timeout)))
     (unless system
       (error "system is required"))
-    (when (and timeout-seconds (not (plusp timeout-seconds)))
+    (when (and raw-timeout (null timeout-seconds))
       (error "timeout_seconds must be a positive number"))
     (let ((ht (with-asdf-load-lock
                 (load-system system
@@ -171,12 +175,13 @@ caller is answered at the deadline even while the suite is still blocked."
                             :framework framework
                             :test test
                             :tests tests))))
-        (multiple-value-bind (result status)
+        (multiple-value-bind (result status thread-leaked)
             (call-with-test-run-deadline #'do-run effective-timeout)
           (build-run-tests-response
            (ecase status
              (:ok result)
-             (:timeout (make-timeout-result result))
+             (:timeout (make-timeout-result result
+                                            :thread-leaked thread-leaked))
              ;; Re-signal so genuine failures still surface as JSON-RPC
              ;; errors instead of being reported as a bogus test result.
              (:error (error result)))))))))

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -75,11 +75,17 @@ key-present-with-false (use NIL)."
   "Evaluate code and return the same response structure as define-tool
 \"repl-eval\": content, stdout, stderr, and optional result_object_id,
 result_preview, and error_context."
-  (let ((code (gethash "code" params))
+  (let* ((code (gethash "code" params))
          (package (gethash "package" params))
          (print-level (gethash "print_level" params))
          (print-length (gethash "print_length" params))
-         (timeout-seconds (gethash "timeout_seconds" params))
+         ;; Coerced for the same reason %HANDLE-LOAD-SYSTEM coerces: params
+         ;; arrive unvalidated here, and %REPL-EVAL-WITH-TIMEOUT treats a
+         ;; non-real value as "no deadline at all" -- so a string would run
+         ;; unbounded while the proxy, which does accept it, budgets for it
+         ;; and kills the worker when that budget runs out.
+         (raw-timeout (gethash "timeout_seconds" params))
+         (timeout-seconds (coerce-timeout-seconds raw-timeout))
          (max-output-length (gethash "max_output_length" params))
          (safe-read (gethash "safe_read" params))
          (include-result-preview (%bool-default params "include_result_preview" t))
@@ -91,6 +97,8 @@ result_preview, and error_context."
          (locals-preview-skip-internal (%bool-default params "locals_preview_skip_internal" t)))
     (unless code
       (error "code is required"))
+    (when (and raw-timeout (null timeout-seconds))
+      (error "timeout_seconds must be a positive number"))
     (multiple-value-bind (printed raw-value stdout stderr error-context)
         (repl-eval code
                    :package (or package *package*)

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -52,42 +52,51 @@ this message, which names the cause and the fix, instead.")
 (defun %signal-asdf-load-lock-timeout ()
   "Signal that *ASDF-LOAD-LOCK* could not be acquired, naming the likely cause.
 
-Two very different situations reach here and they need opposite advice.  The
-init hook loads on its own thread, holding this lock for a whole cold compile
-with no deadline of its own, so a large application system legitimately keeps
-it past this timeout -- telling that caller to kill the worker would abort a
-healthy load that was about to finish.  Any other owner is a thread that
-outlived its deadline and will never release the lock, and there the worker
-really does have to be replaced."
+Three situations reach here and they need different advice.  The init hook
+loads on its own thread, holding this lock for a whole cold compile with no
+deadline of its own, so a large application system legitimately keeps it past
+this timeout -- telling that caller to kill the worker would abort a healthy
+load that was about to finish.  The lock may also be free again by the time we
+look, which means the contention was transient and there is nothing to fix.
+Only a lock still held by some other thread means a run outlived its deadline
+and will never release it, and only there does the worker have to be replaced."
   (let* ((owner (sb-thread:mutex-owner *asdf-load-lock*))
-         (owner-name (and owner (sb-thread:thread-name owner)))
-         (init-in-progress (equal owner-name "mcp-worker-init")))
+         (owner-name (and owner (sb-thread:thread-name owner))))
     (ignore-errors
      (log-event :error "worker.asdf-load-lock.timeout"
                 "seconds" *asdf-load-lock-timeout*
-                "owner" (or owner-name "none")
-                "init_in_progress" (if init-in-progress "true" "false")))
-    (if init-in-progress
-        ;; TRANSIENT-ERROR, so the response builders withhold their standing
-        ;; "replace the worker" advice.  Appending it here would undo the
-        ;; whole point of separating these two cases: the caller would be told
-        ;; to run pool-kill-worker and would abort a healthy load.
-        (error 'transient-error
-               :format-control
-               "Timed out after ~A seconds waiting for this worker's ASDF ~
-                load lock: the init hook is still loading and holds it. That ~
-                load has no deadline of its own, so a cold compile of a large ~
-                system can legitimately take longer. Wait for ~
-                worker/init-status to report ready, or retry with a larger ~
-                timeout_seconds."
-               :format-arguments (list *asdf-load-lock-timeout*))
-        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
-                load lock~@[, held by thread ~A~]. A previous run most likely ~
-                left a thread behind that never released it; this worker ~
-                cannot load systems again. Use pool-kill-worker to get a ~
-                fresh worker."
-               *asdf-load-lock-timeout*
-               owner-name))))
+                "owner" (or owner-name "none")))
+    (cond
+      ;; Released between the wait expiring and this sample.  Reporting a
+      ;; wedged worker for a lock that is free again would send the caller to
+      ;; pool-kill-worker for nothing.
+      ((null owner)
+       (error 'transient-error
+              :format-control
+              "Timed out after ~A seconds waiting for this worker's ASDF load ~
+               lock, which was released just as the wait expired. Nothing is ~
+               wrong with this worker; retry."
+              :format-arguments (list *asdf-load-lock-timeout*)))
+      ;; TRANSIENT-ERROR, so the response builders withhold their standing
+      ;; "replace the worker" advice.  Appending it here would undo the whole
+      ;; point of separating these cases: the caller would be told to run
+      ;; pool-kill-worker and would abort a healthy load.
+      ((equal owner-name "mcp-worker-init")
+       (error 'transient-error
+              :format-control
+              "Timed out after ~A seconds waiting for this worker's ASDF load ~
+               lock: the init hook is still loading and holds it. That load ~
+               has no deadline of its own, so a cold compile of a large system ~
+               can legitimately take longer. Wait for worker/init-status to ~
+               report ready, or retry with a larger timeout_seconds."
+              :format-arguments (list *asdf-load-lock-timeout*)))
+      (t
+       (error "Timed out after ~A seconds waiting for this worker's ASDF load ~
+               lock~@[, held by thread ~A~]. A previous run most likely left a ~
+               thread behind that never released it; this worker cannot load ~
+               systems again. Use pool-kill-worker to get a fresh worker."
+              *asdf-load-lock-timeout*
+              owner-name)))))
 
 (defun call-with-asdf-load-lock (thunk)
   "Call THUNK holding *ASDF-LOAD-LOCK*, or signal if it cannot be acquired.

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -16,6 +16,7 @@
   (:import-from #:cl-mcp/src/tools/helpers #:make-ht)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:export #:*asdf-load-lock*
+           #:*asdf-load-lock-timeout*
            #:with-asdf-load-lock
            #:handle-init-start
            #:handle-init-status))
@@ -52,23 +53,34 @@ this message, which names the cause and the fix, instead.")
   "Call THUNK holding *ASDF-LOAD-LOCK*, or signal if it cannot be acquired.
 Times out rather than blocking forever, so a lock left owned by a thread that
 outlived its deadline surfaces as one actionable error instead of hanging
-every later load in this worker."
-  (if (sb-thread:grab-mutex *asdf-load-lock*
-                            :timeout *asdf-load-lock-timeout*)
-      (unwind-protect (funcall thunk)
-        (sb-thread:release-mutex *asdf-load-lock*))
-      (let ((owner (sb-thread:mutex-owner *asdf-load-lock*)))
-        (ignore-errors
-         (log-event :error "worker.asdf-load-lock.timeout"
-                    "seconds" *asdf-load-lock-timeout*
-                    "owner" (if owner (sb-thread:thread-name owner) "none")))
-        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
-                load lock~@[, held by thread ~A~]. A previous run most likely ~
-                left a thread behind that never released it; this worker ~
-                cannot load systems again. Use pool-kill-worker to get a ~
-                fresh worker."
-               *asdf-load-lock-timeout*
-               (and owner (sb-thread:thread-name owner))))))
+every later load in this worker.
+
+SB-THREAD:WITH-MUTEX rather than a GRAB-MUTEX/UNWIND-PROTECT pair: SBCL
+documents GRAB-MUTEX and RELEASE-MUTEX as not interrupt-safe, and this runs on
+the very thread a run-tests deadline interrupts.  An interrupt arriving
+between GRAB-MUTEX returning and the UNWIND-PROTECT being established would
+leak the lock outright -- the exact failure the timeout below exists to make
+survivable.  WITH-MUTEX returns NIL rather than signalling when the timeout
+expires, so RAN distinguishes that from a THUNK that returned NIL."
+  (let* ((ran nil)
+         (values (sb-thread:with-mutex (*asdf-load-lock*
+                                        :timeout *asdf-load-lock-timeout*)
+                   (setf ran t)
+                   (multiple-value-list (funcall thunk)))))
+    (if ran
+        (values-list values)
+        (let ((owner (sb-thread:mutex-owner *asdf-load-lock*)))
+          (ignore-errors
+           (log-event :error "worker.asdf-load-lock.timeout"
+                      "seconds" *asdf-load-lock-timeout*
+                      "owner" (if owner (sb-thread:thread-name owner) "none")))
+          (error "Timed out after ~A seconds waiting for this worker's ASDF ~
+                  load lock~@[, held by thread ~A~]. A previous run most ~
+                  likely left a thread behind that never released it; this ~
+                  worker cannot load systems again. Use pool-kill-worker to ~
+                  get a fresh worker."
+                 *asdf-load-lock-timeout*
+                 (and owner (sb-thread:thread-name owner)))))))
 
 (defvar *init-lock* (bt:make-lock "worker-init-state")
   "Protects *INIT-STATE*.")

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -49,6 +49,39 @@ this message, which names the cause and the fix, instead.")
 *ASDF-LOAD-LOCK-TIMEOUT* seconds to acquire it."
   `(call-with-asdf-load-lock (lambda () ,@body)))
 
+(defun %signal-asdf-load-lock-timeout ()
+  "Signal that *ASDF-LOAD-LOCK* could not be acquired, naming the likely cause.
+
+Two very different situations reach here and they need opposite advice.  The
+init hook loads on its own thread, holding this lock for a whole cold compile
+with no deadline of its own, so a large application system legitimately keeps
+it past this timeout -- telling that caller to kill the worker would abort a
+healthy load that was about to finish.  Any other owner is a thread that
+outlived its deadline and will never release the lock, and there the worker
+really does have to be replaced."
+  (let* ((owner (sb-thread:mutex-owner *asdf-load-lock*))
+         (owner-name (and owner (sb-thread:thread-name owner)))
+         (init-in-progress (equal owner-name "mcp-worker-init")))
+    (ignore-errors
+     (log-event :error "worker.asdf-load-lock.timeout"
+                "seconds" *asdf-load-lock-timeout*
+                "owner" (or owner-name "none")
+                "init_in_progress" (if init-in-progress "true" "false")))
+    (if init-in-progress
+        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
+                load lock: the init hook is still loading and holds it. That ~
+                load has no deadline of its own, so a cold compile of a large ~
+                system can legitimately take longer. Wait for worker/init-status ~
+                to report ready, or retry with a larger timeout_seconds."
+               *asdf-load-lock-timeout*)
+        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
+                load lock~@[, held by thread ~A~]. A previous run most likely ~
+                left a thread behind that never released it; this worker ~
+                cannot load systems again. Use pool-kill-worker to get a ~
+                fresh worker."
+               *asdf-load-lock-timeout*
+               owner-name))))
+
 (defun call-with-asdf-load-lock (thunk)
   "Call THUNK holding *ASDF-LOAD-LOCK*, or signal if it cannot be acquired.
 Times out rather than blocking forever, so a lock left owned by a thread that
@@ -69,18 +102,7 @@ expires, so RAN distinguishes that from a THUNK that returned NIL."
                    (multiple-value-list (funcall thunk)))))
     (if ran
         (values-list values)
-        (let ((owner (sb-thread:mutex-owner *asdf-load-lock*)))
-          (ignore-errors
-           (log-event :error "worker.asdf-load-lock.timeout"
-                      "seconds" *asdf-load-lock-timeout*
-                      "owner" (if owner (sb-thread:thread-name owner) "none")))
-          (error "Timed out after ~A seconds waiting for this worker's ASDF ~
-                  load lock~@[, held by thread ~A~]. A previous run most ~
-                  likely left a thread behind that never released it; this ~
-                  worker cannot load systems again. Use pool-kill-worker to ~
-                  get a fresh worker."
-                 *asdf-load-lock-timeout*
-                 (and owner (sb-thread:thread-name owner)))))))
+        (%signal-asdf-load-lock-timeout))))
 
 (defvar *init-lock* (bt:make-lock "worker-init-state")
   "Protects *INIT-STATE*.")

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -13,7 +13,7 @@
   (:import-from #:cl-mcp/src/system-loader-core #:load-system)
   (:import-from #:cl-mcp/src/repl-core #:repl-eval)
   (:import-from #:cl-mcp/src/utils/sanitize #:sanitize-error-message)
-  (:import-from #:cl-mcp/src/tools/helpers #:make-ht)
+  (:import-from #:cl-mcp/src/tools/helpers #:make-ht #:transient-error)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:export #:*asdf-load-lock*
            #:*asdf-load-lock-timeout*
@@ -68,12 +68,19 @@ really does have to be replaced."
                 "owner" (or owner-name "none")
                 "init_in_progress" (if init-in-progress "true" "false")))
     (if init-in-progress
-        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
+        ;; TRANSIENT-ERROR, so the response builders withhold their standing
+        ;; "replace the worker" advice.  Appending it here would undo the
+        ;; whole point of separating these two cases: the caller would be told
+        ;; to run pool-kill-worker and would abort a healthy load.
+        (error 'transient-error
+               :format-control
+               "Timed out after ~A seconds waiting for this worker's ASDF ~
                 load lock: the init hook is still loading and holds it. That ~
                 load has no deadline of its own, so a cold compile of a large ~
-                system can legitimately take longer. Wait for worker/init-status ~
-                to report ready, or retry with a larger timeout_seconds."
-               *asdf-load-lock-timeout*)
+                system can legitimately take longer. Wait for ~
+                worker/init-status to report ready, or retry with a larger ~
+                timeout_seconds."
+               :format-arguments (list *asdf-load-lock-timeout*))
         (error "Timed out after ~A seconds waiting for this worker's ASDF ~
                 load lock~@[, held by thread ~A~]. A previous run most likely ~
                 left a thread behind that never released it; this worker ~

--- a/src/worker/init-hook.lisp
+++ b/src/worker/init-hook.lisp
@@ -29,9 +29,46 @@ concurrent ASDF load-ops in one worker image, which the single-threaded
 dispatch loop does NOT prevent because load-system/repl-eval run their
 work on spawned helper threads.")
 
+(defparameter *asdf-load-lock-timeout* 240
+  "Seconds to wait for *ASDF-LOAD-LOCK* before giving up on it.
+
+The lock is normally held only for the duration of one load, so waiting this
+long already means something is wrong -- in practice, a run-tests deadline
+that could not stop its thread, leaving the load lock owned by a thread that
+will never release it.  Waiting forever there would hang this worker's single
+connection thread on every later load, with nothing to tell the user why.
+
+The value sits below the proxy's own budget on purpose: the proxy waits
+*PROXY-RPC-TIMEOUT* plus *PROXY-RPC-BUFFER*, and a timeout there kills the
+worker with a generic crash notice.  Giving up first means the caller gets
+this message, which names the cause and the fix, instead.")
+
 (defmacro with-asdf-load-lock (&body body)
-  "Evaluate BODY holding *ASDF-LOAD-LOCK*."
-  `(bt:with-lock-held (*asdf-load-lock*) ,@body))
+  "Evaluate BODY holding *ASDF-LOAD-LOCK*, waiting at most
+*ASDF-LOAD-LOCK-TIMEOUT* seconds to acquire it."
+  `(call-with-asdf-load-lock (lambda () ,@body)))
+
+(defun call-with-asdf-load-lock (thunk)
+  "Call THUNK holding *ASDF-LOAD-LOCK*, or signal if it cannot be acquired.
+Times out rather than blocking forever, so a lock left owned by a thread that
+outlived its deadline surfaces as one actionable error instead of hanging
+every later load in this worker."
+  (if (sb-thread:grab-mutex *asdf-load-lock*
+                            :timeout *asdf-load-lock-timeout*)
+      (unwind-protect (funcall thunk)
+        (sb-thread:release-mutex *asdf-load-lock*))
+      (let ((owner (sb-thread:mutex-owner *asdf-load-lock*)))
+        (ignore-errors
+         (log-event :error "worker.asdf-load-lock.timeout"
+                    "seconds" *asdf-load-lock-timeout*
+                    "owner" (if owner (sb-thread:thread-name owner) "none")))
+        (error "Timed out after ~A seconds waiting for this worker's ASDF ~
+                load lock~@[, held by thread ~A~]. A previous run most likely ~
+                left a thread behind that never released it; this worker ~
+                cannot load systems again. Use pool-kill-worker to get a ~
+                fresh worker."
+               *asdf-load-lock-timeout*
+               (and owner (sb-thread:thread-name owner))))))
 
 (defvar *init-lock* (bt:make-lock "worker-init-state")
   "Protects *INIT-STATE*.")

--- a/src/worker/main.lisp
+++ b/src/worker/main.lisp
@@ -223,9 +223,16 @@ Roswell REPL."
               ;; output-suppression helpers (%call-with-suppressed-output,
               ;; repl-eval) rebind them to capture streams, so logging inside
               ;; load-system/repl-eval is still returned in tool results.
+              ;; *TRACE-OUTPUT* is a synonym for the same descriptor, and it
+              ;; is where (TIME ...) and TRACE write -- evaluated code using
+              ;; either would otherwise hit the dead pipe exactly as log4cl
+              ;; did.  *STANDARD-INPUT* is the pipe's other half and has
+              ;; nothing left to read.
               (setf *debug-io* interactive
                     *terminal-io* interactive
-                    *query-io* interactive))
+                    *query-io* interactive
+                    *trace-output* devnull
+                    *standard-input* (make-concatenated-stream)))
             (%start-parent-watchdog)
             (start-accept-loop server))))
     (serious-condition (e)

--- a/src/worker/main.lisp
+++ b/src/worker/main.lisp
@@ -201,8 +201,16 @@ Roswell REPL."
                        "swank_port" (or swank-port "none")
                        "pid" (%get-pid))
             (%output-handshake tcp-port swank-port)
-            (let ((devnull (open #P"/dev/null" :direction :output
-                                               :if-exists :append)))
+            (let* ((devnull (open #P"/dev/null" :direction :output
+                                                :if-exists :append))
+                   ;; ANSI requires the three interactive streams below to be
+                   ;; bidirectional.  Pointing them at an output-only stream
+                   ;; turns any read -- a Y-OR-N-P reached from a system's
+                   ;; load-time code, a restart prompt -- into "not an input
+                   ;; stream"; over an empty input side it reads EOF instead,
+                   ;; which is what a non-interactive process should see.
+                   (interactive (make-two-way-stream
+                                 (make-concatenated-stream) devnull)))
               (setf *standard-output* devnull)
               ;; Also redirect *DEBUG-IO* and the other interactive streams.
               ;; log4cl's console appender writes to a synonym stream for
@@ -215,9 +223,9 @@ Roswell REPL."
               ;; output-suppression helpers (%call-with-suppressed-output,
               ;; repl-eval) rebind them to capture streams, so logging inside
               ;; load-system/repl-eval is still returned in tool results.
-              (setf *debug-io* devnull
-                    *terminal-io* devnull
-                    *query-io* devnull))
+              (setf *debug-io* interactive
+                    *terminal-io* interactive
+                    *query-io* interactive))
             (%start-parent-watchdog)
             (start-accept-loop server))))
     (serious-condition (e)

--- a/tests/core-test.lisp
+++ b/tests/core-test.lisp
@@ -53,18 +53,30 @@
         "through a synonym stream, which is what *standard-output* normally is")
     (ok (not (cl-mcp/src/run::%process-stdout-p (make-string-output-stream)))
         "a caller's own stream is not the process channel"))
-  (testing "all four globals are moved off the channel while the session runs"
+  (testing "every stream on that descriptor moves while the session runs"
+    ;; *TRACE-OUTPUT* matters as much as *STANDARD-OUTPUT* here: it is a
+    ;; synonym for the same descriptor by default, and it is where (TIME ...)
+    ;; and TRACE write.
     (let (inside)
       (cl-mcp/src/run::%call-with-stdout-isolated
        sb-sys:*stdout*
        (lambda ()
          (setf inside
                (list (cl-mcp/src/run::%process-stdout-p *standard-output*)
+                     (cl-mcp/src/run::%process-stdout-p *trace-output*)
                      (cl-mcp/src/run::%process-stdout-p *debug-io*)
                      (cl-mcp/src/run::%process-stdout-p *terminal-io*)
                      (cl-mcp/src/run::%process-stdout-p *query-io*)))))
-      (ok (equal '(nil nil nil nil) inside)
+      (ok (equal '(nil nil nil nil nil) inside)
           "nothing reachable from a spawned thread still points at fd 1")))
+  (testing "and standard input stops competing for the client's requests"
+    ;; A stray READ in evaluated code would otherwise consume the next
+    ;; JSON-RPC request line off the same pipe the server is reading.
+    (let (eof)
+      (cl-mcp/src/run::%call-with-stdout-isolated
+       sb-sys:*stdout*
+       (lambda () (setf eof (read-char *standard-input* nil :eof))))
+      (ok (eq :eof eof))))
   (testing "the replacements stay bidirectional, as ANSI requires"
     (let (readable)
       (cl-mcp/src/run::%call-with-stdout-isolated
@@ -74,11 +86,12 @@
   (testing "and are restored, so a later run does not inherit the sink as OUT"
     ;; Left in place, the sink becomes the next RUN's default OUT and every
     ;; JSON-RPC response is silently discarded.
-    (let ((before (list *standard-output* *debug-io* *terminal-io* *query-io*)))
+    (let ((before (list *standard-output* *trace-output* *standard-input*
+                        *debug-io* *terminal-io* *query-io*)))
       (cl-mcp/src/run::%call-with-stdout-isolated sb-sys:*stdout*
                                                   (lambda () nil))
-      (ok (equal before (list *standard-output* *debug-io*
-                              *terminal-io* *query-io*)))))
+      (ok (equal before (list *standard-output* *trace-output* *standard-input*
+                              *debug-io* *terminal-io* *query-io*)))))
   (testing "a caller's own OUT leaves the image alone"
     (let ((before *standard-output*))
       (cl-mcp/src/run::%call-with-stdout-isolated (make-string-output-stream)

--- a/tests/core-test.lisp
+++ b/tests/core-test.lisp
@@ -39,3 +39,48 @@
       (let ((s (get-output-stream-string out)))
         (ok (> (length s) 0))
         (ok (search "\"result\"" s))))))
+
+(deftest stdio-keeps-the-image-off-the-protocol-channel
+  ;; With the worker pool disabled every tool runs in the server process, and
+  ;; a thread a tool or test suite spawns sees only the GLOBAL value of a
+  ;; special -- so a stray (FORMAT T ...) there lands between JSON-RPC lines.
+  ;; RUN moves the global output streams off that descriptor for the duration
+  ;; of a stdio session.
+  (testing "a stream on the process's own stdout is recognized"
+    (ok (cl-mcp/src/run::%process-stdout-p sb-sys:*stdout*))
+    (ok (cl-mcp/src/run::%process-stdout-p
+         (make-synonym-stream 'sb-sys:*stdout*))
+        "through a synonym stream, which is what *standard-output* normally is")
+    (ok (not (cl-mcp/src/run::%process-stdout-p (make-string-output-stream)))
+        "a caller's own stream is not the process channel"))
+  (testing "all four globals are moved off the channel while the session runs"
+    (let (inside)
+      (cl-mcp/src/run::%call-with-stdout-isolated
+       sb-sys:*stdout*
+       (lambda ()
+         (setf inside
+               (list (cl-mcp/src/run::%process-stdout-p *standard-output*)
+                     (cl-mcp/src/run::%process-stdout-p *debug-io*)
+                     (cl-mcp/src/run::%process-stdout-p *terminal-io*)
+                     (cl-mcp/src/run::%process-stdout-p *query-io*)))))
+      (ok (equal '(nil nil nil nil) inside)
+          "nothing reachable from a spawned thread still points at fd 1")))
+  (testing "the replacements stay bidirectional, as ANSI requires"
+    (let (readable)
+      (cl-mcp/src/run::%call-with-stdout-isolated
+       sb-sys:*stdout*
+       (lambda () (setf readable (input-stream-p *query-io*))))
+      (ok readable)))
+  (testing "and are restored, so a later run does not inherit the sink as OUT"
+    ;; Left in place, the sink becomes the next RUN's default OUT and every
+    ;; JSON-RPC response is silently discarded.
+    (let ((before (list *standard-output* *debug-io* *terminal-io* *query-io*)))
+      (cl-mcp/src/run::%call-with-stdout-isolated sb-sys:*stdout*
+                                                  (lambda () nil))
+      (ok (equal before (list *standard-output* *debug-io*
+                              *terminal-io* *query-io*)))))
+  (testing "a caller's own OUT leaves the image alone"
+    (let ((before *standard-output*))
+      (cl-mcp/src/run::%call-with-stdout-isolated (make-string-output-stream)
+                                                  (lambda () nil))
+      (ok (eq before *standard-output*)))))

--- a/tests/core-test.lisp
+++ b/tests/core-test.lisp
@@ -52,7 +52,20 @@
          (make-synonym-stream 'sb-sys:*stdout*))
         "through a synonym stream, which is what *standard-output* normally is")
     (ok (not (cl-mcp/src/run::%process-stdout-p (make-string-output-stream)))
-        "a caller's own stream is not the process channel"))
+        "a caller's own stream is not the process channel")
+    ;; Every composite the standard defines, not just the two SBCL happens to
+    ;; use for *STANDARD-OUTPUT*: a broadcast stream reaches the descriptor if
+    ;; any component does, and missing that leaves the image writing to the
+    ;; protocol channel.
+    (ok (cl-mcp/src/run::%process-stdout-p
+         (make-broadcast-stream (make-string-output-stream) sb-sys:*stdout*))
+        "through a broadcast stream that includes it")
+    (ok (cl-mcp/src/run::%process-stdout-p
+         (make-echo-stream (make-concatenated-stream) sb-sys:*stdout*))
+        "through an echo stream")
+    (ok (not (cl-mcp/src/run::%process-stdout-p
+              (make-broadcast-stream (make-string-output-stream))))
+        "and a broadcast stream with no component on it is left alone"))
   (testing "every stream on that descriptor moves while the session runs"
     ;; *TRACE-OUTPUT* matters as much as *STANDARD-OUTPUT* here: it is a
     ;; synonym for the same descriptor by default, and it is where (TIME ...)

--- a/tests/proxy-test.lisp
+++ b/tests/proxy-test.lisp
@@ -84,3 +84,33 @@
     (ok (search "crashed" text))
     (ok (search "load-system again" text)
      "guidance about reloading is always present"))))
+
+(defun effective-timeout-for (&optional timeout-seconds)
+  "Run the proxy's RPC budget calculation for a call carrying TIMEOUT-SECONDS."
+  (let ((params (make-hash-table :test 'equal)))
+    (when timeout-seconds
+      (setf (gethash "timeout_seconds" params) timeout-seconds))
+    (cl-mcp/src/proxy::%effective-rpc-timeout params)))
+
+(deftest proxy-budget-outlasts-the-deadline-the-worker-enforces
+  (testing "with no timeout_seconds the proxy waits past the worker's default"
+    ;; The worker defaults run-tests to this same figure and only then builds
+    ;; its timeout result.  A proxy budget equal to that default expires
+    ;; first, and a proxy timeout is not a timeout report: WORKER-RPC marks
+    ;; the worker crashed and kills it, so the graceful answer never lands
+    ;; and the session's Lisp state is reset instead.
+    (ok (> (effective-timeout-for) cl-mcp/src/proxy:*proxy-rpc-timeout*)
+        "the silent-caller budget leaves room for the worker to answer"))
+  (testing "the caller's own deadline is honoured, plus the margin"
+    (ok (= (+ 60 cl-mcp/src/proxy::*proxy-rpc-buffer*)
+           (effective-timeout-for 60))))
+  (testing "a numeric string is not dropped back to the default"
+    ;; Params reach the proxy unvalidated on this path; a string that failed
+    ;; the old (NUMBERP ...) guard silently widened a 60 s deadline to 300 s.
+    (ok (= (effective-timeout-for 60) (effective-timeout-for "60"))))
+  (testing "a caller may ask for more than the default"
+    (ok (= (+ 3600 cl-mcp/src/proxy::*proxy-rpc-buffer*)
+           (effective-timeout-for 3600))))
+  (testing "an unusable value falls back to the default rather than erroring"
+    (ok (= (effective-timeout-for) (effective-timeout-for "not-a-number")))
+    (ok (= (effective-timeout-for) (effective-timeout-for -5)))))

--- a/tests/proxy-test.lisp
+++ b/tests/proxy-test.lisp
@@ -113,4 +113,23 @@
            (effective-timeout-for 3600))))
   (testing "an unusable value falls back to the default rather than erroring"
     (ok (= (effective-timeout-for) (effective-timeout-for "not-a-number")))
-    (ok (= (effective-timeout-for) (effective-timeout-for -5)))))
+    (ok (= (effective-timeout-for) (effective-timeout-for -5))))
+  (testing "an out-of-range request is clamped in the params too, not just here"
+    ;; Clamping only the proxy's own wait would invert the ordering this whole
+    ;; calculation exists to keep: the worker reads timeout_seconds to set its
+    ;; deadline, so it would enforce the larger figure while the proxy gave up
+    ;; first and killed it for still working.  1e20 is also what makes
+    ;; SB-EXT:WITH-TIMEOUT signal a TYPE-ERROR, since it takes a
+    ;; (SIGNED-BYTE 64).
+    (let ((params (make-hash-table :test 'equal))
+          (cap cl-mcp/src/proxy::+max-proxy-rpc-timeout+))
+      (setf (gethash "timeout_seconds" params) 1d20)
+      (cl-mcp/src/proxy::%clamp-timeout-param params)
+      (ok (= cap (gethash "timeout_seconds" params))
+          "the worker is told the clamped deadline")
+      (ok (= (+ cap cl-mcp/src/proxy::*proxy-rpc-buffer*)
+             (cl-mcp/src/proxy::%effective-rpc-timeout params))
+          "and the proxy still waits the margin beyond it")
+      (ok (typep (cl-mcp/src/proxy::%effective-rpc-timeout params)
+                 '(signed-byte 64))
+          "within the range SB-EXT:WITH-TIMEOUT accepts"))))

--- a/tests/repl-test.lisp
+++ b/tests/repl-test.lisp
@@ -768,3 +768,28 @@ Checks for control chars (0-31 except tab/newline/CR) and DEL (127)."
           "the condition report reaches the caller as text")
       (ok (search "layer-two-probe-boom" (or (getf (fifth result) :message) ""))
           "error-context carries the same message"))))
+
+(deftest repl-eval-keeps-the-interactive-streams-bidirectional
+  ;; The three interactive streams are redirected away from the worker's dead
+  ;; stdout pipe, but ANSI requires them to be bidirectional.  Bound to an
+  ;; output-only stream, any read reached from evaluated code -- a stray
+  ;; Y-OR-N-P, a restart prompt -- fails with "not an input stream" rather
+  ;; than seeing the empty input a non-interactive process should present.
+  (testing "*query-io* and its siblings accept input operations"
+    (multiple-value-bind (printed value)
+        (repl-eval "(list (input-stream-p *query-io*)
+                          (input-stream-p *terminal-io*)
+                          (input-stream-p *debug-io*))")
+      (declare (ignore printed))
+      (ok (equal '(t t t) value)
+          "all three are readable as well as writable")))
+  (testing "reading from them yields EOF rather than an error"
+    (multiple-value-bind (printed value)
+        (repl-eval "(read-char *query-io* nil :eof)")
+      (declare (ignore printed))
+      (ok (eq :eof value))))
+  (testing "and they still carry output into the captured stdout"
+    (multiple-value-bind (printed value stdout)
+        (repl-eval "(write-string \"via-query-io\" *query-io*)")
+      (declare (ignore printed value))
+      (ok (search "via-query-io" (or stdout ""))))))

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -27,6 +27,20 @@
     ;; and so silently fell back to the 300 s default.
     (ok (= 60 (coerce-timeout-seconds "60")))
     (ok (= 60 (coerce-timeout-seconds " 60 "))))
+  (testing "a decimal string is accepted"
+    (ok (= 1.5 (coerce-timeout-seconds "1.5")))
+    (ok (= 90 (coerce-timeout-seconds "+90"))))
+  (testing "text that only the reader would accept is rejected"
+    ;; These all pass a "digits, sign, dot and exponent" character filter,
+    ;; which is how the first implementation guarded READ-FROM-STRING.  The
+    ;; reader turns each of them into a SYMBOL and interns it in whichever
+    ;; package is current, so a client looping over such values could grow
+    ;; that package without bound in a long-lived parent process.
+    (dolist (bait '("e12" "1e2e" "--" "+" "..." "1.2.3" "1.5e2"))
+      (ok (null (coerce-timeout-seconds bait))
+          (format nil "~S is rejected" bait)))
+    (ok (null (find-symbol "E12" (find-package "CL-MCP/SRC/TEST-RUNNER-CORE")))
+        "and is rejected without being interned"))
   (testing "unusable values yield NIL so callers keep their own default"
     (ok (null (coerce-timeout-seconds nil)))
     (ok (null (coerce-timeout-seconds "abc")))
@@ -94,6 +108,50 @@
               (format nil "answered in ~,2Fs despite the run still blocking"
                       elapsed)))))))
 
+(deftest deadline-reports-a-thread-it-could-not-stop
+  (testing "a genuinely uninterruptible run is answered AND reported as leaked"
+    ;; SB-SYS:WITHOUT-INTERRUPTS defers both the cooperative unwind and
+    ;; DESTROY-THREAD, which is the case the polling wrapper exists for: a
+    ;; suite blocked where neither can reach it.  The test above does NOT
+    ;; reach this branch -- its HANDLER-CASE cannot swallow a throw, so that
+    ;; thread dies on the first interrupt and the leak path stays uncovered.
+    ;;
+    ;; A leaked thread is still executing in the worker and may hold
+    ;; *ASDF-LOAD-LOCK*, so the caller has to be told the difference between
+    ;; "the run was stopped" and "the run is still going".
+    (let ((start (get-internal-real-time)))
+      (multiple-value-bind (result status leaked)
+          (call-with-test-run-deadline
+           (lambda ()
+             (sb-sys:without-interrupts (sleep 4))
+             :finished)
+           1)
+        (let ((elapsed (/ (- (get-internal-real-time) start)
+                          internal-time-units-per-second)))
+          (ok (eq :timeout status))
+          (ok (eql 1 result))
+          (ok leaked "the surviving run thread is reported to the caller")
+          (ok (< elapsed 3.5)
+              (format nil "answered in ~,2Fs, well before the run let go"
+                      elapsed)))))))
+
+(deftest deadline-does-not-mistake-the-runs-own-timeout-for-its-own
+  (testing "an SB-EXT:TIMEOUT raised by the suite is an error, not a deadline breach"
+    ;; The deadline used to be enforced with SB-EXT:WITH-TIMEOUT, whose
+    ;; condition is exactly what a suite raises when it exercises timeout
+    ;; behaviour -- and this repo ships such suites (tests/timeout-test,
+    ;; tests/pool-test).  The two were indistinguishable, so a suite that let
+    ;; one escape a test was reported as "timed out after 300 seconds",
+    ;; failed:1, duration 300000 ms, with advice to kill the worker.  The
+    ;; deadline is now a throw to a tag private to the call, which no
+    ;; condition can impersonate.
+    (multiple-value-bind (result status)
+        (call-with-test-run-deadline
+         (lambda () (sb-ext:with-timeout 0.05 (sleep 5)))
+         30)
+      (ok (eq :error status) "the suite's own timeout surfaces as an error")
+      (ok (typep result 'sb-ext:timeout)))))
+
 (deftest deadline-reports-a-signalling-run-as-error
   (testing "a run that signals yields :ERROR and the condition"
     (multiple-value-bind (result status)
@@ -113,3 +171,19 @@
       (ok (equal "TIMEOUT"
                  (gethash "test_name"
                           (aref (gethash "failed_tests" ht) 0)))))))
+
+(deftest make-timeout-result-distinguishes-a-leaked-thread
+  (testing "a run that was stopped and one still running get different advice"
+    ;; The two cases need different actions from the user: a stopped run left
+    ;; the worker healthy and can simply be retried with a longer timeout,
+    ;; whereas a leaked thread is still executing and holding whatever locks
+    ;; it had, so the session does not recover until the worker is replaced.
+    (flet ((reason (ht)
+             (gethash "reason" (aref (gethash "failed_tests" ht) 0))))
+      (let ((stopped (reason (make-timeout-result 5)))
+            (leaked (reason (make-timeout-result 5 :thread-leaked t))))
+        (ok (search "was stopped" stopped))
+        (ok (null (search "pool-kill-worker" stopped))
+            "a healthy worker is not sent to pool-kill-worker")
+        (ok (search "still executing" leaked))
+        (ok (search "pool-kill-worker" leaked))))))

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -39,8 +39,21 @@
     (dolist (bait '("e12" "1e2e" "--" "+" "..." "1.2.3" "1.5e2"))
       (ok (null (coerce-timeout-seconds bait))
           (format nil "~S is rejected" bait)))
-    (ok (null (find-symbol "E12" (find-package "CL-MCP/SRC/TEST-RUNNER-CORE")))
-        "and is rejected without being interned"))
+    ;; READ-FROM-STRING interns into the *dynamic* value of *PACKAGE*, not
+    ;; into the package this file was compiled in, so the interning check has
+    ;; to watch whatever package is current during the call.  Watching the
+    ;; wrong one passes against the old implementation too and proves nothing.
+    (let ((probe (make-package (symbol-name (gensym "COERCE-PROBE"))
+                               :use nil)))
+      (unwind-protect
+           (let ((*package* probe)
+                 (interned 0))
+             (dolist (bait '("e12" "1e2e" "--" "+" "..." "1.2.3" "1.5e2"))
+               (coerce-timeout-seconds bait))
+             (do-symbols (sym probe) (declare (ignore sym)) (incf interned))
+             (ok (zerop interned)
+                 "and is rejected without interning anything"))
+        (delete-package probe))))
   (testing "unusable values yield NIL so callers keep their own default"
     (ok (null (coerce-timeout-seconds nil)))
     (ok (null (coerce-timeout-seconds "abc")))
@@ -80,28 +93,27 @@
               (format nil "answered in ~,2Fs, not after the 30s sleep"
                       elapsed)))))))
 
-(deftest deadline-answers-even-when-the-run-cannot-be-interrupted
-  (testing "a run busy in a condition handler still cannot hold the caller"
-    ;; Stands in for a suite that keeps working through anything raised at it
-    ;; -- a retry loop around a flaky operation, say.  Run inline, such a
-    ;; suite wedges the worker's single connection thread and every later
-    ;; tool call for the session with it; here the caller is answered at the
-    ;; deadline regardless.
+(deftest deadline-throw-cannot-be-swallowed-by-a-handler-case
+  (testing "a run that handles everything raised at it is still stopped"
+    ;; This is what the deadline being a THROW rather than a condition buys.
+    ;; A suite that keeps working through anything raised at it -- a retry
+    ;; loop around a flaky operation, say -- would swallow a signalled
+    ;; deadline and run on; run inline it wedges the worker's single
+    ;; connection thread and every later tool call for the session with it.
+    ;; A throw is not a condition and this HANDLER-CASE cannot see it, so the
+    ;; thread dies on the first interrupt.
     ;;
-    ;; Note this does NOT reach the leaked-thread branch: the deadline is a
-    ;; throw, which a HANDLER-CASE cannot swallow, so this thread dies on the
-    ;; first interrupt.  DEADLINE-REPORTS-A-THREAD-IT-COULD-NOT-STOP covers
-    ;; the genuinely uninterruptible case.
+    ;; Which is also why this test does NOT reach the leaked-thread branch:
+    ;; DEADLINE-REPORTS-A-THREAD-IT-COULD-NOT-STOP covers the genuinely
+    ;; uninterruptible case, where interrupts are deferred outright.
     (let ((start (get-internal-real-time)))
-      (multiple-value-bind (result status)
+      (multiple-value-bind (result status leaked)
           (call-with-test-run-deadline
            (lambda ()
              (let ((stop (+ (get-internal-real-time)
                             (* 60 internal-time-units-per-second))))
                (loop while (< (get-internal-real-time) stop)
                      do (handler-case (sleep 0.05)
-                          ;; Swallow the deadline unwind and keep going:
-                          ;; exactly the uninterruptible case.
                           (serious-condition () nil)))
                :finished))
            1)
@@ -109,6 +121,8 @@
                           internal-time-units-per-second)))
           (ok (eq :timeout status))
           (ok (eql 1 result))
+          (ok (not leaked)
+              "the throw stopped it, so no thread was left behind")
           (ok (< elapsed 10)
               (format nil "answered in ~,2Fs despite the run still blocking"
                       elapsed)))))))
@@ -128,7 +142,11 @@
       (multiple-value-bind (result status leaked)
           (call-with-test-run-deadline
            (lambda ()
-             (sb-sys:without-interrupts (sleep 4))
+             ;; Well past the ~2.5 s the deadline machinery needs, so a
+             ;; loaded machine cannot let the thunk finish before the
+             ;; assertions run -- LEAKED would then flip to NIL and the test
+             ;; would fail for a reason that is not the one it is about.
+             (sb-sys:without-interrupts (sleep 20))
              :finished)
            1)
         (let ((elapsed (/ (- (get-internal-real-time) start)

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -81,12 +81,17 @@
                       elapsed)))))))
 
 (deftest deadline-answers-even-when-the-run-cannot-be-interrupted
-  (testing "a run that swallows the interrupt still cannot hold the caller"
-    ;; Stands in for a suite blocked in something SB-EXT:WITH-TIMEOUT cannot
-    ;; unwind -- a server accept loop left behind by the tests, say.  Run
-    ;; inline, that wedges the worker's single connection thread and every
-    ;; later tool call for the session with it; here the caller is answered
-    ;; at the deadline regardless, and the blocked thread is torn down.
+  (testing "a run busy in a condition handler still cannot hold the caller"
+    ;; Stands in for a suite that keeps working through anything raised at it
+    ;; -- a retry loop around a flaky operation, say.  Run inline, such a
+    ;; suite wedges the worker's single connection thread and every later
+    ;; tool call for the session with it; here the caller is answered at the
+    ;; deadline regardless.
+    ;;
+    ;; Note this does NOT reach the leaked-thread branch: the deadline is a
+    ;; throw, which a HANDLER-CASE cannot swallow, so this thread dies on the
+    ;; first interrupt.  DEADLINE-REPORTS-A-THREAD-IT-COULD-NOT-STOP covers
+    ;; the genuinely uninterruptible case.
     (let ((start (get-internal-real-time)))
       (multiple-value-bind (result status)
           (call-with-test-run-deadline

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -152,6 +152,24 @@
       (ok (eq :error status) "the suite's own timeout surfaces as an error")
       (ok (typep result 'sb-ext:timeout)))))
 
+(deftest deadline-reports-a-vanished-thread-as-an-error
+  (testing "a run that exits its own thread is not blamed on the deadline"
+    ;; SB-THREAD:ABORT-THREAD leaves the thread without unwinding to the
+    ;; handler that records the outcome, so nothing is published and the
+    ;; thread is simply gone.  Calling that a timeout would name a deadline
+    ;; that never elapsed -- the run died in the first milliseconds of a
+    ;; thirty second budget -- and would report duration_ms 30000 for it.
+    (let ((start (get-internal-real-time)))
+      (multiple-value-bind (result status)
+          (call-with-test-run-deadline (lambda () (sb-thread:abort-thread)) 30)
+        (let ((elapsed (/ (- (get-internal-real-time) start)
+                          internal-time-units-per-second)))
+          (ok (eq :error status))
+          (ok (typep result 'condition))
+          (ok (search "without a result" (princ-to-string result)))
+          (ok (< elapsed 10)
+              (format nil "answered in ~,2Fs, not at the deadline" elapsed)))))))
+
 (deftest deadline-reports-a-signalling-run-as-error
   (testing "a run that signals yields :ERROR and the condition"
     (multiple-value-bind (result status)

--- a/tests/test-runner-deadline-test.lisp
+++ b/tests/test-runner-deadline-test.lisp
@@ -100,13 +100,15 @@
     ;; loop around a flaky operation, say -- would swallow a signalled
     ;; deadline and run on; run inline it wedges the worker's single
     ;; connection thread and every later tool call for the session with it.
-    ;; A throw is not a condition and this HANDLER-CASE cannot see it, so the
-    ;; thread dies on the first interrupt.
     ;;
-    ;; Which is also why this test does NOT reach the leaked-thread branch:
-    ;; DEADLINE-REPORTS-A-THREAD-IT-COULD-NOT-STOP covers the genuinely
-    ;; uninterruptible case, where interrupts are deferred outright.
-    (let ((start (get-internal-real-time)))
+    ;; The unwind grace is stretched so the assertion can tell which of the
+    ;; two shutdown stages did the work.  DESTROY-THREAD would also stop this
+    ;; sleep loop, and it runs after the grace -- so with the grace at five
+    ;; seconds, finishing in under three proves the cooperative throw is what
+    ;; ended it.  At the default half-second grace the two are only 0.5 s
+    ;; apart and the timing proves nothing.
+    (let ((cl-mcp/src/utils/deadline:*unwind-grace-seconds* 5.0d0)
+          (start (get-internal-real-time)))
       (multiple-value-bind (result status leaked)
           (call-with-test-run-deadline
            (lambda ()
@@ -121,10 +123,10 @@
                           internal-time-units-per-second)))
           (ok (eq :timeout status))
           (ok (eql 1 result))
-          (ok (not leaked)
-              "the throw stopped it, so no thread was left behind")
-          (ok (< elapsed 10)
-              (format nil "answered in ~,2Fs despite the run still blocking"
+          (ok (not leaked) "and nothing was left running")
+          (ok (< elapsed 3)
+              (format nil "stopped in ~,2Fs, inside the grace rather than by ~
+                           the destroy that follows it"
                       elapsed)))))))
 
 (deftest deadline-reports-a-thread-it-could-not-stop

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -1071,3 +1071,91 @@ RUN-TESTS-LOAD-LOCK-WRAPPER-COVERS-LOAD-PHASE-ONLY is running its thunk.")
                   (remove :fiveam-detail-probe (symbol-value var))))
           (ignore-errors (asdf:clear-system system))
           (ignore-errors (uiop:delete-directory-tree tmp-dir :validate t))))))
+
+(deftest fiveam-captures-output-from-a-suite-with-threads-and-sockets
+  ;; The FiveAM backend's stdout/stderr capture was removed on the grounds
+  ;; that binding the standard streams -- "even to a broadcast stream" --
+  ;; hangs suites that spawn real threads and sockets.  That mechanism cannot
+  ;; hold: in SBCL a new thread starts from the GLOBAL value of a special, so
+  ;; a binding made on the run thread is invisible to any thread the suite
+  ;; spawns and cannot be what blocked them.  This suite does both of the
+  ;; things named -- printing threads and a real accept loop -- so a
+  ;; regression to the reported behaviour fails here rather than silently
+  ;; costing every FiveAM user their stdout and stderr again.
+  (if (null (asdf:find-system "fiveam" nil))
+      (rove:skip "FiveAM is not installed; the FiveAM backend cannot run here")
+      (let* ((tmp-dir (uiop:ensure-directory-pathname
+                       (uiop:merge-pathnames*
+                        (format nil "cl-mcp-fiveam-threads-~A-~A/"
+                                (get-universal-time) (random 100000))
+                        (uiop:temporary-directory))))
+             (system "fiveam-thread-probe")
+             (asd-path (uiop:merge-pathnames*
+                        (format nil "~A.asd" system) tmp-dir)))
+        (asdf:load-system "fiveam")
+        (unwind-protect
+             (progn
+               (ensure-directories-exist tmp-dir)
+               (with-open-file (s asd-path :direction :output
+                                           :if-exists :supersede)
+                 (write-string
+                  "(asdf:defsystem \"fiveam-thread-probe\"
+  :depends-on (\"fiveam\" \"usocket\" \"bordeaux-threads\")
+  :components ((:file \"suite\")))
+"
+                  s))
+               (with-open-file (s (uiop:merge-pathnames* "suite.lisp" tmp-dir)
+                                  :direction :output :if-exists :supersede)
+                 (write-string
+                  "(defpackage #:fiveam-thread-probe-suite (:use #:cl #:fiveam))
+(in-package #:fiveam-thread-probe-suite)
+(def-suite :fiveam-thread-probe)
+(in-suite :fiveam-thread-probe)
+
+(test spawns-threads-that-print
+  (format t \"parent-line~%\")
+  (let ((threads (loop repeat 8
+                       collect (bordeaux-threads:make-thread
+                                (lambda ()
+                                  (dotimes (i 20)
+                                    (format t \"child-line ~A~%\" i)))))))
+    (dolist (th threads) (bordeaux-threads:join-thread th)))
+  (is (= 1 1)))
+
+(test opens-a-real-socket
+  (let* ((server (usocket:socket-listen \"127.0.0.1\" 0 :reuse-address t))
+         (port (usocket:get-local-port server)))
+    (unwind-protect
+         (let ((acceptor (bordeaux-threads:make-thread
+                          (lambda ()
+                            (let ((c (usocket:socket-accept server)))
+                              (format t \"accepted~%\")
+                              (usocket:socket-close c))))))
+           (usocket:socket-close (usocket:socket-connect \"127.0.0.1\" port))
+           (bordeaux-threads:join-thread acceptor))
+      (usocket:socket-close server))
+    (is (= 2 2))))
+"
+                  s))
+               (let ((asdf:*central-registry*
+                       (cons tmp-dir asdf:*central-registry*)))
+                 (asdf:load-asd asd-path)
+                 ;; Bound so a regression shows up as a failure here instead
+                 ;; of hanging the whole suite.
+                 (let ((result (sb-ext:with-timeout 120
+                                 (run-tests system))))
+                   (testing "the run completes rather than blocking"
+                     (ok (equal "fiveam" (gethash "framework" result))
+                         (format nil "framework=~A" (gethash "framework" result)))
+                     (ok (= 2 (gethash "passed" result)))
+                     (ok (= 0 (gethash "failed" result))))
+                   (testing "and its standard output is captured"
+                     (let ((stdout (gethash "stdout" result)))
+                       (ok (stringp stdout) "stdout is reported")
+                       (ok (search "parent-line" (or stdout ""))
+                           "output written by the test itself is captured"))))))
+          (let ((var (uiop:find-symbol* '#:*toplevel-suites* :fiveam)))
+            (setf (symbol-value var)
+                  (remove :fiveam-thread-probe (symbol-value var))))
+          (ignore-errors (asdf:clear-system system))
+          (ignore-errors (uiop:delete-directory-tree tmp-dir :validate t))))))

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -91,6 +91,44 @@
     (ok (eq :ran (with-asdf-load-lock :ran))
         "a thunk's own return value survives the timeout plumbing")))
 
+(deftest asdf-load-lock-busy-does-not-advise-killing-a-healthy-worker
+  (testing "a caller blocked behind a running init is not told to kill it"
+    ;; The init hook holds this lock for a whole cold compile with no deadline
+    ;; of its own, so a large application system legitimately outlasts the
+    ;; timeout.  Telling that caller to run pool-kill-worker would abort a
+    ;; load that was about to finish.  The signaller distinguishes the two
+    ;; cases, but the advice is appended afterwards by the response builder,
+    ;; so suppressing it there is what actually reaches the client.
+    (let* ((held (bt:make-semaphore))
+           (release (bt:make-semaphore))
+           (holder (bt:make-thread
+                    (lambda ()
+                      (with-asdf-load-lock
+                        (bt:signal-semaphore held)
+                        (bt:wait-on-semaphore release)))
+                    ;; The thread name is what tells a running init apart from
+                    ;; a thread that outlived its deadline.
+                    :name "mcp-worker-init")))
+      (unwind-protect
+           (progn
+             (bt:wait-on-semaphore held)
+             (let ((params (make-hash-table :test 'equal)))
+               (setf (gethash "system" params) "alexandria"
+                     (gethash "force" params) nil
+                     (gethash "timeout_seconds" params) 2)
+               (let* ((resp (cl-mcp/src/worker/handlers::%handle-load-system
+                             params))
+                      (text (gethash "text"
+                                     (aref (gethash "content" resp) 0))))
+                 (ok (search "init hook is still loading" text)
+                     "the message names the real cause")
+                 (ok (search "worker/init-status" text)
+                     "and says what to wait for")
+                 (ok (null (search "pool-kill-worker" text))
+                     "and does not tell the caller to destroy a healthy worker"))))
+        (bt:signal-semaphore release)
+        (bt:join-thread holder)))))
+
 (deftest init-state-transitions
   (testing "state starts idle, moves to loading/running/failed, snapshots as a hash-table"
     (cl-mcp/src/worker/init-hook::%reset-init-state)

--- a/tests/worker-init-hook-test.lisp
+++ b/tests/worker-init-hook-test.lisp
@@ -55,6 +55,42 @@
         (bt:join-thread th)
         (ok finished "handler completed after the lock was released")))))
 
+(deftest asdf-load-lock-times-out-with-actionable-advice
+  (testing "a lock nobody releases ends in one error, not an endless block"
+    ;; A run-tests deadline that cannot stop its thread can leave this lock
+    ;; owned by a thread that never releases it.  SBCL has no dead-owner
+    ;; detection, so waiting forever would hang every later load in this
+    ;; worker with nothing to say why -- and the proxy would eventually kill
+    ;; the worker with a generic crash notice instead.
+    (let* ((held (bt:make-semaphore))
+           (release (bt:make-semaphore))
+           (holder (bt:make-thread
+                    (lambda ()
+                      (with-asdf-load-lock
+                        (bt:signal-semaphore held)
+                        (bt:wait-on-semaphore release)))
+                    :name "lock-holder")))
+      (unwind-protect
+           (progn
+             (bt:wait-on-semaphore held)
+             (let ((cl-mcp/src/worker/init-hook:*asdf-load-lock-timeout* 0.3)
+                   (message nil)
+                   (start (get-internal-real-time)))
+               (handler-case (with-asdf-load-lock :never-reached)
+                 (error (e) (setf message (princ-to-string e))))
+               (let ((elapsed (/ (- (get-internal-real-time) start)
+                                 internal-time-units-per-second)))
+                 (ok message "the wait ends in an error rather than blocking")
+                 (ok (search "pool-kill-worker" (or message ""))
+                     "and the message names the recovery")
+                 (ok (< elapsed 5)
+                     (format nil "gave up in ~,2Fs" elapsed)))))
+        (bt:signal-semaphore release)
+        (bt:join-thread holder))))
+  (testing "the lock still works normally once released"
+    (ok (eq :ran (with-asdf-load-lock :ran))
+        "a thunk's own return value survives the timeout plumbing")))
+
 (deftest init-state-transitions
   (testing "state starts idle, moves to loading/running/failed, snapshots as a hash-table"
     (cl-mcp/src/worker/init-hook::%reset-init-state)


### PR DESCRIPTION
Follow-up to #143, from a review of that branch after it merged. #143 fixed a
real and painful bug — log4cl writing to the worker's dead stdout pipe — and
moved the `run-tests` deadline off the connection thread, which is the right
shape. This PR keeps both and fixes what review found around them.

The headline item is that #143's own feature did not reach the client: the
graceful timeout report it introduced was unreachable in the default case.

## What this fixes

### The proxy killed the worker before its timeout report could arrive

`%handle-run-tests` defaults to a 300 s deadline; `*proxy-rpc-timeout*` was
also exactly 300. The worker only *starts* building its timeout result at that
mark — after the unwind grace and the destroy check — so with `timeout_seconds`
omitted the proxy always gave up first. A proxy timeout is not a timeout
report: `worker-rpc` marks the worker crashed and kills it. Every long
`run-tests` therefore ended in a killed worker and "All Lisp state has been
reset" instead of `make-timeout-result`.

The budget is now one rule with no per-method knowledge: wait out whatever
deadline the worker will enforce, then a margin. The margin is back to 30 s
rather than 10 — it has to cover the unwind grace, `destroy-thread`'s grace,
building the response and serializing it, which for `repl-eval` is up to
`max_output_length` bytes.

`repl-eval` had no worker-side deadline at all, so an accidental `(loop)`
pinned the worker's connection thread until the proxy gave up and killed it —
the same outcome, on the most-used tool. It defaults to 300 s now, like
`run-tests`, and a caller can still ask for more.

### The deadline signal was indistinguishable from a suite's own

`sb-ext:with-timeout` signals `sb-ext:timeout` — the same condition a suite
raises when it exercises timeout behaviour, which this repo's own
`tests/timeout-test` and `tests/pool-test` do. A suite that let one escape was
reported as "timed out after 300 seconds", failed:1, with advice to kill the
worker. The deadline is now a `throw` to a tag private to the call, which no
condition can impersonate and no `handler-case` inside the run can swallow.

### A completed run could still be reported as a timeout

The old code committed to `:timeout` the moment it entered the destroy path and
never looked at the result again — contradicting its own docstring's promise
that completed work is never discarded. The outcome is now published under
`without-interrupts` and the interrupt closure re-reads it before throwing at
all, so a run that finishes as the deadline expires still returns its value.

### A leaked run thread was invisible, and could wedge the worker forever

A thread that survives both the unwind and `destroy-thread` keeps running, and
`run-tests` takes `*ASDF-LOAD-LOCK*` for its force-reload phase. SBCL has no
dead-owner detection, so every later load in that worker blocked with nothing
to say why.

The leak is reported to the caller now, and the two cases get different advice:
a stopped run leaves the worker healthy and can be retried with a larger
`timeout_seconds`, while a leaked one needs `pool-kill-worker`. The lock is
also taken from inside the load's own deadline thread, so the thread doing the
ASDF work is the thread holding the lock — a load that outlives its deadline
keeps the lock it is still using instead of releasing it while ASDF runs on.
And `with-asdf-load-lock` waits with a timeout, so a poisoned lock surfaces as
one message naming the cause and the fix rather than an invisible hang.

### Three copies of the same deadline dance

`run-tests`, `repl-eval` and `load-system` each had their own
spawn/poll/destroy sequence, already drifted: only one logged a leaked thread,
only one re-read its result, each named the outcome differently. Extracted as
`cl-mcp/src/utils/deadline:call-with-deadline-thread`; the fixes above land in
all three at once.

### FiveAM output capture, removed on a diagnosis that does not hold

#143 removed the FiveAM backend's stdout/stderr capture because binding the
standard streams "even to a broadcast stream" hangs suites that spawn real
threads and sockets. That mechanism cannot be it: in SBCL a new thread starts
from the **global** value of a special, so a binding made on the run thread is
invisible to any thread the suite spawns. The broken pipes that prompted the
change have a proven cause fixed in that same PR.

Measured rather than argued — a FiveAM suite with eight printing threads and a
real accept loop completes in hundredths of a second with the streams bound,
and ships here as a regression test. Its log shows the mechanism directly: the
suite's own output is captured while its spawned threads' output goes to the
process stdout, exactly as the special-variable rule predicts.

An alternative explanation for the original report — unbounded accumulation
before `*max-test-output-length*` is applied — survives that rebuttal and is
split out as #146.

### Nothing else in the image writes to the protocol channel

With the worker pool disabled every tool runs in the server process, and a
thread a tool or suite spawns sees only the global value of a special — so a
stray `(format t ...)` landed between JSON-RPC lines. The stdio server now
moves `*standard-output*`, `*trace-output*`, `*standard-input*` and the three
interactive streams off that descriptor for the duration of a session, and
restores them afterwards. Whether to do so is decided by walking the stream
graph to an fd, not by how `run` was called, so `:out *standard-output*` and a
broadcast stream that includes stdout are both recognized.

The worker gained the same treatment for `*trace-output*` and
`*standard-input*`: `(time ...)` and `trace` write to the former, which was
still pointed at the dead pipe.

### Smaller items

- `%handle-load-system` and `%handle-eval` coerce `timeout_seconds` like
  `%handle-run-tests` does. Params reach the worker unvalidated, so
  `(plusp "120")` was a raw `TYPE-ERROR` surfacing as "Internal error during
  load-system".
- `coerce-timeout-seconds` parses instead of reading. Its character filter
  could not make `read-from-string` safe: permissive enough for `"1.5e2"`, it
  also admitted `"e12"` and `"--"`, which the reader **interns** as symbols in
  the long-lived parent process. The reader also honours the global
  `*read-base*`, under which `"60"` is 96.
- `%effective-rpc-timeout` is clamped, and the clamp is written back into the
  params the worker reads. `sb-ext:with-timeout` takes a `(signed-byte 64)`, so
  `timeout_seconds: 1e20` produced a bignum, a `TYPE-ERROR` on the read, and a
  worker killed for a protocol error it did not commit.
- The redirected interactive streams are two-way, as ANSI requires. Pointed at
  output-only streams, any read reached from loaded or evaluated code failed
  with "not an input stream".
- `debug_output` is capped like the other two, on all three backends. It had
  become the FiveAM backend's only channel yet alone skipped
  `%truncate-test-output`, and `build-run-tests-response` embeds it verbatim in
  `content[].text`.

## Review

Six passes: four by Codex, three by independent agents given no context beyond
the diff. Later commits fix defects the earlier ones introduced — an
interrupt-unsafe `grab-mutex`, a lock released while its work was still
running, a stale `throw` that killed the worker under `--disable-debugger`, a
canned "kill the worker" hint that overrode the message written to avoid it,
and fd-1 detection that missed composite streams. Three tests were corrected
for claiming more than they exercised; one was withdrawn outright after it
turned out not to reproduce the case it was named for.

## Deliberately not changed

`coerce-timeout-seconds` accepting a numeric string does not take effect for
tool arguments, and this PR leaves that alone rather than widening
`define-tool`. `:type :number` rejects `"60"` before the tool body runs, with a
message naming the argument — a better answer than silently coercing. The
coercion stays where it is reachable and where a bad value is dangerous: the
worker handlers and the proxy read `timeout_seconds` straight out of the params
hash.

## Split out

- #145 — a leaked run thread is reported to one caller but never retired, and
  `pool-status` cannot see it.
- #146 — test output capture accumulates unbounded before
  `*max-test-output-length*` is applied; plus `*log-lock*` having no timeout.

## Testing

Full suite in a fresh process (`rove cl-mcp.asd`): 57 test systems, 4,520
assertions, no failures. Rove's final `Summary:` block reports only the last
package, not the aggregate; the two `×` lines in the log are the deliberately
red scaffold `project-scaffold-test` builds to check that `test-op` signals on
failure.

`(asdf:compile-system :cl-mcp :force :all)` is clean — the remaining warnings
are pre-existing. `mallet src/*.lisp src/*/*.lisp tests/*.lisp` reports no
problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEcTKuWZJKC1MbUp447Uoo
