### PR TITLE
Bound repl-eval's captured output while it is written

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,7 +11,7 @@ Input schema (JSON):
 - `print_level` (integer|null): binds `*print-level*`
 - `print_length` (integer|null): binds `*print-length*`
 - `timeout_seconds` (number|null): abort evaluation after this many seconds
-- `max_output_length` (integer|null): keep at most this many characters of
+- `max_output_length` (optional integer, non-negative): keep at most this many characters of
   `content`/`stdout`/`stderr`. `stdout` and `stderr` are bounded as the form
   writes them, so output past the limit is never held in memory, and a short
   note saying how many characters there were in total is appended past that

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,7 +11,12 @@ Input schema (JSON):
 - `print_level` (integer|null): binds `*print-level*`
 - `print_length` (integer|null): binds `*print-length*`
 - `timeout_seconds` (number|null): abort evaluation after this many seconds
-- `max_output_length` (integer|null): truncate `content`/`stdout`/`stderr` to this many characters
+- `max_output_length` (integer|null): keep at most this many characters of
+  `content`/`stdout`/`stderr`. `stdout` and `stderr` are bounded as the form
+  writes them, so output past the limit is never held in memory, and a short
+  note saying how many characters there were in total is appended past that
+  limit. `0` suppresses the output. `content` is truncated after the fact and
+  marked `...(truncated)`.
 - `safe_read` (boolean|null): when `true`, disables `*read-eval*` while reading forms
 Output fields:
 - `content`: last value as text

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -83,8 +83,10 @@ a second.  The evaluation deadline is no protection at that speed.
 
 Zero is a limit, not a missing one: max_output_length is declared (integer 0)
 and asking for zero asks for the output to be suppressed, which the stream
-does exactly.  Only a value that is not a usable limit at all falls back to
-the default."
+does exactly.  That is the case this guard exists for -- REPL-EVAL's declaimed
+ftype already rejects everything else that is not NIL, so in practice only NIL
+reaches the fallback.  The rest of the test is defence for a caller reaching
+this helper directly."
   (make-bounded-output-stream (if (and (integerp max-output-length)
                                        (not (minusp max-output-length)))
                                   max-output-length

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -8,6 +8,9 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/utils/deadline
                 #:call-with-deadline-thread)
+  (:import-from #:cl-mcp/src/utils/bounded-stream
+                #:make-bounded-output-stream
+                #:bounded-output-string)
   (:import-from #:cl-mcp/src/frame-inspector #:capture-error-context)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-for-json)
@@ -65,6 +68,33 @@ on large outputs)."
                    (%sanitize-control-chars (subseq string 0 max-output-length))
                    "...(truncated)")
       (%sanitize-control-chars string)))
+
+(defun %make-capture-stream (max-output-length)
+  "Return a stream for capturing evaluated code's output, bounded by
+MAX-OUTPUT-LENGTH.
+
+Bounded while writing rather than truncated afterwards.  A
+STRING-OUTPUT-STREAM holds everything the form produced, so the limit governed
+what was reported while the heap paid for the rest -- and the form here is
+whatever the client sent.  Measured, `(dotimes (i 500000) (write-string ...))'
+cost 313 MB of heap to report 50 KB of it, and under a 256 MB dynamic space it
+died with HEAP-EXHAUSTED-ERROR while materialising the string, in a quarter of
+a second.  The evaluation deadline is no protection at that speed."
+  (make-bounded-output-stream (if (and max-output-length
+                                       (integerp max-output-length)
+                                       (plusp max-output-length))
+                                  max-output-length
+                                  *default-max-output-length*)))
+
+(defun %captured-output (stream)
+  "Drain STREAM's bounded capture and sanitize it for JSON.
+
+The bounding already happened on the way in, so only the sanitizing half of
+%TRUNCATE-OUTPUT is left to do here.  The note the stream appends differs from
+that function's \"...(truncated)\": the stream counted what it discarded and
+says how much, which is worth more to a caller than knowing only that
+something was lost."
+  (%sanitize-control-chars (bounded-output-string stream)))
 
 (define-condition %package-not-found-error (package-error)
   ()
@@ -189,8 +219,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
   (let ((last-value nil)
         (error-context nil)
         (eval-package nil)
-        (stdout (make-string-output-stream))
-        (stderr (make-string-output-stream)))
+        (stdout (%make-capture-stream max-output-length))
+        (stderr (%make-capture-stream max-output-length)))
     (handler-bind ((warning (lambda (w)
                               (format stderr "~&Warning: ~A~%" w)
                               (when (find-restart 'muffle-warning)
@@ -201,8 +231,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
                              (msg (%truncate-output raw-msg max-output-length)))
                         (return-from %do-repl-eval
                           (values msg msg
-                                  (%truncate-output (get-output-stream-string stdout) max-output-length)
-                                  (%truncate-output (get-output-stream-string stderr) max-output-length)
+                                  (%captured-output stdout)
+                                  (%captured-output stderr)
                                   (list :condition-type (princ-to-string (type-of e))
                                         :message msg
                                         :restarts nil
@@ -213,8 +243,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
                              (msg (%truncate-output raw-msg max-output-length)))
                         (return-from %do-repl-eval
                           (values msg msg
-                                  (%truncate-output (get-output-stream-string stdout) max-output-length)
-                                  (%truncate-output (get-output-stream-string stderr) max-output-length)
+                                  (%captured-output stdout)
+                                  (%captured-output stderr)
                                   (list :condition-type (princ-to-string (type-of e))
                                         :message msg
                                         :restarts nil
@@ -239,8 +269,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
                             (return-from %do-repl-eval
                               (values (%truncate-output last-value max-output-length)
                                       last-value
-                                      (%truncate-output (get-output-stream-string stdout) max-output-length)
-                                      (%truncate-output (get-output-stream-string stderr) max-output-length)
+                                      (%captured-output stdout)
+                                      (%captured-output stderr)
                                       error-context)))))
       (let ((pkg (%resolve-eval-package package)))
         (setf eval-package pkg)
@@ -254,8 +284,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
                          (let ((msg "Reader error: unexpected end of file -- check for unbalanced parentheses"))
                            (return-from %do-repl-eval
                              (values msg msg
-                                     (%truncate-output (get-output-stream-string stdout) max-output-length)
-                                     (%truncate-output (get-output-stream-string stderr) max-output-length)
+                                     (%captured-output stdout)
+                                     (%captured-output stderr)
                                      (list :condition-type "END-OF-FILE"
                                            :message msg
                                            :restarts nil
@@ -281,8 +311,8 @@ ERROR-CONTEXT is a plist with structured error info when an error occurs, NIL ot
           (*print-circle* t))
       (values (%truncate-output (%safe-prin1-to-string last-value) max-output-length)
               last-value
-              (%truncate-output (get-output-stream-string stdout) max-output-length)
-              (%truncate-output (get-output-stream-string stderr) max-output-length)
+              (%captured-output stdout)
+              (%captured-output stderr)
               nil))))
 
 (defun %thunk-error-result (condition)

--- a/src/repl-core.lisp
+++ b/src/repl-core.lisp
@@ -79,10 +79,14 @@ what was reported while the heap paid for the rest -- and the form here is
 whatever the client sent.  Measured, `(dotimes (i 500000) (write-string ...))'
 cost 313 MB of heap to report 50 KB of it, and under a 256 MB dynamic space it
 died with HEAP-EXHAUSTED-ERROR while materialising the string, in a quarter of
-a second.  The evaluation deadline is no protection at that speed."
-  (make-bounded-output-stream (if (and max-output-length
-                                       (integerp max-output-length)
-                                       (plusp max-output-length))
+a second.  The evaluation deadline is no protection at that speed.
+
+Zero is a limit, not a missing one: max_output_length is declared (integer 0)
+and asking for zero asks for the output to be suppressed, which the stream
+does exactly.  Only a value that is not a usable limit at all falls back to
+the default."
+  (make-bounded-output-stream (if (and (integerp max-output-length)
+                                       (not (minusp max-output-length)))
                                   max-output-length
                                   *default-max-output-length*)))
 
@@ -90,11 +94,17 @@ a second.  The evaluation deadline is no protection at that speed."
   "Drain STREAM's bounded capture and sanitize it for JSON.
 
 The bounding already happened on the way in, so only the sanitizing half of
-%TRUNCATE-OUTPUT is left to do here.  The note the stream appends differs from
-that function's \"...(truncated)\": the stream counted what it discarded and
-says how much, which is worth more to a caller than knowing only that
-something was lost."
-  (%sanitize-control-chars (bounded-output-string stream)))
+%TRUNCATE-OUTPUT is left to do here.  Sanitizing runs on the retained text
+alone, before the stream appends its note: capture cut mid-escape-sequence
+ends in an introducer whose terminator was dropped, and SANITIZE-FOR-JSON then
+consumes everything after it -- which, applied to the composed string, is the
+note saying output went missing.  The client would be handed silently
+shortened output with nothing to say so.
+
+The note the stream appends differs from %TRUNCATE-OUTPUT's \"...(truncated)\":
+the stream counted what it discarded and says how much, which is worth more to
+a caller than knowing only that something was lost."
+  (bounded-output-string stream :transform #'%sanitize-control-chars))
 
 (define-condition %package-not-found-error (package-error)
   ()

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -68,7 +68,7 @@ read in the original package. Use separate repl-eval calls or specify the
   (timeout-seconds :type :number :json-name "timeout_seconds" :description
    "Seconds to wait before timing out evaluation")
   (max-output-length :type :integer :json-name "max_output_length" :description
-   "Maximum characters for printed result/stdout/stderr")
+   "Maximum characters for printed result/stdout/stderr; non-negative, and 0 suppresses output")
   (safe-read :type :boolean :json-name "safe_read" :description
    "When true, disables #. reader evaluation for safety")
   (include-result-preview :type :boolean :json-name "include_result_preview"
@@ -116,6 +116,16 @@ read in the original package. Use separate repl-eval calls or specify the
      (error 'arg-validation-error
             :arg-name "timeout_seconds"
             :message "timeout_seconds must be a positive number"))
+   ;; Likewise: the worker rejects a negative max_output_length with a message
+   ;; naming the argument, while the inline path would hand it to repl-eval
+   ;; and get a raw TYPE-ERROR off its declaimed ftype instead.  The JSON
+   ;; schema can only say "integer", so the range has to be checked here.
+   (when (and max-output-length
+              (not (and (integerp max-output-length)
+                        (not (minusp max-output-length)))))
+     (error 'arg-validation-error
+            :arg-name "max_output_length"
+            :message "max_output_length must be a non-negative integer"))
    (multiple-value-bind (printed raw-value stdout stderr error-context)
        (repl-eval code :package (or package *package*) :print-level print-level
         :print-length print-length

--- a/src/utils/bounded-stream.lisp
+++ b/src/utils/bounded-stream.lisp
@@ -44,6 +44,12 @@ pretty-printed lines at the wrong places, silently rewriting the output it
 was only supposed to be bounding.  Counting past the limit as well keeps
 those decisions matching what the writer would have seen.
 
+One inherited limitation: CL:STREAM-EXTERNAL-FORMAT signals on this stream
+where a STRING-OUTPUT-STREAM answers NIL.  SBCL implements that as an ordinary
+function rather than a generic, so no method can be added for it, and every
+Gray stream in SBCL behaves this way.  Evaluated code asking its own
+*STANDARD-OUTPUT* that question gets an error naming this class.
+
 Not synchronized, and neither was the STRING-OUTPUT-STREAM it replaces:
 concurrent writers can overshoot the limit by roughly one write each, where
 the string stream instead lost characters outright.  Suites that spawn
@@ -106,23 +112,27 @@ captured text -- sanitizing escape sequences out of it, say -- would otherwise
 have the rewriting swallow its own note: retained text cut mid-sequence ends
 in an introducer whose terminator was dropped, and a sanitizer then consumes
 everything after it, including the note saying that output went missing.  The
-reported total is taken from the text as captured, so a transform that changes
-the length cannot understate it.
+reported total is taken from the text as captured, so a transform that empties
+or shortens it cannot understate what there was.
+
+The counters are reset before TRANSFORM runs.  It is arbitrary caller code at
+that point, and a transform that signals would otherwise leave the stream
+drained but still counting its old total against the limit.
 
 The column survives a drain, unlike the kept and dropped counts.  Reading the
 text out does not move the writer's cursor, so a writer left mid-line is still
 mid-line afterwards and FRESH-LINE must still say so."
   (let* ((raw (get-output-stream-string (%sink stream)))
          (dropped (%dropped stream))
-         (total (+ (length raw) dropped))
-         (kept (funcall transform raw)))
+         (total (+ (length raw) dropped)))
     (setf (%kept stream) 0
           (%dropped stream) 0)
-    (cond
-      ((zerop dropped) kept)
-      ;; No separating newline when nothing was kept: the note would otherwise
-      ;; start with a blank line, which reads as retained output.
-      ((zerop (length kept))
-       (format nil "... (truncated, ~D total chars)" total))
-      (t
-       (format nil "~A~%... (truncated, ~D total chars)" kept total)))))
+    (let ((kept (funcall transform raw)))
+      (cond
+        ((zerop dropped) kept)
+        ;; No separating newline when nothing was kept: the note would
+        ;; otherwise start with a blank line, which reads as retained output.
+        ((zerop (length kept))
+         (format nil "... (truncated, ~D total chars)" total))
+        (t
+         (format nil "~A~%... (truncated, ~D total chars)" kept total))))))

--- a/src/utils/bounded-stream.lisp
+++ b/src/utils/bounded-stream.lisp
@@ -95,16 +95,27 @@ from a special's global value."))
   "Number of characters STREAM discarded for exceeding its limit."
   (%dropped stream))
 
-(defun bounded-output-string (stream)
+(defun bounded-output-string (stream &key (transform #'identity))
   "Return what STREAM retained, noting the total when anything was dropped.
 Drains the stream, as GET-OUTPUT-STREAM-STRING does, so calling it twice
 yields the retained text once.
 
+TRANSFORM is applied to the retained text before the note is appended, and
+exists because the note must not be exposed to it.  A caller that rewrites the
+captured text -- sanitizing escape sequences out of it, say -- would otherwise
+have the rewriting swallow its own note: retained text cut mid-sequence ends
+in an introducer whose terminator was dropped, and a sanitizer then consumes
+everything after it, including the note saying that output went missing.  The
+reported total is taken from the text as captured, so a transform that changes
+the length cannot understate it.
+
 The column survives a drain, unlike the kept and dropped counts.  Reading the
 text out does not move the writer's cursor, so a writer left mid-line is still
 mid-line afterwards and FRESH-LINE must still say so."
-  (let ((kept (get-output-stream-string (%sink stream)))
-        (dropped (%dropped stream)))
+  (let* ((raw (get-output-stream-string (%sink stream)))
+         (dropped (%dropped stream))
+         (total (+ (length raw) dropped))
+         (kept (funcall transform raw)))
     (setf (%kept stream) 0
           (%dropped stream) 0)
     (cond
@@ -112,7 +123,6 @@ mid-line afterwards and FRESH-LINE must still say so."
       ;; No separating newline when nothing was kept: the note would otherwise
       ;; start with a blank line, which reads as retained output.
       ((zerop (length kept))
-       (format nil "... (truncated, ~D total chars)" dropped))
+       (format nil "... (truncated, ~D total chars)" total))
       (t
-       (format nil "~A~%... (truncated, ~D total chars)"
-               kept (+ (length kept) dropped))))))
+       (format nil "~A~%... (truncated, ~D total chars)" kept total)))))

--- a/src/worker/handlers.lisp
+++ b/src/worker/handlers.lisp
@@ -99,6 +99,14 @@ result_preview, and error_context."
       (error "code is required"))
     (when (and raw-timeout (null timeout-seconds))
       (error "timeout_seconds must be a positive number"))
+    ;; Checked for the same reason timeout_seconds is: params arrive
+    ;; unvalidated here, and REPL-EVAL's declaimed ftype would turn a bad one
+    ;; into a raw TYPE-ERROR naming an internal type, rather than a message
+    ;; naming the argument the client got wrong.
+    (when (and max-output-length
+               (not (and (integerp max-output-length)
+                         (not (minusp max-output-length)))))
+      (error "max_output_length must be a non-negative integer"))
     (multiple-value-bind (printed raw-value stdout stderr error-context)
         (repl-eval code
                    :package (or package *package*)

--- a/tests/repl-test.lisp
+++ b/tests/repl-test.lisp
@@ -793,3 +793,52 @@ Checks for control chars (0-31 except tab/newline/CR) and DEL (127)."
         (repl-eval "(write-string \"via-query-io\" *query-io*)")
       (declare (ignore printed value))
       (ok (search "via-query-io" (or stdout ""))))))
+
+(deftest repl-eval-does-not-retain-output-it-will-not-report
+  ;; max_output_length governs what is reported; it has to govern what is held
+  ;; too.  Captured into a STRING-OUTPUT-STREAM and truncated afterwards, a
+  ;; form printing 40 million characters cost 313 MB of heap to report 50 KB,
+  ;; and under a 256 MB dynamic space it died with HEAP-EXHAUSTED-ERROR in a
+  ;; quarter of a second -- so the evaluation deadline was no protection.
+  ;; repl-eval runs whatever the client sends, which makes this one request
+  ;; rather than a suite someone had to write first.
+  (testing "a form printing far past the limit is capped, and says how far"
+    (multiple-value-bind (printed value stdout stderr)
+        (repl-eval "(dotimes (i 100000) (write-string \"0123456789\"))"
+                   :max-output-length 1000)
+      (declare (ignore printed value stderr))
+      (ok (<= (length stdout) 1100)
+          (format nil "reported ~D chars for a limit of 1000" (length stdout)))
+      (let ((marker (search "(truncated, " stdout)))
+        (ok marker "the note is present")
+        ;; The true total, not the retained length: that number is the only
+        ;; signal the caller gets about how much was lost.
+        (let ((total (and marker (parse-integer stdout :start (+ marker 12)
+                                                       :junk-allowed t))))
+          (ok (and total (>= total 1000000))
+              (format nil "the note reports the real total (~A)" total))))))
+  (testing "and holds a fraction of what retaining it would cost"
+    ;; The assertion above passes on a stream that keeps everything and
+    ;; truncates at the end -- it is a guard on reporting shape.  This one is
+    ;; the memory property, calibrated against the stream this replaced rather
+    ;; than a fixed byte count.
+    (flet ((consed (thunk)
+             (sb-ext:gc :full t)
+             (let ((before (sb-ext:get-bytes-consed)))
+               (funcall thunk)
+               (- (sb-ext:get-bytes-consed) before))))
+      (let ((bounding (consed
+                       (lambda ()
+                         (repl-eval "(dotimes (i 100000) (write-string \"0123456789\"))"
+                                    :max-output-length 1000))))
+            (retaining (consed
+                        (lambda ()
+                          (let ((s (make-string-output-stream)))
+                            (dotimes (i 100000) (write-string "0123456789" s))
+                            (get-output-stream-string s))))))
+        ;; A clear margin rather than a bare <: the bounded run still conses
+        ;; for reading and evaluating the form, so the assertion has to say
+        ;; "a fraction of", not merely "less than".
+        (ok (< bounding (floor retaining 4))
+            (format nil "~D bytes to bound 1 000 000 characters, against ~D to retain them"
+                    bounding retaining))))))

--- a/tests/repl-test.lisp
+++ b/tests/repl-test.lisp
@@ -807,15 +807,19 @@ Checks for control chars (0-31 except tab/newline/CR) and DEL (127)."
         (repl-eval "(dotimes (i 100000) (write-string \"0123456789\"))"
                    :max-output-length 1000)
       (declare (ignore printed value stderr))
-      (ok (<= (length stdout) 1100)
+      ;; Room for the note and nothing more.  A looser bound lets a stream
+      ;; that quietly keeps extra characters past the limit pass.
+      (ok (<= (length stdout) 1040)
           (format nil "reported ~D chars for a limit of 1000" (length stdout)))
       (let ((marker (search "(truncated, " stdout)))
         (ok marker "the note is present")
         ;; The true total, not the retained length: that number is the only
-        ;; signal the caller gets about how much was lost.
+        ;; signal the caller gets about how much was lost.  Exact rather than
+        ;; a lower bound -- the form writes exactly a million characters, and
+        ;; >= would accept an overstated count as readily as the right one.
         (let ((total (and marker (parse-integer stdout :start (+ marker 12)
                                                        :junk-allowed t))))
-          (ok (and total (>= total 1000000))
+          (ok (eql 1000000 total)
               (format nil "the note reports the real total (~A)" total))))))
   (testing "and holds a fraction of what retaining it would cost"
     ;; The assertion above passes on a stream that keeps everything and

--- a/tests/repl-test.lisp
+++ b/tests/repl-test.lisp
@@ -871,8 +871,11 @@ Checks for control chars (0-31 except tab/newline/CR) and DEL (127)."
       (let ((marker (search "(truncated, " stdout)))
         (ok marker
             (format nil "the note survives sanitizing: ~S" stdout))
-        (ok (= 1005 (and marker (parse-integer stdout :start (+ marker 12)
-                                                      :junk-allowed t)))
+        ;; EQL against the parse, not =: when the note is gone MARKER is NIL
+        ;; and = would fail with a type error rather than for the reason the
+        ;; assertion names.
+        (ok (eql 1005 (and marker (parse-integer stdout :start (+ marker 12)
+                                                        :junk-allowed t)))
             "and still reports the true total")
         (ok (notany (lambda (c) (< (char-code c) 32))
                     (remove #\Newline stdout))

--- a/tests/repl-test.lisp
+++ b/tests/repl-test.lisp
@@ -842,3 +842,38 @@ Checks for control chars (0-31 except tab/newline/CR) and DEL (127)."
         (ok (< bounding (floor retaining 4))
             (format nil "~D bytes to bound 1 000 000 characters, against ~D to retain them"
                     bounding retaining))))))
+
+(deftest repl-eval-capture-limit-edges
+  (testing "a zero limit suppresses the output rather than falling back"
+    ;; max_output_length is declared (integer 0), and zero asks for the output
+    ;; to be suppressed.  Treating it as "no limit given" hands back up to the
+    ;; 50 000 character default instead -- the opposite of what was asked.
+    (multiple-value-bind (printed value stdout stderr)
+        (repl-eval "(write-string \"secret\")" :max-output-length 0)
+      (declare (ignore printed value stderr))
+      (ok (null (search "secret" stdout))
+          (format nil "nothing of the output survives: ~S" stdout))
+      (ok (search "truncated" stdout)
+          "and the caller is told output was suppressed")))
+  (testing "an escape sequence cut by the limit cannot eat the note"
+    ;; Capture that stops mid-sequence leaves an introducer whose terminator
+    ;; was dropped.  Sanitizing the composed string then consumes everything
+    ;; after it -- including the note -- and the caller gets shortened output
+    ;; with nothing saying so.  Sanitizing has to run on the retained text
+    ;; alone, before the note is attached.
+    (multiple-value-bind (printed value stdout stderr)
+        (repl-eval "(progn (write-string \"abc\")
+                           (write-char (code-char 27))
+                           (write-string \"]\")
+                           (dotimes (i 100) (write-string \"xxxxxxxxxx\")))"
+                   :max-output-length 5)
+      (declare (ignore printed value stderr))
+      (let ((marker (search "(truncated, " stdout)))
+        (ok marker
+            (format nil "the note survives sanitizing: ~S" stdout))
+        (ok (= 1005 (and marker (parse-integer stdout :start (+ marker 12)
+                                                      :junk-allowed t)))
+            "and still reports the true total")
+        (ok (notany (lambda (c) (< (char-code c) 32))
+                    (remove #\Newline stdout))
+            "while the escape itself is still stripped")))))

--- a/tests/utils-bounded-stream-test.lisp
+++ b/tests/utils-bounded-stream-test.lisp
@@ -173,7 +173,10 @@ three!" s)
                    s :transform (lambda (raw) (subseq raw 0 2)))))
         (ok (search "truncated" text)
             (format nil "the note survived the transform: ~S" text))
-        (ok (string= "ab" (subseq text 0 2))
+        ;; The whole retained part, not its first two characters: a stream
+        ;; that ignored the transform would keep "abc" here and still start
+        ;; with "ab", so checking a prefix proves nothing about the transform.
+        (ok (string= "ab" (subseq text 0 (position #\Newline text)))
             "and the transform still applied to the retained text"))))
   (testing "the total counts what was captured, not what the transform left"
     ;; A transform that shortens the text must not shrink the reported total:

--- a/tests/utils-bounded-stream-test.lisp
+++ b/tests/utils-bounded-stream-test.lisp
@@ -157,3 +157,60 @@ three!" s)
       (let ((text (bounded-output-string s)))
         (ok (equal "bb" text))
         (ok (null (search "truncated" text)))))))
+
+(deftest bounded-stream-transform-cannot-consume-its-own-note
+  ;; TRANSFORM exists so a caller that rewrites the captured text cannot have
+  ;; the rewriting swallow the note that says output went missing.  repl-eval
+  ;; passes SANITIZE-FOR-JSON, and capture cut mid-escape-sequence leaves an
+  ;; introducer whose terminator was dropped -- a sanitizer applied to the
+  ;; composed string then eats everything after it, note included.
+  (testing "the note is composed after the transform, not passed through it"
+    (let ((s (make-bounded-output-stream 3)))
+      (write-string "abcdefghij" s)
+      ;; Stands in for a sanitizer that consumes a trailing introducer and
+      ;; whatever follows it.
+      (let ((text (bounded-output-string
+                   s :transform (lambda (raw) (subseq raw 0 2)))))
+        (ok (search "truncated" text)
+            (format nil "the note survived the transform: ~S" text))
+        (ok (string= "ab" (subseq text 0 2))
+            "and the transform still applied to the retained text"))))
+  (testing "the total counts what was captured, not what the transform left"
+    ;; A transform that shortens the text must not shrink the reported total:
+    ;; that number is the caller's only measure of how much was lost.
+    (let ((s (make-bounded-output-stream 5)))
+      (write-string (make-string 100 :initial-element #\x) s)
+      (let* ((text (bounded-output-string
+                    s :transform (lambda (raw) (declare (ignore raw)) "Z")))
+             (marker (search "(truncated, " text))
+             (total (and marker (parse-integer text :start (+ marker 12)
+                                                    :junk-allowed t))))
+        (ok (eql 100 total)
+            (format nil "reported ~A, captured 100" total)))))
+  (testing "and still counts it when the transform empties the text entirely"
+    ;; Reachable from repl-eval: everything retained was an escape sequence,
+    ;; so sanitizing leaves nothing.  Counting only the dropped characters
+    ;; here understates the total by exactly what was retained.
+    (let ((s (make-bounded-output-stream 5)))
+      (write-string (make-string 100 :initial-element #\x) s)
+      (let* ((text (bounded-output-string
+                    s :transform (lambda (raw) (declare (ignore raw)) "")))
+             (marker (search "(truncated, " text))
+             (total (and marker (parse-integer text :start (+ marker 12)
+                                                    :junk-allowed t))))
+        (ok (eql 100 total)
+            (format nil "reported ~A, captured 100" total))
+        (ok (not (eql #\Newline (char text 0)))
+            "with no leading blank line where the text would have been"))))
+  (testing "the counters are reset before the transform runs"
+    ;; TRANSFORM is arbitrary caller code.  One that signals must not leave the
+    ;; stream drained but still counting its old total against the limit.
+    (let ((s (make-bounded-output-stream 5)))
+      (write-string "abcdefghij" s)
+      (ignore-errors
+       (bounded-output-string s :transform (lambda (raw)
+                                             (declare (ignore raw))
+                                             (error "transform failed"))))
+      (write-string "xy" s)
+      (ok (equal "xy" (bounded-output-string s))
+          "the stream still accepts and retains after a failed transform"))))


### PR DESCRIPTION
Closes #148.

`max_output_length` governed what `repl-eval` **reported**, not what it
**held**. Output went into a `string-output-stream` and was truncated at each
of the five exit points, so the heap paid for everything the form produced no
matter how little was ever shown — and the form here is whatever the client
sent.

## Measured first

`(dotimes (i 500000) (write-string <79 chars>) (terpri))` — 40 million
characters, the same volume #147 measured on the test backends:

| dynamic space | before | after |
|---|---|---|
| 1024 MB | peak heap **+313 MB**, 0.23 s | **+1.3 MB**, 0.10 s |
| 256 MB | `Heap exhausted during allocation: 59604992 bytes available, 160000016 requested` | **+1.3 MB** |
| 128 MB | — | **+1.6 MB** |

Reported output is 50 KB either way. A quarter of a second to get there, so
the evaluation deadline is no protection — and this is one request, not a
suite someone had to write and load first, which is why this site matters more
than the three #147 converted.

## What changed

The two capture streams become the bounded stream added in #147.
`%truncate-output` stays for the printed value and the error messages, which
are built as strings rather than streamed; only its sanitizing half is left to
do for the captures.

**One observable change:** the note on `stdout`/`stderr` becomes the stream's
`(truncated, N total chars)` instead of `...(truncated)`, so the caller learns
how much went missing rather than only that something did. The printed value
keeps the old marker and the tests pinning it are untouched.

## On the tests

Checked against the unfixed source rather than assumed to discriminate. With
`src/repl-core.lisp` reverted to `main` the new assertions fail — and the
reporting-shape one passes there (1014 characters for a limit of 1000), which
is exactly why it cannot be the assertion that carries the property. The
allocation measurement is, and it is calibrated against the stream this
replaces rather than a fixed byte count:

| | bounded | retaining |
|---|---|---|
| 1 000 000 characters | 524 KB | 11.7 MB |
| same test, source reverted | 12.4 MB | 11.7 MB |

## Testing

Full suite in a fresh process (`rove cl-mcp.asd`): 58 test systems, 4,585
assertions, no failures. The two `×` lines in the log are the deliberately red
scaffold `project-scaffold-test` builds to check that `test-op` signals on
failure. `mallet` reports no problems; `(asdf:compile-system :cl-mcp :force
:all)` is clean apart from pre-existing warnings.

## Not in scope

The printed **result value** is also bounded by `%truncate-output`, but it is
built by `prin1-to-string` rather than streamed, so a bounded stream does not
apply — printing a huge structure still materialises it first. That needs
`*print-length*`/`*print-level*` instead, and is worth its own issue if it
turns out to matter in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEcTKuWZJKC1MbUp447Uoo
