### PR TITLE
Bound test output while it is written, not after

### DIFF
--- a/src/system-loader-core.lisp
+++ b/src/system-loader-core.lisp
@@ -200,8 +200,13 @@ DEFUN' lines are noise that drown real warnings."
                                (*compile-print* nil)
                                (*load-verbose* nil)
                                (*load-print* nil)
-                               (*standard-output* (make-string-output-stream))
-                               (*trace-output* (make-string-output-stream))
+                               ;; Discarded rather than collected: these two
+                               ;; are bound purely to suppress, and nothing
+                               ;; ever reads them back.  A string stream would
+                               ;; hold every character a noisy compile emits
+                               ;; for output no one will ever see.
+                               (*standard-output* (make-broadcast-stream))
+                               (*trace-output* (make-broadcast-stream))
                                (*error-output* stderr)
                                ;; log4cl's console appender writes to a synonym
                                ;; stream for *DEBUG-IO*, which in a worker
@@ -246,8 +251,8 @@ DEFUN' lines are noise that drown real warnings."
                              (*compile-print* nil)
                              (*load-verbose* nil)
                              (*load-print* nil)
-                             (*standard-output* (make-string-output-stream))
-                             (*trace-output* (make-string-output-stream))
+                             (*standard-output* (make-broadcast-stream))
+                             (*trace-output* (make-broadcast-stream))
                              (*error-output* stderr)
                              (*debug-io* interactive)
                              (*terminal-io* interactive)

--- a/src/test-runner-core.lisp
+++ b/src/test-runner-core.lisp
@@ -11,6 +11,9 @@
                 #:transient-error)
   (:import-from #:cl-mcp/src/utils/deadline
                 #:call-with-deadline-thread)
+  (:import-from #:cl-mcp/src/utils/bounded-stream
+                #:make-bounded-output-stream
+                #:bounded-output-string)
   (:export #:run-tests
            #:detect-test-framework
            #:make-load-failure-result
@@ -48,13 +51,17 @@ worker dispatches handlers on the calling thread.")
       (funcall *load-lock-wrapper* thunk)
       (funcall thunk)))
 
-(defun %truncate-test-output (string)
-  "Truncate STRING to *max-test-output-length* if it exceeds the limit."
-  (if (> (length string) *max-test-output-length*)
-      (format nil "~A~%... (truncated, ~D total chars)"
-              (subseq string 0 *max-test-output-length*)
-              (length string))
-      string))
+(defun %make-capture-stream ()
+  "Return a stream for capturing test output, bounded by
+*MAX-TEST-OUTPUT-LENGTH*.
+
+Bounded while writing rather than truncated afterwards: a STRING-OUTPUT-STREAM
+holds everything the suite produced, so the limit governed what was reported
+while the heap paid for the rest.  Measured, a suite emitting 40 million
+characters cost 367 MB to report 50 KB of it, and under a smaller dynamic
+space the run died with HEAP-EXHAUSTED-ERROR while materializing the string --
+in a fifth of a second, so the run deadline was no protection."
+  (make-bounded-output-stream *max-test-output-length*))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Framework Detection
@@ -901,9 +908,9 @@ without testing wrappers crash Rove's internals with NO-APPLICABLE-METHOD)."
          (_ (unless report-stream-sym
               (error "Rove internal symbol *REPORT-STREAM* not found; incompatible Rove version?")))
          (start-time (get-internal-real-time))
-         (stdout-stream (make-string-output-stream))
-         (stderr-stream (make-string-output-stream))
-         (debug-stream (make-string-output-stream))
+         (stdout-stream (%make-capture-stream))
+         (stderr-stream (%make-capture-stream))
+         (debug-stream (%make-capture-stream))
          successp
          results
          rove-error)
@@ -927,10 +934,9 @@ without testing wrappers crash Rove's internals with NO-APPLICABLE-METHOD)."
             (round
              (* 1000
                 (/ (- end-time start-time) internal-time-units-per-second))))
-           (stdout (%truncate-test-output (get-output-stream-string stdout-stream)))
-           (stderr (%truncate-test-output (get-output-stream-string stderr-stream)))
-           (debug-output
-            (%truncate-test-output (get-output-stream-string debug-stream))))
+           (stdout (bounded-output-string stdout-stream))
+           (stderr (bounded-output-string stderr-stream))
+           (debug-output (bounded-output-string debug-stream)))
       (if rove-error
           ;; Rove crashed (e.g., direct assertions without testing wrapper)
           (let ((ht (make-test-result
@@ -1012,9 +1018,9 @@ detects test sub-systems from ASDF dependencies and runs each individually."
               (error "Rove internal symbols not found (~A ~A); incompatible Rove version?"
                      report-stream-sym last-report-sym)))
          (start-time (get-internal-real-time))
-         (stdout-stream (make-string-output-stream))
-         (stderr-stream (make-string-output-stream))
-         (debug-stream (make-string-output-stream))
+         (stdout-stream (%make-capture-stream))
+         (stderr-stream (%make-capture-stream))
+         (debug-stream (%make-capture-stream))
          successp
          results
          rove-error)
@@ -1038,12 +1044,9 @@ detects test sub-systems from ASDF dependencies and runs each individually."
             (round
              (* 1000
                 (/ (- end-time start-time) internal-time-units-per-second))))
-           (stdout
-            (%truncate-test-output (get-output-stream-string stdout-stream)))
-           (stderr
-            (%truncate-test-output (get-output-stream-string stderr-stream)))
-           (debug-output
-            (%truncate-test-output (get-output-stream-string debug-stream))))
+           (stdout (bounded-output-string stdout-stream))
+           (stderr (bounded-output-string stderr-stream))
+           (debug-output (bounded-output-string debug-stream)))
       (if rove-error
           (let ((ht
                  (make-test-result :passed 0 :failed 1 :failed-tests
@@ -1177,9 +1180,9 @@ the surrounding passed/failed/pending/failure-details bindings."
 (defun run-asdf-fallback (system-name)
   "Run tests using asdf:test-system with text output capture."
   (log-event :info "test.runner" "framework" "asdf-fallback" "system" system-name)
-  (let ((output (make-string-output-stream))
-        (error-output (make-string-output-stream))
-        (debug-stream (make-string-output-stream))
+  (let ((output (%make-capture-stream))
+        (error-output (%make-capture-stream))
+        (debug-stream (%make-capture-stream))
         (start-time (get-internal-real-time))
         (success nil)
         (condition-message nil))
@@ -1196,8 +1199,8 @@ the surrounding passed/failed/pending/failure-details bindings."
     (let* ((end-time (get-internal-real-time))
            (duration-ms (round (* 1000 (/ (- end-time start-time)
                                           internal-time-units-per-second))))
-           (stdout (%truncate-test-output (get-output-stream-string output)))
-           (stderr (%truncate-test-output (get-output-stream-string error-output)))
+           (stdout (bounded-output-string output))
+           (stderr (bounded-output-string error-output))
            (failure-reason (or condition-message
                                (and (plusp (length stderr)) stderr)
                                "asdf:test-system failed"))
@@ -1217,8 +1220,7 @@ the surrounding passed/failed/pending/failure-details bindings."
         (setf (gethash "stdout" ht) stdout))
       (when (plusp (length stderr))
         (setf (gethash "stderr" ht) stderr))
-      (let ((debug-output
-              (%truncate-test-output (get-output-stream-string debug-stream))))
+      (let ((debug-output (bounded-output-string debug-stream)))
         (when (plusp (length debug-output))
           (setf (gethash "debug_output" ht) debug-output)))
       ht)))
@@ -1504,19 +1506,16 @@ spawns is not captured and reaches the process's own stdout: in SBCL a new
 thread starts from the GLOBAL value of a special, so these bindings are
 invisible to it.  The Rove backend has the same property."
   (let ((start-time (get-internal-real-time))
-        (stdout-stream (make-string-output-stream))
-        (stderr-stream (make-string-output-stream))
-        (debug-stream (make-string-output-stream))
+        (stdout-stream (%make-capture-stream))
+        (stderr-stream (%make-capture-stream))
+        (debug-stream (%make-capture-stream))
         all-results)
     (flet ((duration-ms ()
              (round (* 1000 (/ (- (get-internal-real-time) start-time)
                                internal-time-units-per-second))))
-           (stdout () (%truncate-test-output
-                       (get-output-stream-string stdout-stream)))
-           (stderr () (%truncate-test-output
-                       (get-output-stream-string stderr-stream)))
-           (debug-output () (%truncate-test-output
-                             (get-output-stream-string debug-stream))))
+           (stdout () (bounded-output-string stdout-stream))
+           (stderr () (bounded-output-string stderr-stream))
+           (debug-output () (bounded-output-string debug-stream)))
       (handler-case
           (dolist (spec specs)
             (let ((results

--- a/src/utils/bounded-stream.lisp
+++ b/src/utils/bounded-stream.lisp
@@ -1,0 +1,77 @@
+;;;; src/utils/bounded-stream.lisp
+;;;;
+;;;; A character output stream that stops retaining past a limit.
+;;;;
+;;;; Capturing a test suite's output into a STRING-OUTPUT-STREAM and truncating
+;;;; the result afterwards bounds what is *reported* but not what is *held*: a
+;;;; suite emitting 40 million characters costs 367 MB of heap to report 50 KB
+;;;; of it, and on a worker with a smaller dynamic space the run dies with
+;;;; HEAP-EXHAUSTED-ERROR while materializing the string.  A suite can reach
+;;;; that in a fraction of a second, so the run deadline does not help.
+
+(defpackage #:cl-mcp/src/utils/bounded-stream
+  (:use #:cl)
+  (:export #:bounded-output-stream
+           #:make-bounded-output-stream
+           #:bounded-output-string
+           #:bounded-output-dropped))
+
+(in-package #:cl-mcp/src/utils/bounded-stream)
+
+(defclass bounded-output-stream (sb-gray:fundamental-character-output-stream)
+  ((sink :initform (make-string-output-stream) :reader %sink)
+   (limit :initarg :limit :reader %limit)
+   (kept :initform 0 :accessor %kept)
+   (dropped :initform 0 :accessor %dropped))
+  (:documentation "A character sink that keeps at most LIMIT characters.
+
+Writes past the limit are counted and discarded rather than stored, so the
+memory a capture costs is bounded by the limit instead of by how much the
+writer produced.  Everything written is still accepted -- the writer never
+sees an error or a short write -- which matters because the writer here is
+arbitrary test code."))
+
+(defun make-bounded-output-stream (limit)
+  "Return a character output stream retaining at most LIMIT characters."
+  (make-instance 'bounded-output-stream :limit (max 0 limit)))
+
+(defmethod sb-gray:stream-write-char ((stream bounded-output-stream) character)
+  (if (< (%kept stream) (%limit stream))
+      (progn (write-char character (%sink stream))
+             (incf (%kept stream)))
+      (incf (%dropped stream)))
+  character)
+
+(defmethod sb-gray:stream-write-string ((stream bounded-output-stream) string
+                                        &optional (start 0) end)
+  (let* ((end (or end (length string)))
+         (length (max 0 (- end start)))
+         (room (max 0 (- (%limit stream) (%kept stream))))
+         (taken (min length room)))
+    (when (plusp taken)
+      (write-string string (%sink stream) :start start :end (+ start taken))
+      (incf (%kept stream) taken))
+    (incf (%dropped stream) (- length taken)))
+  string)
+
+(defmethod sb-gray:stream-line-column ((stream bounded-output-stream))
+  ;; Not tracked: the pretty printer only uses this as a hint, and tracking it
+  ;; would mean re-scanning every write for newlines.
+  nil)
+
+(defun bounded-output-dropped (stream)
+  "Number of characters STREAM discarded for exceeding its limit."
+  (%dropped stream))
+
+(defun bounded-output-string (stream)
+  "Return what STREAM retained, noting the total when anything was dropped.
+Drains the stream, as GET-OUTPUT-STREAM-STRING does, so calling it twice
+yields the retained text once."
+  (let ((kept (get-output-stream-string (%sink stream)))
+        (dropped (%dropped stream)))
+    (setf (%kept stream) 0
+          (%dropped stream) 0)
+    (if (plusp dropped)
+        (format nil "~A~%... (truncated, ~D total chars)"
+                kept (+ (length kept) dropped))
+        kept)))

--- a/src/utils/bounded-stream.lisp
+++ b/src/utils/bounded-stream.lisp
@@ -20,16 +20,30 @@
 
 (defclass bounded-output-stream (sb-gray:fundamental-character-output-stream)
   ((sink :initform (make-string-output-stream) :reader %sink)
-   (limit :initarg :limit :reader %limit)
+   (limit :initarg :limit :initform 0 :reader %limit)
    (kept :initform 0 :accessor %kept)
-   (dropped :initform 0 :accessor %dropped))
+   (dropped :initform 0 :accessor %dropped)
+   (column :initform 0 :accessor %column))
   (:documentation "A character sink that keeps at most LIMIT characters.
 
 Writes past the limit are counted and discarded rather than stored, so the
 memory a capture costs is bounded by the limit instead of by how much the
 writer produced.  Everything written is still accepted -- the writer never
 sees an error or a short write -- which matters because the writer here is
-arbitrary test code."))
+arbitrary test code.
+
+The column is tracked across every write, dropped ones included, because
+FRESH-LINE, ~T and the pretty printer all ask for it: a stream that answers
+NIL makes ~& emit a newline unconditionally, mis-tabulates ~T, and breaks
+pretty-printed lines at the wrong places, silently rewriting the output it
+was only supposed to be bounding.  Counting past the limit as well keeps
+those decisions matching what the writer would have seen.
+
+Not synchronized, and neither was the STRING-OUTPUT-STREAM it replaces:
+concurrent writers can overshoot the limit by roughly one write each, where
+the string stream instead lost characters outright.  Suites that spawn
+threads do not reach these bindings anyway -- in SBCL a new thread starts
+from a special's global value."))
 
 (defun make-bounded-output-stream (limit)
   "Return a character output stream retaining at most LIMIT characters."
@@ -40,6 +54,9 @@ arbitrary test code."))
       (progn (write-char character (%sink stream))
              (incf (%kept stream)))
       (incf (%dropped stream)))
+  (if (char= character #\Newline)
+      (setf (%column stream) 0)
+      (incf (%column stream)))
   character)
 
 (defmethod sb-gray:stream-write-string ((stream bounded-output-stream) string
@@ -51,13 +68,23 @@ arbitrary test code."))
     (when (plusp taken)
       (write-string string (%sink stream) :start start :end (+ start taken))
       (incf (%kept stream) taken))
-    (incf (%dropped stream) (- length taken)))
+    (incf (%dropped stream) (- length taken))
+    (when (plusp length)
+      (let ((last-newline (position #\Newline string :from-end t
+                                                     :start start :end end)))
+        (if last-newline
+            (setf (%column stream) (- end last-newline 1))
+            (incf (%column stream) length)))))
   string)
 
 (defmethod sb-gray:stream-line-column ((stream bounded-output-stream))
-  ;; Not tracked: the pretty printer only uses this as a hint, and tracking it
-  ;; would mean re-scanning every write for newlines.
-  nil)
+  ;; Answering NIL here is legal and nothing errors on it, but it is not
+  ;; faithful: SBCL's STREAM-START-LINE-P is (eql (stream-line-column s) 0),
+  ;; so ~& would emit a newline even at the start of a line, ~T would
+  ;; mis-tabulate, and the pretty printer would break lines as though every
+  ;; write began at column zero.  Capture would then quietly rewrite the
+  ;; output it exists to record.
+  (%column stream))
 
 (defun bounded-output-dropped (stream)
   "Number of characters STREAM discarded for exceeding its limit."
@@ -71,7 +98,12 @@ yields the retained text once."
         (dropped (%dropped stream)))
     (setf (%kept stream) 0
           (%dropped stream) 0)
-    (if (plusp dropped)
-        (format nil "~A~%... (truncated, ~D total chars)"
-                kept (+ (length kept) dropped))
-        kept)))
+    (cond
+      ((zerop dropped) kept)
+      ;; No separating newline when nothing was kept: the note would otherwise
+      ;; start with a blank line, which reads as retained output.
+      ((zerop (length kept))
+       (format nil "... (truncated, ~D total chars)" dropped))
+      (t
+       (format nil "~A~%... (truncated, ~D total chars)"
+               kept (+ (length kept) dropped))))))

--- a/src/utils/bounded-stream.lisp
+++ b/src/utils/bounded-stream.lisp
@@ -20,7 +20,12 @@
 
 (defclass bounded-output-stream (sb-gray:fundamental-character-output-stream)
   ((sink :initform (make-string-output-stream) :reader %sink)
-   (limit :initarg :limit :initform 0 :reader %limit)
+   ;; Required, and loudly: a default of 0 would make a stream constructed
+   ;; without one silently discard everything written to it, which for a class
+   ;; whose whole job is deciding what to throw away is the worst failure
+   ;; available.
+   (limit :initarg :limit :reader %limit
+          :initform (error "BOUNDED-OUTPUT-STREAM requires a :LIMIT."))
    (kept :initform 0 :accessor %kept)
    (dropped :initform 0 :accessor %dropped)
    (column :initform 0 :accessor %column))
@@ -93,7 +98,11 @@ from a special's global value."))
 (defun bounded-output-string (stream)
   "Return what STREAM retained, noting the total when anything was dropped.
 Drains the stream, as GET-OUTPUT-STREAM-STRING does, so calling it twice
-yields the retained text once."
+yields the retained text once.
+
+The column survives a drain, unlike the kept and dropped counts.  Reading the
+text out does not move the writer's cursor, so a writer left mid-line is still
+mid-line afterwards and FRESH-LINE must still say so."
   (let ((kept (get-output-stream-string (%sink stream)))
         (dropped (%dropped stream)))
     (setf (%kept stream) 0

--- a/tests.lisp
+++ b/tests.lisp
@@ -29,6 +29,7 @@
   (:import-from #:cl-mcp/tests/test-runner-deadline-test)
   (:import-from #:cl-mcp/tests/tools-helpers-test)
   (:import-from #:cl-mcp/tests/utils-paths-test)
+  (:import-from #:cl-mcp/tests/utils-bounded-stream-test)
   (:import-from #:cl-mcp/tests/validate-test)
   (:import-from #:cl-mcp/tests/tcp-test)
   (:import-from #:cl-mcp/tests/tools-test)

--- a/tests/clgrep-test.lisp
+++ b/tests/clgrep-test.lisp
@@ -79,10 +79,11 @@
             ;; The same search unfiltered.  Showing it spans several form
             ;; types is what makes the single-form-type result below evidence
             ;; that the filter ran, rather than an accident of what the
-            ;; pattern happened to hit.  A small explicit limit keeps it cheap
-            ;; -- the default 200 is more than enough to see several types,
-            ;; and asking for it made the "small directory" pointless.
-            (unfiltered (clgrep-search "." :path "src/utils/"
+            ;; pattern happened to hit.  Deliberately sampled from src/ rather
+            ;; than a directory this suite's own subject matter lives in: the
+            ;; evidence should not come from a file the change under test
+            ;; happens to add.
+            (unfiltered (clgrep-search "." :path "src/"
                                        :recursive nil
                                        :limit 50)))
         (ok (listp results))

--- a/tests/clgrep-test.lisp
+++ b/tests/clgrep-test.lisp
@@ -76,12 +76,15 @@
       (let ((results (clgrep-search "." :path "."
                                     :recursive t
                                     :form-types #("defmethod")))
-            ;; The same search unfiltered, over one small directory so it
-            ;; stays cheap.  Showing it spans several form types is what makes
-            ;; the single-form-type result below evidence that the filter ran,
-            ;; rather than an accident of what the pattern happened to hit.
+            ;; The same search unfiltered.  Showing it spans several form
+            ;; types is what makes the single-form-type result below evidence
+            ;; that the filter ran, rather than an accident of what the
+            ;; pattern happened to hit.  A small explicit limit keeps it cheap
+            ;; -- the default 200 is more than enough to see several types,
+            ;; and asking for it made the "small directory" pointless.
             (unfiltered (clgrep-search "." :path "src/utils/"
-                                       :recursive nil)))
+                                       :recursive nil
+                                       :limit 50)))
         (ok (listp results))
         (ok (> (length results) 0) "Should find at least one defmethod")
         (ok (> (length (remove-duplicates

--- a/tests/clgrep-test.lisp
+++ b/tests/clgrep-test.lisp
@@ -70,17 +70,26 @@
             (ok (string-equal form-type "defparameter")
                 (format nil "Expected defparameter but got ~A" form-type)))))))
   (testing "clgrep-search with vector form-types filters rare form types correctly"
-    ;; Test with defmethod which has only 2 occurrences in the project
-    ;; This would have returned thousands of results before the fix
+    ;; A pattern matching every line, filtered to a form type the project uses
+    ;; sparingly.  Before the fix this returned every line in the project.
     (let ((*project-root* (asdf:system-source-directory :cl-mcp)))
       (let ((results (clgrep-search "." :path "."
                                     :recursive t
-                                    :form-types #("defmethod"))))
+                                    :form-types #("defmethod")))
+            ;; The same search unfiltered, over one small directory so it
+            ;; stays cheap.  Showing it spans several form types is what makes
+            ;; the single-form-type result below evidence that the filter ran,
+            ;; rather than an accident of what the pattern happened to hit.
+            (unfiltered (clgrep-search "." :path "src/utils/"
+                                       :recursive nil)))
         (ok (listp results))
-        ;; Should find defmethod results (there are exactly 2 defmethod forms)
-        ;; Each form may have multiple line matches, but all should be defmethod
         (ok (> (length results) 0) "Should find at least one defmethod")
-        (ok (< (length results) 20) "Should not return excessive results")
+        (ok (> (length (remove-duplicates
+                        (mapcar (lambda (r) (cdr (assoc :form-type r)))
+                                unfiltered)
+                        :test #'equal))
+               1)
+            "unfiltered, the same pattern spans several form types")
         ;; All results must be defmethod
         (dolist (r results)
           (let ((form-type (cdr (assoc :form-type r))))

--- a/tests/test-runner-test-chatty.lisp
+++ b/tests/test-runner-test-chatty.lisp
@@ -1,0 +1,21 @@
+;;;; tests/test-runner-test-chatty.lisp --- Helper test that prints far more
+;;;; than *max-test-output-length*, so the capture path can be checked for
+;;;; bounding what it holds rather than only what it reports.
+
+(defpackage #:cl-mcp/tests/test-runner-test-chatty
+  (:use #:cl)
+  (:import-from #:rove
+                #:deftest #:testing #:ok))
+
+(in-package #:cl-mcp/tests/test-runner-test-chatty)
+
+(deftest chatty-capture-test
+  (testing "prints well past the reporting limit"
+    ;; 400 000 characters against a 50 000 character limit.  Small enough to
+    ;; stay quick, large enough that the difference between bounding on write
+    ;; and truncating afterwards is unambiguous in the reported total.
+    (let ((line (make-string 79 :initial-element #\x)))
+      (dotimes (i 5000)
+        (write-string line)
+        (terpri)))
+    (ok t)))

--- a/tests/test-runner-test.lisp
+++ b/tests/test-runner-test.lisp
@@ -172,6 +172,42 @@
          (ok (search "DEBUG-MARKER-12345" stdout)
           "stdout should contain the debug output from the test")))))))
 
+(deftest run-tests-bounds-what-a-chatty-suite-costs
+  (testing "a suite printing far past the limit is capped, and says so"
+    ;; The limit governs what is *held*, not only what is reported.  Captured
+    ;; into a STRING-OUTPUT-STREAM and truncated afterwards, a suite emitting
+    ;; 40 million characters cost 367 MB of heap to report 50 KB of it, and
+    ;; under a 256 MB dynamic space the run died with HEAP-EXHAUSTED-ERROR
+    ;; while materialising the string -- in a fifth of a second, so the run
+    ;; deadline was no protection either.
+    (let ((result (run-tests "cl-mcp/tests/test-runner-test-chatty")))
+      (ok (= 0 (gethash "failed" result)) "the helper test itself passes")
+      (let ((stdout (gethash "stdout" result)))
+        (cond
+          ;; Same nested-rove caveat as RUN-TESTS-CAPTURES-STDOUT above.
+          ((null stdout)
+           (rove:skip "stdout not captured (nested rove:run limitation)"))
+          (t
+           (ok (<= (length stdout)
+                   (+ cl-mcp/src/test-runner-core:*max-test-output-length*
+                      100))
+               (format nil "reported ~D chars for a limit of ~D"
+                       (length stdout)
+                       cl-mcp/src/test-runner-core:*max-test-output-length*))
+           ;; The note has to carry the true total, not the retained length:
+           ;; that number is the only evidence the caller gets about how much
+           ;; was dropped, and reporting the kept size would read as "nothing
+           ;; was lost".  The fixture emits 400 000 characters of its own.
+           (let ((marker (search "(truncated, " stdout)))
+             (ok marker "the note is present")
+             (let ((total (and marker
+                               (parse-integer stdout
+                                              :start (+ marker 12)
+                                              :junk-allowed t))))
+               (ok (and total (>= total 400000))
+                   (format nil "the note reports the real total (~A)"
+                           total))))))))))
+
 (deftest run-tests-selected-captures-stdout
  (testing "run-tests with :test captures stdout"
   (let ((result

--- a/tests/utils-bounded-stream-test.lisp
+++ b/tests/utils-bounded-stream-test.lisp
@@ -56,12 +56,65 @@
       (dotimes (i 100) (format s "line ~D~%" i))
       (ok (plusp (bounded-output-dropped s)))
       (ok (search "total chars" (bounded-output-string s)))))
-  (testing "the pretty printer can write to it"
-    ;; STREAM-LINE-COLUMN returns NIL, which the printer must tolerate.
-    (let ((s (make-bounded-output-stream 1000)))
-      (let ((*print-pretty* t))
-        (prin1 '(a (b (c (d (e (f (g (h (i (j)))))))))) s))
-      (ok (plusp (length (bounded-output-string s)))))))
+  (testing "column-sensitive output matches a string-output-stream exactly"
+    ;; Tolerating the stream is not enough -- it has to be faithful.
+    ;; FRESH-LINE, ~T and the pretty printer all consult STREAM-LINE-COLUMN,
+    ;; so a stream answering NIL silently rewrites what it captures: ~& emits
+    ;; a newline even at the start of a line, ~T mis-tabulates, and lines wrap
+    ;; as though every write began at column zero.  Comparing against the
+    ;; stream this replaced is the only assertion that catches that.
+    (flet ((render (make-stream)
+             (let ((s (funcall make-stream)))
+               (format s "first line~%")
+               (format s "~&already at column zero~%")
+               (write-string "mid-line" s)
+               (format s "~&after a partial line~%")
+               (format s "col:~10Tx~%")
+               (write-string "PREFIX: " s)
+               (let ((*print-pretty* t) (*print-right-margin* 20))
+                 (prin1 '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) s))
+               s)))
+      (let ((bounded (bounded-output-string
+                      (render (lambda () (make-bounded-output-stream 10000)))))
+            (reference (get-output-stream-string
+                        (render #'make-string-output-stream))))
+        (ok (equal reference bounded)
+            (format nil "bounded=~S reference=~S" bounded reference)))))
+  (testing "the column keeps tracking past the limit"
+    ;; Dropped writes still move the cursor the writer sees, so ~& has to make
+    ;; the same decision after the limit as before it.
+    (let ((s (make-bounded-output-stream 5)))
+      (write-string "0123456789" s)
+      (ok (= 10 (sb-gray:stream-line-column s)))
+      (write-char #\Newline s)
+      (ok (= 0 (sb-gray:stream-line-column s))))))
+
+(deftest bounded-stream-does-not-retain-what-it-drops
+  (testing "writing far past the limit costs a fraction of what keeping it would"
+    ;; The point of the stream, and the one property none of the assertions
+    ;; above would notice: truncating a STRING-OUTPUT-STREAM afterwards gives
+    ;; exactly the same reported text while the heap pays for everything the
+    ;; writer produced.  Calibrated against that stream rather than a fixed
+    ;; byte count, so the test says "bounded" rather than encoding one SBCL's
+    ;; allocation behaviour.
+    (let ((chunk (make-string 10000 :initial-element #\x))
+          (reps 200))
+      (flet ((consed (thunk)
+               (sb-ext:gc :full t)
+               (let ((before (sb-ext:get-bytes-consed)))
+                 (funcall thunk)
+                 (- (sb-ext:get-bytes-consed) before))))
+        (let ((retaining (consed (lambda ()
+                                   (let ((s (make-string-output-stream)))
+                                     (dotimes (i reps) (write-string chunk s))
+                                     (get-output-stream-string s)))))
+              (bounding (consed (lambda ()
+                                  (let ((s (make-bounded-output-stream 1000)))
+                                    (dotimes (i reps) (write-string chunk s))
+                                    (bounded-output-string s))))))
+          (ok (< bounding (floor retaining 10))
+              (format nil "~D bytes to bound ~D characters, against ~D to retain them"
+                      bounding (* reps (length chunk)) retaining)))))))
 
 (deftest bounded-stream-drains-like-a-string-output-stream
   (testing "reading it twice yields the retained text once"

--- a/tests/utils-bounded-stream-test.lisp
+++ b/tests/utils-bounded-stream-test.lisp
@@ -1,0 +1,79 @@
+;;;; tests/utils-bounded-stream-test.lisp
+;;;;
+;;;; The capture stream test output goes through.  Its job is to bound what a
+;;;; run *holds*, not only what it reports: truncating a STRING-OUTPUT-STREAM
+;;;; afterwards leaves the heap paying for everything the suite produced.
+
+(defpackage #:cl-mcp/tests/utils-bounded-stream-test
+  (:use #:cl)
+  (:import-from #:rove
+                #:deftest #:testing #:ok)
+  (:import-from #:cl-mcp/src/utils/bounded-stream
+                #:make-bounded-output-stream
+                #:bounded-output-string
+                #:bounded-output-dropped))
+
+(in-package #:cl-mcp/tests/utils-bounded-stream-test)
+
+(deftest bounded-stream-keeps-only-up-to-its-limit
+  (testing "output under the limit is returned unchanged and unannotated"
+    (let ((s (make-bounded-output-stream 100)))
+      (write-string "hello" s)
+      (let ((text (bounded-output-string s)))
+        (ok (equal "hello" text))
+        (ok (null (search "truncated" text))))))
+  (testing "output past the limit is kept up to it and counted after it"
+    (let ((s (make-bounded-output-stream 10)))
+      (write-string (make-string 1000 :initial-element #\x) s)
+      (ok (= 990 (bounded-output-dropped s)))
+      (let ((text (bounded-output-string s)))
+        (ok (equal (make-string 10 :initial-element #\x)
+                   (subseq text 0 10))
+            "the retained prefix is the first LIMIT characters")
+        (ok (search "1000 total chars" text)
+            "and the note reports the true total, not the retained length"))))
+  (testing "a zero limit retains nothing but still accepts writes"
+    (let ((s (make-bounded-output-stream 0)))
+      (write-string "dropped entirely" s)
+      (ok (= 16 (bounded-output-dropped s)))
+      (ok (search "16 total chars" (bounded-output-string s))))))
+
+(deftest bounded-stream-bounds-every-write-path
+  ;; WRITE-CHAR and WRITE-STRING reach different generic functions, and a
+  ;; suite's output arrives through both -- FORMAT picks per directive.
+  (testing "character-at-a-time writing is bounded"
+    (let ((s (make-bounded-output-stream 5)))
+      (dotimes (i 100) (write-char #\a s))
+      (ok (= 95 (bounded-output-dropped s)))
+      (ok (equal "aaaaa" (subseq (bounded-output-string s) 0 5)))))
+  (testing "a bounded substring write counts only the substring"
+    (let ((s (make-bounded-output-stream 3)))
+      (write-string "0123456789" s :start 2 :end 6)
+      (ok (= 1 (bounded-output-dropped s)) "four written, three kept")
+      (ok (equal "234" (subseq (bounded-output-string s) 0 3)))))
+  (testing "FORMAT output is bounded too"
+    (let ((s (make-bounded-output-stream 20)))
+      (dotimes (i 100) (format s "line ~D~%" i))
+      (ok (plusp (bounded-output-dropped s)))
+      (ok (search "total chars" (bounded-output-string s)))))
+  (testing "the pretty printer can write to it"
+    ;; STREAM-LINE-COLUMN returns NIL, which the printer must tolerate.
+    (let ((s (make-bounded-output-stream 1000)))
+      (let ((*print-pretty* t))
+        (prin1 '(a (b (c (d (e (f (g (h (i (j)))))))))) s))
+      (ok (plusp (length (bounded-output-string s)))))))
+
+(deftest bounded-stream-drains-like-a-string-output-stream
+  (testing "reading it twice yields the retained text once"
+    (let ((s (make-bounded-output-stream 100)))
+      (write-string "first" s)
+      (ok (equal "first" (bounded-output-string s)))
+      (ok (equal "" (bounded-output-string s)))))
+  (testing "the drop count resets with it, so a later note is not inflated"
+    (let ((s (make-bounded-output-stream 2)))
+      (write-string "aaaaaa" s)
+      (bounded-output-string s)
+      (write-string "bb" s)
+      (let ((text (bounded-output-string s)))
+        (ok (equal "bb" text))
+        (ok (null (search "truncated" text)))))))

--- a/tests/utils-bounded-stream-test.lisp
+++ b/tests/utils-bounded-stream-test.lisp
@@ -36,7 +36,13 @@
     (let ((s (make-bounded-output-stream 0)))
       (write-string "dropped entirely" s)
       (ok (= 16 (bounded-output-dropped s)))
-      (ok (search "16 total chars" (bounded-output-string s))))))
+      (let ((text (bounded-output-string s)))
+        (ok (search "16 total chars" text))
+        ;; The note separates itself from retained text with a newline; with
+        ;; nothing retained there is nothing to separate from, and a leading
+        ;; blank line would read as output that was kept.
+        (ok (not (eql #\Newline (char text 0)))
+            "no leading blank line when nothing was kept")))))
 
 (deftest bounded-stream-bounds-every-write-path
   ;; WRITE-CHAR and WRITE-STRING reach different generic functions, and a
@@ -80,14 +86,35 @@
                         (render #'make-string-output-stream))))
         (ok (equal reference bounded)
             (format nil "bounded=~S reference=~S" bounded reference)))))
-  (testing "the column keeps tracking past the limit"
+  (testing "the column keeps tracking once nothing more is being kept"
     ;; Dropped writes still move the cursor the writer sees, so ~& has to make
-    ;; the same decision after the limit as before it.
+    ;; the same decision after the limit as before it.  A write that straddles
+    ;; the limit does not test this -- it still takes the keeping path -- so
+    ;; the writes below go on until nothing at all is being kept.
     (let ((s (make-bounded-output-stream 5)))
       (write-string "0123456789" s)
-      (ok (= 10 (sb-gray:stream-line-column s)))
+      (ok (= 10 (sb-gray:stream-line-column s)) "a straddling write")
+      (write-string "abcde" s)
+      (ok (= 15 (sb-gray:stream-line-column s))
+          "a write with nothing left to keep still advances the column")
+      (write-char #\x s)
+      (ok (= 16 (sb-gray:stream-line-column s))
+          "and so does a character with nothing left to keep")
       (write-char #\Newline s)
-      (ok (= 0 (sb-gray:stream-line-column s))))))
+      (ok (= 0 (sb-gray:stream-line-column s)))))
+  (testing "a single write carrying several newlines lands on the last one"
+    ;; Rove prints several lines per WRITE-STRING, so the column after such a
+    ;; write is measured from the final newline, not the first.
+    (let ((s (make-bounded-output-stream 1000)))
+      (write-string "one
+two
+three!" s)
+      (ok (= 6 (sb-gray:stream-line-column s)))))
+  (testing "consecutive partial writes accumulate rather than replace"
+    (let ((s (make-bounded-output-stream 1000)))
+      (write-string "abc" s)
+      (write-string "de" s)
+      (ok (= 5 (sb-gray:stream-line-column s))))))
 
 (deftest bounded-stream-does-not-retain-what-it-drops
   (testing "writing far past the limit costs a fraction of what keeping it would"


### PR DESCRIPTION
Closes #146 for the three test backends.

`*max-test-output-length*` governed what a run **reported**, not what it
**held**. Output was collected into a `string-output-stream` and truncated
afterwards, so the heap paid for everything the suite produced no matter how
little of it was ever shown.

## Measured first

A FiveAM suite emitting 40 million characters — a few seconds of ordinary
chatter:

| dynamic space | before |
|---|---|
| 1024 MB | peak heap **367 MB**, 0.21 s, 50 KB reported |
| 256 MB | `Heap exhausted during allocation: 48594944 bytes available, 160000016 requested` |

The 160,000,016-byte request is the string being materialised. The run deadline
added in #144 is no protection here: the suite reached that in a fifth of a
second.

## After

| dynamic space | after |
|---|---|
| 1024 MB | peak heap **68 MB**, 0.05 s, 50 KB reported |
| 256 MB | peak heap **43 MB**, 0.06 s, 50 KB reported |
| 128 MB | peak heap **41 MB**, 0.05 s, 50 KB reported |

Reported output is unchanged, including its column-sensitive rendering: the
stream tracks the column, so `~&`, `~T` and the pretty printer break lines
exactly where they did.

Speed is a wash and workload-dependent, so treat the memory result as the
point. Large single writes get faster for not copying what they were going to
discard; `format`-driven line-at-a-time output is somewhat slower through
generic dispatch — measured at ~7 ms for a full 50 KB capture, which is
irrelevant beside the allocation it removes.

## What changed

A bounded character output stream (`src/utils/bounded-stream.lisp`, an
`sb-gray` class) replaces `make-string-output-stream` at all four capture
sites — the two Rove paths, the ASDF fallback, and FiveAM. Writes past the
limit are counted and discarded rather than stored, so a capture costs the
limit rather than whatever the suite felt like producing. Everything written is
still accepted: the writer is arbitrary test code and must never see an error
or a short write.

The truncation note keeps carrying the **true total** rather than the retained
length. It is the only signal the caller gets about how much was dropped, and
reporting the kept size would read as "nothing was lost".

## On the #143 hang

#143 removed FiveAM's output capture because binding the standard streams
hung suites that spawn threads and sockets. #144 disproved the stated
mechanism — in SBCL a new thread starts from the global value of a special, so
a binding made on the run thread is invisible to any thread the suite spawns —
but did not explain the observation.

Unbounded accumulation produces the same symptom by a different route, and
this PR shows it doing so. Whether it was the cause in #143 cannot be
established after the fact; it is no longer available as one.

## Split out

- #148 — `repl-eval` captures its output the same way and is more exposed: it
  evaluates arbitrary client-supplied forms, so `(loop (princ "x"))` reaches
  the same heap exhaustion in one request. Found by the second review.

## Not in scope

The load-diagnostic capture in `%ensure-system-loaded` has the same shape and
is left alone: it is bounded by `%tail-lines` for reporting, and a compile that
noisy is a different problem. The `*log-lock*` items noted in #146 are also
untouched, so that issue stays open for them.

## Review

Two independent passes, each given no context beyond the diff. The first found
that `stream-line-column` returning NIL silently rewrote captured output —
`~&` emitted a newline even at the start of a line, doubling every line of a
suite that uses it — and that no test would fail on `main`. The second
mutation-tested the fix and found the new column assertion could not fail
either: it wrote across the limit rather than past it, so reverting the
behaviour the commit added left the file green. Both are fixed, and the four
mutants the reviewer constructed are now caught, 2 to 8 failing assertions
each.

## Testing

Full suite in a fresh process (`rove cl-mcp.asd`): 58 test systems, 4,581
assertions, no failures. The two `×` lines in the log are the deliberately red
scaffold `project-scaffold-test` builds to check that `test-op` signals on
failure. `mallet` reports no problems; `(asdf:compile-system :cl-mcp :force
:all)` is clean apart from pre-existing warnings.

New coverage:

- unit tests for the stream: the limit is respected on both the `write-char`
  and `write-string` paths and through `format`, a bounded substring write
  counts only the substring, the pretty printer can write to it, reading drains
  it like a string stream, and the drop count resets with it
- a comparison against the `string-output-stream` this replaces, over the `~&`,
  `~T` and pretty-printing cases the column feeds — the only assertion that
  fails when the column is wrong
- an allocation measurement calibrated against that same stream: 2,000,000
  characters cost 0 bytes to bound against 18,160,336 to retain. The
  end-to-end reporting test passes on `main`, so this is the one that
  discriminates
- an end-to-end test that a chatty suite's reported output is capped **and**
  that the note reports the real total (400 000) rather than the retained
  length

The second commit is fallout: `clgrep-test` asserted a filtered search returned
"fewer than 20" results on the premise that the project contained exactly two
`defmethod` forms. This PR adds three. The count was a proxy for a regression
the test already catches exactly — every result is a `defmethod` — so it is
replaced by a comparison that does not encode today's contents of the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEcTKuWZJKC1MbUp447Uoo
