### PR TITLE
Retire a worker rather than serve a request while it carries a leaked thread

### DIFF
--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -356,6 +356,33 @@ counts those separately, against initialization rather than the session."
   (and (not (worker-retired-p worker))
        (not (%init-attributable-crash-p worker))))
 
+(defun %record-worker-death (worker exit-status exit-code)
+  "Record what killed WORKER and return whether it was a deliberate retirement.
+
+Must be called under *POOL-LOCK*, in the same critical section that moves the
+worker to :CRASHED.  GET-OR-ASSIGN-WORKER takes that lock before asking the
+breaker about a crashed worker, so publishing the state first would let a
+request arriving in between count an unclassified retirement -- three of those
+halt the session, which is the failure this whole exclusion exists to prevent.
+
+The exit code is recorded before it is consulted because on this path -- the
+health monitor reaching a dead worker before any RPC has seen the EOF --
+nothing has classified the death and the code the worker left is the only
+witness there is.  The answer is stored rather than left to be re-derived,
+because the reason below is copied onto the replacement worker and a question
+asked of that copy is answered about the wrong death.
+
+A retirement keeps its marker rather than being flattened into
+\"process-died\": the notification the user is shown reads this slot too."
+  (setf (worker-last-exit-status worker) (or exit-status "unknown")
+        (worker-last-exit-code worker) (or exit-code "unknown"))
+  (let ((retired (or (worker-retired-p worker)
+                     (exit-code-says-retired-p worker))))
+    (setf (worker-retired-p worker) retired
+          (worker-last-crash-reason worker)
+          (if retired *retired-leaked-thread-reason* "process-died"))
+    retired))
+
 (defun %monitor-init (worker session-id max-failures)
   "Poll worker/init-status until terminal, updating failure/disable state.
 Runs on a short-lived background thread with backoff (0.1s -> 2s cap; no
@@ -713,59 +740,56 @@ to prevent recovery threads from spawning orphan workers."
         (was-bound nil)
         (was-standby nil)
         (was-already-crashed nil)
-        (retired-p nil))
+        (retired-p nil)
+        (exit-code nil)
+        (exit-status nil))
+    ;; Read before the lock and recorded inside it: SB-EXT:PROCESS-STATUS is
+    ;; only a struct read, but *POOL-LOCK* is the lock every session's next
+    ;; request goes through, and there is nothing here it needs to see.
+    (ignore-errors
+      (let* ((proc (worker-process-info crashed-worker))
+             (status (and proc (sb-ext:process-status proc))))
+        (when status
+          (setf exit-status (string-downcase (symbol-name status))))
+        (when (member status '(:exited :signaled))
+          (setf exit-code (sb-ext:process-exit-code proc)))))
     (bordeaux-threads:with-lock-held (*pool-lock*)
       (case (worker-state crashed-worker)
         (:bound
          (setf was-bound t
                session-id (worker-session-id crashed-worker))
+         ;; Recorded before the state says there was a death, and under the
+         ;; same lock: GET-OR-ASSIGN-WORKER asks the breaker about any
+         ;; :CRASHED worker it finds, and between the two writes a
+         ;; retirement is indistinguishable from a crash.
+         (setf retired-p (%record-worker-death crashed-worker
+                                               exit-status exit-code))
          (setf (worker-state crashed-worker) :crashed))
         (:standby
          (setf was-standby t)
          (setf *standby-workers* (remove crashed-worker *standby-workers*))
+         (setf retired-p (%record-worker-death crashed-worker
+                                               exit-status exit-code))
          (setf (worker-state crashed-worker) :crashed))
         (:crashed
-         ;; Already marked crashed (e.g. by worker-rpc EOF detection).
-         ;; Clean up pool tracking and trigger replenishment.
+         ;; Already marked crashed (e.g. by worker-rpc EOF detection), so the
+         ;; classification is already published; this adds the exit details
+         ;; the RPC path could not see and keeps whatever it concluded.
          (setf was-already-crashed t
                session-id (worker-session-id crashed-worker))
+         (setf retired-p (%record-worker-death crashed-worker
+                                               exit-status exit-code))
          (when (eql (gethash session-id *affinity-map*) crashed-worker)
            (remhash session-id *affinity-map*)
            (setf was-bound t))
          (setf *all-workers* (remove crashed-worker *all-workers*)))
         (otherwise (return-from %handle-worker-crash))))
-    (let (exit-code exit-status)
-      (ignore-errors
-        (let* ((proc (worker-process-info crashed-worker))
-               (status (and proc (sb-ext:process-status proc))))
-          (when status
-            (setf exit-status (string-downcase (symbol-name status))))
-          (when (member status '(:exited :signaled))
-            (setf exit-code (sb-ext:process-exit-code proc)))))
-      (log-event :warn "pool.worker.crashed" "worker_id"
-                 (worker-id crashed-worker) "session" session-id
-                 "was_standby" was-standby
-                 "exit_status" (or exit-status "unknown")
-                 "exit_code" (or exit-code "unknown"))
-      ;; The exit code is recorded before it is consulted: on this path --
-      ;; the health monitor reaching a dead worker before any RPC has seen
-      ;; the EOF -- nothing has classified the death, and the code this
-      ;; worker left is the only witness there is.  Recording the answer
-      ;; rather than leaving it to be re-derived later is what keeps it
-      ;; attached to the worker it is about, since the reason below is
-      ;; copied onto the replacement.
-      (setf (worker-last-exit-status crashed-worker) (or exit-status "unknown")
-            (worker-last-exit-code crashed-worker) (or exit-code "unknown"))
-      (setf retired-p (or (worker-retired-p crashed-worker)
-                          (exit-code-says-retired-p crashed-worker))
-            (worker-retired-p crashed-worker) retired-p)
-      ;; A retirement keeps its marker rather than being flattened into
-      ;; "process-died".  Everything that reads this slot afterwards --
-      ;; GET-OR-ASSIGN-WORKER's own breaker push when it meets the same
-      ;; worker, the notification the user is shown -- would otherwise see a
-      ;; generic crash, which is how this exclusion has failed before.
-      (setf (worker-last-crash-reason crashed-worker)
-            (if retired-p *retired-leaked-thread-reason* "process-died")))
+    (log-event :warn "pool.worker.crashed" "worker_id"
+               (worker-id crashed-worker) "session" session-id
+               "was_standby" was-standby
+               "retired" retired-p
+               "exit_status" (or exit-status "unknown")
+               "exit_code" (or exit-code "unknown"))
     (ignore-errors (kill-worker crashed-worker))
     ;; Already-crashed workers were cleaned up from tracking above.
     ;; Just schedule replenishment if needed and return.

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -41,6 +41,7 @@
                 #:worker-crashed
                 #:worker-crashed-reason
                 #:worker-retired-p
+                #:exit-code-says-retired-p
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
   (:import-from #:cl-mcp/src/utils/deadline
@@ -342,10 +343,13 @@ never fire.
 A deliberate retirement is excluded.  Three uninterruptible timeouts in five
 minutes would otherwise trip the breaker and halt the session, where the same
 three before this behaviour existed returned three timeouts and left the user
-working.  WORKER-RETIRED-P is asked here and now rather than sampled by the
-caller and passed in: the marker survives %HANDLE-WORKER-CRASH now, so there
-is no longer a moment at which the answer is only briefly available -- and a
-sampled copy is one more thing that can be taken at the wrong moment.
+working.  WORKER-RETIRED-P is a slot recorded by whoever classified the death
+rather than a question asked of the crash reason: the reason is copied onto
+the replacement worker so the user can be told why it was reset, and deriving
+the answer from it made a healthy worker report its predecessor's retirement
+as its own -- which would have disabled this breaker for the rest of the
+session, re-inherited by every later replacement, exactly where a crash loop
+is what the breaker is for.
 
 An init-attributable crash is excluded for the reason it always was: the pool
 counts those separately, against initialization rather than the session."
@@ -743,14 +747,18 @@ to prevent recovery threads from spawning orphan workers."
                  "was_standby" was-standby
                  "exit_status" (or exit-status "unknown")
                  "exit_code" (or exit-code "unknown"))
-      ;; Order matters twice over.  The exit code is recorded before the
-      ;; question is asked, because on this path -- the health monitor
-      ;; reaching a dead worker before any RPC has seen the EOF -- it is the
-      ;; only witness there is.  And the answer is taken before the reason is
-      ;; replaced, because the reason is the other witness.
+      ;; The exit code is recorded before it is consulted: on this path --
+      ;; the health monitor reaching a dead worker before any RPC has seen
+      ;; the EOF -- nothing has classified the death, and the code this
+      ;; worker left is the only witness there is.  Recording the answer
+      ;; rather than leaving it to be re-derived later is what keeps it
+      ;; attached to the worker it is about, since the reason below is
+      ;; copied onto the replacement.
       (setf (worker-last-exit-status crashed-worker) (or exit-status "unknown")
             (worker-last-exit-code crashed-worker) (or exit-code "unknown"))
-      (setf retired-p (worker-retired-p crashed-worker))
+      (setf retired-p (or (worker-retired-p crashed-worker)
+                          (exit-code-says-retired-p crashed-worker))
+            (worker-retired-p crashed-worker) retired-p)
       ;; A retirement keeps its marker rather than being flattened into
       ;; "process-died".  Everything that reads this slot afterwards --
       ;; GET-OR-ASSIGN-WORKER's own breaker push when it meets the same

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -30,6 +30,7 @@
                 #:signal-worker-terminate
                 #:worker-state #:worker-session-id
                 #:worker-needs-reset-notification
+                #:worker-leaked-threads
                 #:worker-tcp-port
                 #:worker-pid #:worker-id
                 #:worker-process-info
@@ -1392,7 +1393,13 @@ unrestricted REPL access bypassing MCP security policies."
                 (gethash "tcp_port" ht) (worker-tcp-port w)
                 (gethash "pid" ht) (worker-pid w)
                 (gethash "state" ht) (string-downcase
-                                       (symbol-name (worker-state w))))
+                                       (symbol-name (worker-state w)))
+                ;; Threads a deadline could not stop, as of this worker's last
+                ;; answer.  It retires itself before serving another request
+                ;; while carrying one, so a non-zero count here means the
+                ;; condition arose and the worker has not been asked for
+                ;; anything since.
+                (gethash "leaked_threads" ht) (worker-leaked-threads w))
           (vector-push-extend ht result))))
     result))
 

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -31,6 +31,7 @@
                 #:worker-state #:worker-session-id
                 #:worker-needs-reset-notification
                 #:worker-leaked-threads
+                #:*retired-leaked-thread-reason*
                 #:worker-tcp-port
                 #:worker-pid #:worker-id
                 #:worker-process-info
@@ -311,6 +312,16 @@ init cannot brick a session's repl-eval/load-system."
           (gethash "package" ht) (getf config :package))
     ht))
 
+(defun %retirement-crash-p (condition)
+  "True when CONDITION is a worker that retired deliberately rather than died.
+
+A worker exits when it finds it is still carrying a thread a deadline could
+not stop, and that reaches the parent as a crash like any other.  It is not
+evidence about whatever the worker happened to be doing at the time, so
+callers that draw conclusions from a crash have to exclude it."
+  (equal *retired-leaked-thread-reason*
+         (ignore-errors (worker-crashed-reason condition))))
+
 (defun %monitor-init (worker session-id max-failures)
   "Poll worker/init-status until terminal, updating failure/disable state.
 Runs on a short-lived background thread with backoff (0.1s -> 2s cap; no
@@ -363,9 +374,13 @@ further init."
                    (%release-runtime-owner-if worker)))
                (return))
               (t nil)))))
-    (worker-crashed ()
+    (worker-crashed (c)
+      ;; A worker that retired for carrying a leaked thread is not evidence
+      ;; about init: it exited deliberately, and blaming init for it disables
+      ;; initialization for every later worker in the pool.
       (bt:with-lock-held (*pool-lock*)
-        (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+        (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker)
+                   (not (%retirement-crash-p c)))
           (setf (gethash (worker-id worker) *init-attributable-crashes*) t
                 *runtime-init-disabled* t)
           (log-event :warn "pool.init.hard-crash"
@@ -403,13 +418,16 @@ worker before the init monitor does."
               (bt:make-thread
                (lambda () (%monitor-init worker session-id max-failures))
                :name (format nil "pool-init-monitor-~A" (worker-id worker)))))
-        (worker-crashed ()
+        (worker-crashed (c)
+          ;; See %MONITOR-INIT: a deliberate retirement is not an init failure.
           (bt:with-lock-held (*pool-lock*)
-            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker))
+            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker)
+                       (not (%retirement-crash-p c)))
               (setf (gethash (worker-id worker) *init-attributable-crashes*) t
                     *runtime-init-disabled* t)))
-          (log-event :warn "pool.init.hard-crash"
-                     "session" session-id "worker_id" (worker-id worker))
+          (unless (%retirement-crash-p c)
+            (log-event :warn "pool.init.hard-crash"
+                       "session" session-id "worker_id" (worker-id worker)))
           (%release-runtime-owner-if worker))
         (error (e)
           ;; A non-crash init-start failure means init never ran; drop the

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -40,6 +40,7 @@
                 #:worker-last-exit-code
                 #:worker-crashed
                 #:worker-crashed-reason
+                #:worker-retired-p
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
   (:import-from #:cl-mcp/src/utils/deadline
@@ -330,13 +331,7 @@ inert.  A TYPEP costs the same and cannot hide that."
        (equal *retired-leaked-thread-reason*
               (worker-crashed-reason condition))))
 
-(defun %retired-worker-p (worker)
-  "True when WORKER died by retiring rather than by crashing.
-The same distinction as %RETIREMENT-CRASH-P, asked of the worker struct after
-the fact rather than of the condition at the time."
-  (equal *retired-leaked-thread-reason* (worker-last-crash-reason worker)))
-
-(defun %breaker-countable-crash-p (worker &key (retired (%retired-worker-p worker)))
+(defun %breaker-countable-crash-p (worker)
   "True when WORKER's death should count toward its session's circuit breaker.
 
 Both push sites ask this rather than each spelling the exclusions out, because
@@ -347,12 +342,14 @@ never fire.
 A deliberate retirement is excluded.  Three uninterruptible timeouts in five
 minutes would otherwise trip the breaker and halt the session, where the same
 three before this behaviour existed returned three timeouts and left the user
-working.  RETIRED is a parameter because one caller has to sample it before
-that overwrite.
+working.  WORKER-RETIRED-P is asked here and now rather than sampled by the
+caller and passed in: the marker survives %HANDLE-WORKER-CRASH now, so there
+is no longer a moment at which the answer is only briefly available -- and a
+sampled copy is one more thing that can be taken at the wrong moment.
 
 An init-attributable crash is excluded for the reason it always was: the pool
 counts those separately, against initialization rather than the session."
-  (and (not retired)
+  (and (not (worker-retired-p worker))
        (not (%init-attributable-crash-p worker))))
 
 (defun %monitor-init (worker session-id max-failures)
@@ -746,14 +743,21 @@ to prevent recovery threads from spawning orphan workers."
                  "was_standby" was-standby
                  "exit_status" (or exit-status "unknown")
                  "exit_code" (or exit-code "unknown"))
-      ;; Captured before the slot is overwritten: %RETIRED-WORKER-P below
-      ;; reads it, and setting it to "process-died" first made that guard
-      ;; unreachable -- the same shape of inert guard this branch already had
-      ;; to fix once.
-      (setf retired-p (%retired-worker-p crashed-worker))
-      (setf (worker-last-crash-reason crashed-worker) "process-died"
-            (worker-last-exit-status crashed-worker) (or exit-status "unknown")
-            (worker-last-exit-code crashed-worker) (or exit-code "unknown")))
+      ;; Order matters twice over.  The exit code is recorded before the
+      ;; question is asked, because on this path -- the health monitor
+      ;; reaching a dead worker before any RPC has seen the EOF -- it is the
+      ;; only witness there is.  And the answer is taken before the reason is
+      ;; replaced, because the reason is the other witness.
+      (setf (worker-last-exit-status crashed-worker) (or exit-status "unknown")
+            (worker-last-exit-code crashed-worker) (or exit-code "unknown"))
+      (setf retired-p (worker-retired-p crashed-worker))
+      ;; A retirement keeps its marker rather than being flattened into
+      ;; "process-died".  Everything that reads this slot afterwards --
+      ;; GET-OR-ASSIGN-WORKER's own breaker push when it meets the same
+      ;; worker, the notification the user is shown -- would otherwise see a
+      ;; generic crash, which is how this exclusion has failed before.
+      (setf (worker-last-crash-reason crashed-worker)
+            (if retired-p *retired-leaked-thread-reason* "process-died")))
     (ignore-errors (kill-worker crashed-worker))
     ;; Already-crashed workers were cleaned up from tracking above.
     ;; Just schedule replenishment if needed and return.
@@ -766,7 +770,7 @@ to prevent recovery threads from spawning orphan workers."
               (window-start (- now *crash-breaker-window*)))
          (bordeaux-threads:with-lock-held (*pool-lock*)
            (let ((history (gethash session-id *crash-history*)))
-             (when (%breaker-countable-crash-p crashed-worker :retired retired-p)
+             (when (%breaker-countable-crash-p crashed-worker)
                (setf history
                      (remove-if (lambda (ts) (< ts window-start)) history))
                (push now history)

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -31,7 +31,6 @@
                 #:worker-state #:worker-session-id
                 #:worker-needs-reset-notification
                 #:worker-leaked-threads
-                #:*retired-leaked-thread-reason*
                 #:worker-tcp-port
                 #:worker-pid #:worker-id
                 #:worker-process-info
@@ -43,6 +42,8 @@
                 #:worker-crashed-reason
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:*retired-leaked-thread-reason*)
   (:import-from #:cl-mcp/src/proxy
                 #:verify-proxy-bindings
                 #:%invalidate-proxy-cache
@@ -334,6 +335,25 @@ inert.  A TYPEP costs the same and cannot hide that."
 The same distinction as %RETIREMENT-CRASH-P, asked of the worker struct after
 the fact rather than of the condition at the time."
   (equal *retired-leaked-thread-reason* (worker-last-crash-reason worker)))
+
+(defun %breaker-countable-crash-p (worker &key (retired (%retired-worker-p worker)))
+  "True when WORKER's death should count toward its session's circuit breaker.
+
+Both push sites ask this rather than each spelling the exclusions out, because
+they had drifted: one of them consulted the crash reason after the surrounding
+function had already overwritten it, so the guard read as effective and could
+never fire.
+
+A deliberate retirement is excluded.  Three uninterruptible timeouts in five
+minutes would otherwise trip the breaker and halt the session, where the same
+three before this behaviour existed returned three timeouts and left the user
+working.  RETIRED is a parameter because one caller has to sample it before
+that overwrite.
+
+An init-attributable crash is excluded for the reason it always was: the pool
+counts those separately, against initialization rather than the session."
+  (and (not retired)
+       (not (%init-attributable-crash-p worker))))
 
 (defun %monitor-init (worker session-id max-failures)
   "Poll worker/init-status until terminal, updating failure/disable state.
@@ -691,7 +711,8 @@ to prevent recovery threads from spawning orphan workers."
   (let ((session-id nil)
         (was-bound nil)
         (was-standby nil)
-        (was-already-crashed nil))
+        (was-already-crashed nil)
+        (retired-p nil))
     (bordeaux-threads:with-lock-held (*pool-lock*)
       (case (worker-state crashed-worker)
         (:bound
@@ -725,6 +746,11 @@ to prevent recovery threads from spawning orphan workers."
                  "was_standby" was-standby
                  "exit_status" (or exit-status "unknown")
                  "exit_code" (or exit-code "unknown"))
+      ;; Captured before the slot is overwritten: %RETIRED-WORKER-P below
+      ;; reads it, and setting it to "process-died" first made that guard
+      ;; unreachable -- the same shape of inert guard this branch already had
+      ;; to fix once.
+      (setf retired-p (%retired-worker-p crashed-worker))
       (setf (worker-last-crash-reason crashed-worker) "process-died"
             (worker-last-exit-status crashed-worker) (or exit-status "unknown")
             (worker-last-exit-code crashed-worker) (or exit-code "unknown")))
@@ -740,8 +766,7 @@ to prevent recovery threads from spawning orphan workers."
               (window-start (- now *crash-breaker-window*)))
          (bordeaux-threads:with-lock-held (*pool-lock*)
            (let ((history (gethash session-id *crash-history*)))
-             (unless (or (%retired-worker-p crashed-worker)
-                         (%init-attributable-crash-p crashed-worker))
+             (when (%breaker-countable-crash-p crashed-worker :retired retired-p)
                (setf history
                      (remove-if (lambda (ts) (< ts window-start)) history))
                (push now history)
@@ -1130,8 +1155,7 @@ cannot be created."
          ;; unstable pool.
          (when (and (eq :crashed (worker-state entry))
                     (not (worker-crash-history-pushed-p entry))
-                    (not (%retired-worker-p entry))
-                    (not (%init-attributable-crash-p entry)))
+                    (%breaker-countable-crash-p entry))
            (let* ((now (get-universal-time))
                   (window-start (- now *crash-breaker-window*))
                   (history (gethash session-id *crash-history*)))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -30,6 +30,7 @@
                 #:signal-worker-terminate
                 #:worker-state #:worker-session-id
                 #:worker-needs-reset-notification
+                #:worker-owes-reset-p
                 #:worker-leaked-threads
                 #:worker-tcp-port
                 #:worker-pid #:worker-id
@@ -223,6 +224,22 @@ Enable the pool to use it.")))
   "Maps session-id to list of crash timestamps (universal-time).
 Used by the circuit breaker to detect repeated crash loops.")
 
+(defvar *owed-resets* (make-hash-table :test 'equal)
+  "Sessions owed a state-reset notification nobody has delivered, mapped to
+the crash details to explain it by: (REASON EXIT-STATUS EXIT-CODE).
+Guarded by *POOL-LOCK*.
+
+The debt belongs to the session because the worker that incurred it is being
+thrown away, and not every path that throws one away has a replacement in
+hand to pass it to: the health monitor can find a worker another thread has
+already marked crashed and simply drop it, and a replacement spawn can fail.
+Both lost the debt, and the user's next call then landed in a fresh image --
+systems unloaded, definitions gone -- with nothing said about it.
+
+Carrying the details rather than a bare flag is what lets the replacement say
+*why*.  Without them a worker that retired for a leaked thread is announced
+as an ordinary crash, which is the one thing this branch exists to stop.")
+
 (defparameter *crash-breaker-window* 300
   "Time window in seconds for the crash circuit breaker.")
 
@@ -384,6 +401,27 @@ A retirement keeps its marker rather than being flattened into
           (if retired *retired-leaked-thread-reason* "process-died"))
     retired))
 
+(defun %note-owed-reset (session-id worker)
+  "Remember a reset WORKER owes SESSION-ID that nobody has delivered.
+Call under *POOL-LOCK*, wherever a worker is dropped without a replacement in
+hand to give the debt to.  A worker that owes nothing changes nothing."
+  (when (and session-id worker (worker-owes-reset-p worker))
+    (setf (gethash session-id *owed-resets*)
+          (list (worker-last-crash-reason worker)
+                (worker-last-exit-status worker)
+                (worker-last-exit-code worker)))))
+
+(defun %hand-reset-to (worker debt)
+  "Put DEBT -- an owed reset and the details that explain it -- onto WORKER.
+Returns WORKER.  Call before the worker becomes visible in the affinity map,
+so a concurrent request cannot find it without the debt."
+  (when debt
+    (setf (worker-needs-reset-notification worker) t
+          (worker-last-crash-reason worker) (first debt)
+          (worker-last-exit-status worker) (second debt)
+          (worker-last-exit-code worker) (third debt)))
+  worker)
+
 (defun %monitor-init (worker session-id max-failures)
   "Poll worker/init-status until terminal, updating failure/disable state.
 Runs on a short-lived background thread with backoff (0.1s -> 2s cap; no
@@ -543,9 +581,11 @@ Must be called with *pool-lock* held."
 (defun %spawn-and-bind (session-id placeholder &key need-reset)
   "Spawn a worker, bind it to SESSION-ID, and notify waiting threads.
 On failure, clean up the affinity map entry and notify waiters of
-the failure.  When NEED-RESET is true, sets the worker's
-needs-reset-notification flag BEFORE making the worker visible in
-the affinity map to prevent concurrent threads from missing the flag.
+the failure.  NEED-RESET, when given, is the session's owed reset and the
+crash details that explain it; it is placed on the worker BEFORE the worker
+becomes visible in the affinity map, so no concurrent thread can find it
+without the debt, and the session's copy is dropped only once this worker is
+registered, so a failed spawn leaves the debt for the next attempt.
 Returns the worker on success.  Signals an error if the spawn was
 cancelled (e.g. release-session during spawn) or failed."
   (let ((new-worker nil))
@@ -554,8 +594,12 @@ cancelled (e.g. release-session during spawn) or failed."
           (setf new-worker (spawn-worker))
           (setf (worker-state new-worker) :bound)
           (setf (worker-session-id new-worker) session-id)
-          (when need-reset
-            (setf (worker-needs-reset-notification new-worker) t))
+          ;; Before the worker is visible in the affinity map: a concurrent
+          ;; request must not be able to find it without the debt.  The
+          ;; session's copy is dropped only once this one is registered, so a
+          ;; spawn that fails leaves the debt for the next attempt rather
+          ;; than resetting the user's session in silence.
+          (%hand-reset-to new-worker need-reset)
           (let ((cancelled nil))
             (bt:with-lock-held (*pool-lock*)
               (cond
@@ -564,7 +608,11 @@ cancelled (e.g. release-session during spawn) or failed."
                  (setf (worker-state new-worker) :released))
                 (t
                  (setf (gethash session-id *affinity-map*) new-worker)
-                 (push new-worker *all-workers*))))
+                 (push new-worker *all-workers*)
+                 ;; The debt is on a bound, visible worker now; anything
+                 ;; still here would be delivered a second time.
+                 (when need-reset
+                   (remhash session-id *owed-resets*)))))
             (cond
               (cancelled
                (bt:with-lock-held ((worker-placeholder-lock placeholder))
@@ -765,6 +813,13 @@ to prevent recovery threads from spawning orphan workers."
          ;; retirement is indistinguishable from a crash.
          (setf retired-p (%record-worker-death crashed-worker
                                                exit-status exit-code))
+         ;; Discovered here rather than by an RPC, so nobody has told the
+         ;; user their session was reset, and the debt is recorded the same
+         ;; way any other death records it.  That way every later step --
+         ;; handing it to the replacement, or leaving it with the session
+         ;; when there is no replacement -- reads one flag rather than
+         ;; guessing from which arm it arrived in.
+         (setf (worker-needs-reset-notification crashed-worker) t)
          (setf (worker-state crashed-worker) :crashed))
         (:standby
          (setf was-standby t)
@@ -781,6 +836,12 @@ to prevent recovery threads from spawning orphan workers."
          (setf retired-p (%record-worker-death crashed-worker
                                                exit-status exit-code))
          (when (eql (gethash session-id *affinity-map*) crashed-worker)
+           ;; Dropped here with no replacement in hand -- this arm only
+           ;; schedules replenishment -- so an undelivered reset has to be
+           ;; left with the session or it goes with the worker.  The RPC that
+           ;; marked this one crashed may have been the pool's own, and
+           ;; swallowed the error.
+           (%note-owed-reset session-id crashed-worker)
            (remhash session-id *affinity-map*)
            (setf was-bound t))
          (setf *all-workers* (remove crashed-worker *all-workers*)))
@@ -854,6 +915,10 @@ to prevent recovery threads from spawning orphan workers."
                         (setf *all-workers*
                               (remove crashed-worker *all-workers*))
                         (push new-worker *all-workers*)
+                        ;; This worker carries the reset now -- it was
+                        ;; flagged above -- so a copy left with the session
+                        ;; would be delivered a second time.
+                        (remhash session-id *owed-resets*)
                         (setf registered t))
                        (t
                         (setf (worker-state new-worker) :released)
@@ -883,6 +948,10 @@ to prevent recovery threads from spawning orphan workers."
                       "session" session-id
                       "error" (princ-to-string e))
            (bordeaux-threads:with-lock-held (*pool-lock*)
+             ;; The replacement never happened, so nothing carries the reset
+             ;; this death owes.  Left with the session, the next request to
+             ;; get a worker delivers it.
+             (%note-owed-reset session-id crashed-worker)
              (when (eql (gethash session-id *affinity-map*) crashed-worker)
                (remhash session-id *affinity-map*))
              (setf *all-workers* (remove crashed-worker *all-workers*))))))
@@ -1130,7 +1199,9 @@ snapshotting and killing workers."
       (setf workers (copy-list *all-workers*))
       (setf *all-workers* nil
             *standby-workers* nil)
-      (clrhash *affinity-map*))
+      (clrhash *affinity-map*)
+      ;; Nothing survives a shutdown to be told anything.
+      (clrhash *owed-resets*))
     (dolist (w workers) (ignore-errors (kill-worker w))))
   (log-event :info "pool.shutdown-complete"))
 
@@ -1230,12 +1301,19 @@ cannot be created."
          ;; deliberately rather than by chance: the root sync is a request
          ;; like any other, and a worker carrying a leaked thread retires on
          ;; it.
-         (setf entry nil
-               need-reset (worker-needs-reset-notification
-                           old-worker-to-kill)))
+         (%note-owed-reset session-id old-worker-to-kill)
+         (setf entry nil))
         ;; Path 2: Placeholder — another thread is spawning
         ((and entry (typep entry 'worker-placeholder))
          nil))
+      ;; Asked of the session, and after the paths above have had their say,
+      ;; because a debt reaches here by more routes than the worker this call
+      ;; happens to find.  Recovery can drop a dead worker with no
+      ;; replacement to hand it to, and a replacement spawn can fail; both
+      ;; leave the debt on the session with no worker to read it from, and
+      ;; both used to lose it -- the user's next call landing in a fresh
+      ;; image with nothing said about it.
+      (setf need-reset (gethash session-id *owed-resets*))
       ;; Phase 2: assign standby or spawn
       ;; Skip when circuit breaker tripped — the error is raised after
       ;; the lock, but we must not leave a placeholder that nobody resolves.
@@ -1246,11 +1324,12 @@ cannot be created."
               for w = (pop *standby-workers*)
               do (cond
                    ((%worker-process-alive-p w)
+                    (%hand-reset-to w need-reset)
+                    (when need-reset
+                      (remhash session-id *owed-resets*))
                     (setf (worker-state w) :bound
                           (worker-session-id w) session-id
                           (gethash session-id *affinity-map*) w)
-                    (when need-reset
-                      (setf (worker-needs-reset-notification w) t))
                     (setf assigned-from-standby w)
                     (return))
                    (t
@@ -1346,6 +1425,10 @@ impending kill as a crash."
            (setf (worker-state worker-to-kill) :released)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
+           ;; The session is going away; a reset owed to it is owed to
+           ;; nobody, and leaving it would greet a later session that
+           ;; reused the id with someone else's crash.
+           (remhash session-id *owed-resets*)
            (setf *all-workers* (remove worker-to-kill *all-workers*))
            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
              (setf *runtime-owner* nil)))
@@ -1353,6 +1436,7 @@ impending kill as a crash."
            (setf (worker-placeholder-cancelled entry) t)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
+           (remhash session-id *owed-resets*)
            (log-event :info "pool.session.cancelled-spawn"
                       "session" session-id)))))
     (when worker-to-kill

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -40,6 +40,7 @@
                 #:worker-last-exit-status
                 #:worker-last-exit-code
                 #:worker-crashed
+                #:worker-crashed-reason
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
   (:import-from #:cl-mcp/src/proxy
@@ -318,9 +319,21 @@ init cannot brick a session's repl-eval/load-system."
 A worker exits when it finds it is still carrying a thread a deadline could
 not stop, and that reaches the parent as a crash like any other.  It is not
 evidence about whatever the worker happened to be doing at the time, so
-callers that draw conclusions from a crash have to exclude it."
-  (equal *retired-leaked-thread-reason*
-         (ignore-errors (worker-crashed-reason condition))))
+callers that draw conclusions from a crash have to exclude it.
+
+Typed rather than wrapped in IGNORE-ERRORS: the first version of this guarded
+the reader that way, and when the reader turned out not to be imported here
+the swallowed undefined-function error made the whole exclusion silently
+inert.  A TYPEP costs the same and cannot hide that."
+  (and (typep condition 'worker-crashed)
+       (equal *retired-leaked-thread-reason*
+              (worker-crashed-reason condition))))
+
+(defun %retired-worker-p (worker)
+  "True when WORKER died by retiring rather than by crashing.
+The same distinction as %RETIREMENT-CRASH-P, asked of the worker struct after
+the fact rather than of the condition at the time."
+  (equal *retired-leaked-thread-reason* (worker-last-crash-reason worker)))
 
 (defun %monitor-init (worker session-id max-failures)
   "Poll worker/init-status until terminal, updating failure/disable state.
@@ -727,7 +740,8 @@ to prevent recovery threads from spawning orphan workers."
               (window-start (- now *crash-breaker-window*)))
          (bordeaux-threads:with-lock-held (*pool-lock*)
            (let ((history (gethash session-id *crash-history*)))
-             (unless (%init-attributable-crash-p crashed-worker)
+             (unless (or (%retired-worker-p crashed-worker)
+                         (%init-attributable-crash-p crashed-worker))
                (setf history
                      (remove-if (lambda (ts) (< ts window-start)) history))
                (push now history)
@@ -1108,8 +1122,15 @@ cannot be created."
          ;; Skip push if %handle-worker-crash already pushed for this
          ;; worker (prevents double-counting in the race window where
          ;; the health monitor detects the crash first).
+         ;; A deliberate retirement is excluded: a user calling something
+         ;; uninterruptible three times in five minutes would otherwise trip
+         ;; the breaker and halt the session, where before this branch they
+         ;; got three timeouts and kept working.  The worker is replaced each
+         ;; time and the replacement starts clean, so it is not evidence of an
+         ;; unstable pool.
          (when (and (eq :crashed (worker-state entry))
                     (not (worker-crash-history-pushed-p entry))
+                    (not (%retired-worker-p entry))
                     (not (%init-attributable-crash-p entry)))
            (let* ((now (get-universal-time))
                   (window-start (- now *crash-breaker-window*))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -374,7 +374,8 @@ counts those separately, against initialization rather than the session."
   (and (not (worker-retired-p worker))
        (not (%init-attributable-crash-p worker))))
 
-(defun %record-worker-death (worker exit-status exit-code)
+(defun %record-worker-death (worker exit-status exit-code
+                             &key already-classified)
   "Record what killed WORKER and return whether it was a deliberate retirement.
 
 Must be called under *POOL-LOCK*, in the same critical section that moves the
@@ -390,36 +391,62 @@ witness there is.  The answer is stored rather than left to be re-derived,
 because the reason below is copied onto the replacement worker and a question
 asked of that copy is answered about the wrong death.
 
-A retirement keeps its marker rather than being flattened into
-\"process-died\": the notification the user is shown reads this slot too."
-  (setf (worker-last-exit-status worker) (or exit-status "unknown")
-        (worker-last-exit-code worker) (or exit-code "unknown"))
+ALREADY-CLASSIFIED says the caller found this worker already marked crashed,
+so its reason describes this worker's own death and is kept: an RPC that met
+the death knows it was a \"timeout\" or a \"stream-error\", where this
+function only ever knows the process is gone, and \"process-died\" tells the
+user less than the truth it would overwrite.  Without that, any reason
+present was inherited from the predecessor whose replacement this worker is,
+and keeping it would report someone else's death as this one's.
+
+The exit details work the same way round: a fresh reading wins, since it is
+about this worker, and only where there is none is an existing one kept."
+  (let ((status (or exit-status
+                    (and already-classified (worker-last-exit-status worker))))
+        (code (or exit-code
+                  (and already-classified (worker-last-exit-code worker)))))
+    (setf (worker-last-exit-status worker) (or status "unknown")
+          (worker-last-exit-code worker) (or code "unknown")))
   (let ((retired (or (worker-retired-p worker)
                      (exit-code-says-retired-p worker))))
     (setf (worker-retirement-recorded worker) retired
           (worker-last-crash-reason worker)
-          (if retired *retired-leaked-thread-reason* "process-died"))
+          (cond (retired *retired-leaked-thread-reason*)
+                ((and already-classified (worker-last-crash-reason worker)))
+                (t "process-died")))
     retired))
 
-(defun %note-owed-reset (session-id worker)
-  "Remember a reset WORKER owes SESSION-ID that nobody has delivered.
-Call under *POOL-LOCK*, wherever a worker is dropped without a replacement in
-hand to give the debt to.  A worker that owes nothing changes nothing.
+(defun %owed-reset-of (worker)
+  "The reset WORKER owes and nobody has delivered, as (REASON STATUS CODE),
+or NIL when it owes nothing.
 
 Read rather than claimed.  Claiming it -- CHECK-AND-CLEAR-RESET-NOTIFICATION,
 which is atomic against the proxy's own claim -- would make delivery
-at-most-once across the two, but it takes the worker's stream lock, and this
-runs under *POOL-LOCK*.  An RPC holds that stream lock for as long as its
-call takes, which for a load-system is minutes; the pool would stop serving
-every session until it returned.  A cosmetic duplicate is the cheaper of the
-two, and it is not clearly a duplicate: the two messages go to two different
-requests, both of which really were answered by a worker that had been
-replaced."
-  (when (and session-id worker (worker-owes-reset-p worker))
-    (setf (gethash session-id *owed-resets*)
-          (list (worker-last-crash-reason worker)
-                (worker-last-exit-status worker)
-                (worker-last-exit-code worker)))))
+at-most-once across the two, but it takes the worker's stream lock, and the
+callers here run under *POOL-LOCK*.  An RPC holds that stream lock for as
+long as its call takes, which for a load-system is minutes; the pool would
+stop serving every session until it returned.  A duplicate is the cheaper of
+the two, and it is not clearly a duplicate: the two messages go to two
+different requests, both of which really were answered by a worker that had
+been replaced.
+
+Read once, early, and passed along: KILL-WORKER sets this flag on anything it
+kills, and the pool kills a worker before the arms that decide what to do
+about it, so a later reading would find a debt the proxy had already
+delivered and settled."
+  (when (and worker (worker-owes-reset-p worker))
+    (list (worker-last-crash-reason worker)
+          (worker-last-exit-status worker)
+          (worker-last-exit-code worker))))
+
+(defun %leave-owed-reset (session-id owed)
+  "Leave OWED -- a reset nobody has delivered -- with SESSION-ID.
+Call under *POOL-LOCK*, wherever a worker is dropped without a replacement in
+hand to give it to.  Nothing owed changes nothing, and an existing debt is
+not replaced by a later one: the first is the one the user has been waiting
+to hear about."
+  (when (and session-id owed (null (gethash session-id *owed-resets*)))
+    (setf (gethash session-id *owed-resets*) owed)))
 
 (defun %hand-reset-to (worker debt)
   "Put DEBT -- an owed reset and the details that explain it -- onto WORKER.
@@ -800,6 +827,7 @@ to prevent recovery threads from spawning orphan workers."
         (was-standby nil)
         (was-already-crashed nil)
         (retired-p nil)
+        (owed nil)
         (exit-code nil)
         (exit-status nil))
     ;; Read before the lock and recorded inside it: SB-EXT:PROCESS-STATUS is
@@ -830,6 +858,7 @@ to prevent recovery threads from spawning orphan workers."
          ;; when there is no replacement -- reads one flag rather than
          ;; guessing from which arm it arrived in.
          (setf (worker-needs-reset-notification crashed-worker) t)
+         (setf owed (%owed-reset-of crashed-worker))
          (setf (worker-state crashed-worker) :crashed))
         (:standby
          (setf was-standby t)
@@ -844,14 +873,16 @@ to prevent recovery threads from spawning orphan workers."
          (setf was-already-crashed t
                session-id (worker-session-id crashed-worker))
          (setf retired-p (%record-worker-death crashed-worker
-                                               exit-status exit-code))
+                                               exit-status exit-code
+                                               :already-classified t))
+         (setf owed (%owed-reset-of crashed-worker))
          (when (eql (gethash session-id *affinity-map*) crashed-worker)
            ;; Dropped here with no replacement in hand -- this arm only
            ;; schedules replenishment -- so an undelivered reset has to be
            ;; left with the session or it goes with the worker.  The RPC that
            ;; marked this one crashed may have been the pool's own, and
            ;; swallowed the error.
-           (%note-owed-reset session-id crashed-worker)
+           (%leave-owed-reset session-id owed)
            (remhash session-id *affinity-map*)
            (setf was-bound t))
          (setf *all-workers* (remove crashed-worker *all-workers*)))
@@ -897,8 +928,11 @@ to prevent recovery threads from spawning orphan workers."
                  ;; next request is served -- and it would be served by a
                  ;; fresh image with neither the breaker's error nor a word
                  ;; about the reset.
-                 (%note-owed-reset session-id crashed-worker)
                  (when (eql (gethash session-id *affinity-map*) crashed-worker)
+                   ;; Only while this worker is still the session's: another
+                   ;; thread may have replaced it already, and it recorded
+                   ;; whatever was owed when it did.
+                   (%leave-owed-reset session-id owed)
                    (remhash session-id *affinity-map*))
                  (setf *all-workers* (remove crashed-worker *all-workers*))
                  (return-from %handle-worker-crash))))))
@@ -965,11 +999,11 @@ to prevent recovery threads from spawning orphan workers."
                       "session" session-id
                       "error" (princ-to-string e))
            (bordeaux-threads:with-lock-held (*pool-lock*)
-             ;; The replacement never happened, so nothing carries the reset
-             ;; this death owes.  Left with the session, the next request to
-             ;; get a worker delivers it.
-             (%note-owed-reset session-id crashed-worker)
              (when (eql (gethash session-id *affinity-map*) crashed-worker)
+               ;; The replacement never happened, so nothing carries the
+               ;; reset this death owes.  Left with the session, the next
+               ;; request to get a worker delivers it.
+               (%leave-owed-reset session-id owed)
                (remhash session-id *affinity-map*))
              (setf *all-workers* (remove crashed-worker *all-workers*))))))
       (was-standby
@@ -1318,7 +1352,7 @@ cannot be created."
          ;; deliberately rather than by chance: the root sync is a request
          ;; like any other, and a worker carrying a leaked thread retires on
          ;; it.
-         (%note-owed-reset session-id old-worker-to-kill)
+         (%leave-owed-reset session-id (%owed-reset-of old-worker-to-kill))
          (setf entry nil))
         ;; Path 2: Placeholder — another thread is spawning
         ((and entry (typep entry 'worker-placeholder))
@@ -1409,6 +1443,12 @@ cannot be created."
                      "session" session-id
                      "worker_id" (worker-id worker))
           (bordeaux-threads:with-lock-held (*pool-lock*)
+            ;; The last place a worker is dropped with no replacement.  This
+            ;; one may be carrying a debt handed to it moments ago -- the
+            ;; session's copy was dropped when it took it on -- so without
+            ;; this the reset is gone from both places at once and the user
+            ;; is never told their session was reset, twice over.
+            (%leave-owed-reset session-id (%owed-reset-of worker))
             (when (eql (gethash session-id *affinity-map*) worker)
               (remhash session-id *affinity-map*))
             (setf *all-workers* (remove worker *all-workers*)))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -404,7 +404,17 @@ A retirement keeps its marker rather than being flattened into
 (defun %note-owed-reset (session-id worker)
   "Remember a reset WORKER owes SESSION-ID that nobody has delivered.
 Call under *POOL-LOCK*, wherever a worker is dropped without a replacement in
-hand to give the debt to.  A worker that owes nothing changes nothing."
+hand to give the debt to.  A worker that owes nothing changes nothing.
+
+Read rather than claimed.  Claiming it -- CHECK-AND-CLEAR-RESET-NOTIFICATION,
+which is atomic against the proxy's own claim -- would make delivery
+at-most-once across the two, but it takes the worker's stream lock, and this
+runs under *POOL-LOCK*.  An RPC holds that stream lock for as long as its
+call takes, which for a load-system is minutes; the pool would stop serving
+every session until it returned.  A cosmetic duplicate is the cheaper of the
+two, and it is not clearly a duplicate: the two messages go to two different
+requests, both of which really were answered by a worker that had been
+replaced."
   (when (and session-id worker (worker-owes-reset-p worker))
     (setf (gethash session-id *owed-resets*)
           (list (worker-last-crash-reason worker)
@@ -881,6 +891,13 @@ to prevent recovery threads from spawning orphan workers."
                  ;; Clear crash history to prevent stale data if session
                  ;; ID is reused or session reconnects later.
                  (remhash session-id *crash-history*)
+                 ;; The recovery stops here, so this is another drop with no
+                 ;; replacement to hand the debt to.  The session is not
+                 ;; halted for good -- the history is cleared above, so the
+                 ;; next request is served -- and it would be served by a
+                 ;; fresh image with neither the breaker's error nor a word
+                 ;; about the reset.
+                 (%note-owed-reset session-id crashed-worker)
                  (when (eql (gethash session-id *affinity-map*) crashed-worker)
                    (remhash session-id *affinity-map*))
                  (setf *all-workers* (remove crashed-worker *all-workers*))
@@ -1325,11 +1342,14 @@ cannot be created."
               do (cond
                    ((%worker-process-alive-p w)
                     (%hand-reset-to w need-reset)
-                    (when need-reset
-                      (remhash session-id *owed-resets*))
                     (setf (worker-state w) :bound
                           (worker-session-id w) session-id
                           (gethash session-id *affinity-map*) w)
+                    ;; After the worker is registered, not before: the debt
+                    ;; is only safely somewhere else once someone else can
+                    ;; find it there.
+                    (when need-reset
+                      (remhash session-id *owed-resets*))
                     (setf assigned-from-standby w)
                     (return))
                    (t
@@ -1418,6 +1438,13 @@ then checks state outside it) will skip it and not treat the
 impending kill as a crash."
   (let ((worker-to-kill nil))
     (bt:with-lock-held (*pool-lock*)
+      ;; Outside the branches below, because a debt can outlive the affinity
+      ;; entry: recovery that dropped the worker, or a replacement spawn that
+      ;; failed, leaves one behind with nothing in the map.  The session is
+      ;; going away, so a reset owed to it is owed to nobody -- and left
+      ;; here it would greet a later session that reused the id with someone
+      ;; else's crash.
+      (remhash session-id *owed-resets*)
       (let ((entry (gethash session-id *affinity-map*)))
         (cond
           ((and entry (typep entry 'worker))
@@ -1425,10 +1452,6 @@ impending kill as a crash."
            (setf (worker-state worker-to-kill) :released)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
-           ;; The session is going away; a reset owed to it is owed to
-           ;; nobody, and leaving it would greet a later session that
-           ;; reused the id with someone else's crash.
-           (remhash session-id *owed-resets*)
            (setf *all-workers* (remove worker-to-kill *all-workers*))
            (when (and *runtime-owner* (eq (cdr *runtime-owner*) worker-to-kill))
              (setf *runtime-owner* nil)))
@@ -1436,7 +1459,6 @@ impending kill as a crash."
            (setf (worker-placeholder-cancelled entry) t)
            (remhash session-id *affinity-map*)
            (remhash session-id *crash-history*)
-           (remhash session-id *owed-resets*)
            (log-event :info "pool.session.cancelled-spawn"
                       "session" session-id)))))
     (when worker-to-kill

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -41,6 +41,7 @@
                 #:worker-crashed
                 #:worker-crashed-reason
                 #:worker-retired-p
+                #:worker-retirement-recorded
                 #:exit-code-says-retired-p
                 #:*reaper-threads* #:*reaper-threads-lock*
                 #:*worker-startup-timeout*)
@@ -378,7 +379,7 @@ A retirement keeps its marker rather than being flattened into
         (worker-last-exit-code worker) (or exit-code "unknown"))
   (let ((retired (or (worker-retired-p worker)
                      (exit-code-says-retired-p worker))))
-    (setf (worker-retired-p worker) retired
+    (setf (worker-retirement-recorded worker) retired
           (worker-last-crash-reason worker)
           (if retired *retired-leaked-thread-reason* "process-died"))
     retired))
@@ -1213,13 +1214,25 @@ cannot be created."
              (setf (gethash session-id *crash-history*) history)
              (when (>= (length history) *crash-breaker-threshold*)
                (setf circuit-breaker-tripped t))))
-         ;; Avoid double crash notification: when %mark-worker-crashed
-         ;; (called by worker-rpc on EOF) set needs-reset-notification
-         ;; on the old worker, the proxy's worker-crashed handler
-         ;; already returned a notification to the client.
+         ;; The flag on the dead worker is an owed reset that nobody has
+         ;; delivered: %MARK-WORKER-CRASHED and KILL-WORKER set it, and the
+         ;; proxy clears it when it returns the notification itself, so a
+         ;; death reported mid-request does not produce a second one here.
+         ;;
+         ;; It used to be read the other way round, as "the flag is set,
+         ;; therefore the proxy already told them".  That holds only for a
+         ;; death during a user's own request.  The pool makes RPCs of its
+         ;; own -- the project-root sync after fs-set-project-root, the init
+         ;; monitor's polling -- and those swallow the error, so a worker
+         ;; dying on one left the flag set with nobody told.  The user's next
+         ;; call then landed in a fresh image with their systems unloaded and
+         ;; nothing said about it.  A retirement makes that reachable
+         ;; deliberately rather than by chance: the root sync is a request
+         ;; like any other, and a worker carrying a leaked thread retires on
+         ;; it.
          (setf entry nil
-               need-reset (not (worker-needs-reset-notification
-                                old-worker-to-kill))))
+               need-reset (worker-needs-reset-notification
+                           old-worker-to-kill)))
         ;; Path 2: Placeholder — another thread is spawning
         ((and entry (typep entry 'worker-placeholder))
          nil))

--- a/src/pool.lisp
+++ b/src/pool.lisp
@@ -949,12 +949,18 @@ to prevent recovery threads from spawning orphan workers."
                    (setf (worker-state new-worker) :bound)
                    (setf (worker-session-id new-worker) session-id)
                    (setf (worker-needs-reset-notification new-worker) t)
-                   (setf (worker-last-crash-reason new-worker)
-                           (worker-last-crash-reason crashed-worker)
-                         (worker-last-exit-status new-worker)
-                           (worker-last-exit-status crashed-worker)
-                         (worker-last-exit-code new-worker)
-                           (worker-last-exit-code crashed-worker))
+                   ;; The same snapshot every other path hands over, taken
+                   ;; under the lock that classified this death rather than
+                   ;; re-read here, where the reaper may already have closed
+                   ;; the process out from under it.
+                   (%hand-reset-to new-worker
+                                   (or owed
+                                       (list (worker-last-crash-reason
+                                              crashed-worker)
+                                             (worker-last-exit-status
+                                              crashed-worker)
+                                             (worker-last-exit-code
+                                              crashed-worker))))
                    (bordeaux-threads:with-lock-held (*pool-lock*)
                      (cond
                        ((not *pool-running*)
@@ -1448,8 +1454,13 @@ cannot be created."
             ;; session's copy was dropped when it took it on -- so without
             ;; this the reset is gone from both places at once and the user
             ;; is never told their session was reset, twice over.
-            (%leave-owed-reset session-id (%owed-reset-of worker))
+            ;;
+            ;; Only while this worker is still the session's, like every
+            ;; other site: recovery may have replaced it already and given
+            ;; the debt to the replacement, and a copy left here would
+            ;; outlive its consumer and later explain a different death.
             (when (eql (gethash session-id *affinity-map*) worker)
+              (%leave-owed-reset session-id (%owed-reset-of worker))
               (remhash session-id *affinity-map*))
             (setf *all-workers* (remove worker *all-workers*)))
           (ignore-errors (kill-worker worker))

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -18,6 +18,8 @@
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht #:text-content #:result)
   (:import-from #:cl-mcp/src/log #:log-event)
+  (:import-from #:cl-mcp/src/worker-client
+                #:*retired-leaked-thread-reason*)
   (:import-from #:cl-mcp/src/test-runner-core
                 #:coerce-timeout-seconds)
   (:import-from #:cl-mcp/src/utils/sanitize
@@ -163,12 +165,25 @@ When crash details are provided, they are included for diagnostics."
          (ht (make-ht)))
     (setf (gethash "content" ht)
             (text-content
-             (format nil "Worker process crashed~@[ (~A)~] and was restarted. ~
-                          All Lisp state (loaded systems, defined ~
-                          functions, package state) has been reset. ~
-                          Please run load-system again to restore ~
-                          your environment."
-                     detail))
+             (if (equal reason *retired-leaked-thread-reason*)
+                 ;; Not a crash, and saying so matters: the user is owed the
+                 ;; connection between an earlier timeout they were told about
+                 ;; and a reset they were not expecting.
+                 (format nil "Worker process was replaced~@[ (~A)~]. An ~
+                              earlier run exceeded its timeout and left a ~
+                              thread that could not be stopped, so the worker ~
+                              was retired rather than serve further requests ~
+                              from it. All Lisp state (loaded systems, ~
+                              defined functions, package state) has been ~
+                              reset. Please run load-system again to restore ~
+                              your environment."
+                         detail)
+                 (format nil "Worker process crashed~@[ (~A)~] and was ~
+                              restarted. All Lisp state (loaded systems, ~
+                              defined functions, package state) has been ~
+                              reset. Please run load-system again to restore ~
+                              your environment."
+                         detail)))
           (gethash "isError" ht) t)
     ht))
 

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -371,6 +371,15 @@ TOCTOU race with concurrent requests for the same session."
                    (error (e)
                      (cond
                        ((typep e worker-crashed-sym)
+                        ;; Delivering the notification here is what settles
+                        ;; the reset this death owes the user, so consume the
+                        ;; flag that records it.  The pool hands an unconsumed
+                        ;; one to the replacement worker instead -- which is
+                        ;; how a death nobody reported, during an internal RPC
+                        ;; the pool makes on its own behalf, still reaches the
+                        ;; user rather than leaving them talking to a fresh
+                        ;; image that has lost their session.
+                        (ignore-errors (funcall %cached-check-and-clear% worker))
                         (let ((reason
                                (ignore-errors
                                  (funcall %cached-worker-crashed-reason% e))))

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -18,7 +18,7 @@
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht #:text-content #:result)
   (:import-from #:cl-mcp/src/log #:log-event)
-  (:import-from #:cl-mcp/src/worker-client
+  (:import-from #:cl-mcp/src/utils/deadline
                 #:*retired-leaked-thread-reason*)
   (:import-from #:cl-mcp/src/test-runner-core
                 #:coerce-timeout-seconds)

--- a/src/tools/pool-status.lisp
+++ b/src/tools/pool-status.lisp
@@ -22,7 +22,11 @@ max_pool_size, warmup_target, and a workers array.
 
 Each entry in the workers array is an object with keys:
 id (integer), session (string or null, truncated to 8 chars),
-tcp_port (integer), pid (integer), state (\"bound\" or \"standby\")."
+tcp_port (integer), pid (integer), state (\"bound\" or \"standby\"),
+leaked_threads (integer): threads a deadline could not stop, as of that
+worker's last answer.  A non-zero count means a run exceeded its timeout and
+could not be interrupted; the worker retires rather than serve its next
+request while one is still running, and the session's state is reset."
   :args ()
   :body
   (let ((info (pool-status-info)))

--- a/src/tools/pool-status.lisp
+++ b/src/tools/pool-status.lisp
@@ -49,10 +49,13 @@ tcp_port (integer), pid (integer), state (\"bound\" or \"standby\")."
                (when (and workers (plusp (length workers)))
                  (format s "~&~%Workers:")
                  (loop for w across workers
-                       do (format s "~&  #~A [~A] pid=~A port=~A~@[ session=~A~]"
+                       do (format s "~&  #~A [~A] pid=~A port=~A~@[ session=~A~]~
+                                     ~[~:;~:* leaked_threads=~D (will be ~
+                                     replaced on its next request)~]"
                                   (gethash "id" w)
                                   (gethash "state" w)
                                   (gethash "pid" w)
                                   (gethash "tcp_port" w)
-                                  (gethash "session" w))))))))
+                                  (gethash "session" w)
+                                  (or (gethash "leaked_threads" w) 0))))))))
     (result id info)))

--- a/src/tools/pool-status.lisp
+++ b/src/tools/pool-status.lisp
@@ -50,8 +50,9 @@ tcp_port (integer), pid (integer), state (\"bound\" or \"standby\")."
                  (format s "~&~%Workers:")
                  (loop for w across workers
                        do (format s "~&  #~A [~A] pid=~A port=~A~@[ session=~A~]~
-                                     ~[~:;~:* leaked_threads=~D (will be ~
-                                     replaced on its next request)~]"
+                                     ~[~:;~:* leaked_threads=~D as of its last ~
+                                     answer; if still running it retires on ~
+                                     its next request~]"
                                   (gethash "id" w)
                                   (gethash "state" w)
                                   (gethash "pid" w)

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -157,7 +157,16 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                    (%wait-until-dead thread *unwind-grace-seconds*))
                  (when (and thread (thread-alive-p thread))
                    (ignore-errors (destroy-thread thread))
-                   (%wait-until-dead thread *destroy-grace-seconds*)))
+                   (%wait-until-dead thread *destroy-grace-seconds*))
+                 ;; Recorded here rather than on the way out, because STOP is
+                 ;; also what the UNWIND-PROTECT cleanup runs.  A nested
+                 ;; deadline unwound by an outer one never reaches its normal
+                 ;; return, and registering only there would let the thread it
+                 ;; could not stop go unrecorded -- leaving the image looking
+                 ;; clean while still carrying it.
+                 (when (and thread (thread-alive-p thread))
+                   (with-lock-held (%leaked-lock%)
+                     (pushnew thread %leaked-threads%))))
                (finish (timed-out leaked)
                  (let ((settled outcome))
                    (cond
@@ -200,17 +209,12 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                      (%wait-until-dead thread timeout-seconds)
                      (let ((timed-out (thread-alive-p thread)))
                        (stop)
-                       (let ((leaked (thread-alive-p thread)))
-                         ;; Recorded, not merely returned: the caller answers
-                         ;; one request and moves on, while the thread it
-                         ;; could not stop outlives every later one.  The
-                         ;; image has to be able to say it is still carrying
-                         ;; it, which is what LEAKED-THREADS answers.
-                         (when leaked
-                           (with-lock-held (%leaked-lock%)
-                             (pushnew thread %leaked-threads%)))
-                         (multiple-value-prog1 (finish timed-out leaked)
-                           (setf answered t))))))
+                       ;; STOP has already recorded the thread if it survived;
+                       ;; the caller is told here so it can say so in its own
+                       ;; result.
+                       (multiple-value-prog1 (finish timed-out
+                                                     (thread-alive-p thread))
+                         (setf answered t)))))
               ;; A non-local exit from the caller -- an outer deadline, a
               ;; kill -- must not leave the run thread executing unnoticed.
               ;; Guarded so the normal path does not pay for a second

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -17,6 +17,8 @@
                 #:with-lock-held)
   (:export #:call-with-deadline-thread
            #:leaked-threads
+           #:*retired-leaked-thread-reason*
+           #:+leaked-thread-exit-code+
            #:forget-leaked-threads
            #:*poll-interval*
            #:*unwind-grace-seconds*
@@ -35,6 +37,26 @@ cleanups, so it is always preferable to DESTROY-THREAD.")
 (defparameter *destroy-grace-seconds* 1.0d0
   "Seconds allowed for DESTROY-THREAD to take effect before the thread is
 reported as leaked.")
+
+(defparameter *retired-leaked-thread-reason* "retired-leaked-thread"
+  "Crash reason for a worker that exited rather than serve a request while
+carrying a thread a deadline could not stop.
+
+It reaches the parent as EOF like any other death, so this is what the reason
+is set to once the parent has established that is what happened.  Callers that
+treat a crash as evidence about something else -- the pool's init monitor,
+which disables runtime initialization when the init owner crashes, and its
+per-session circuit breaker -- check for it rather than blaming an unrelated
+subsystem for a deliberate retirement.")
+
+(defconstant +leaked-thread-exit-code+ 70
+  "Exit code a worker uses when it retires for carrying a leaked thread.
+The parent reads it to tell a deliberate retirement from a crash.
+
+Both of these live here, with the deadline machinery that creates the
+condition, rather than with either half of the worker protocol: the parent and
+the worker are the two ends of this contract and neither can own it without
+the other depending on it.")
 
 (defvar %leaked-threads% ()
   "Threads a deadline could not stop, still running in this image.

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -188,6 +188,14 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                  ;; clean while still carrying it.
                  (when (and thread (thread-alive-p thread))
                    (with-lock-held (%leaked-lock%)
+                     ;; Pruned as well as added, because in this image
+                     ;; nothing else may ever ask.  LEAKED-THREADS prunes,
+                     ;; and the worker calls it on every request -- but the
+                     ;; same deadline machinery runs inline in the parent
+                     ;; when the pool is disabled, where there is no gate to
+                     ;; ask and finished threads would be held forever.
+                     (setf %leaked-threads%
+                           (remove-if-not #'thread-alive-p %leaked-threads%))
                      (pushnew thread %leaked-threads%))))
                (finish (timed-out leaked)
                  (let ((settled outcome))

--- a/src/utils/deadline.lisp
+++ b/src/utils/deadline.lisp
@@ -12,8 +12,12 @@
                 #:make-thread
                 #:thread-alive-p
                 #:destroy-thread
-                #:interrupt-thread)
+                #:interrupt-thread
+                #:make-lock
+                #:with-lock-held)
   (:export #:call-with-deadline-thread
+           #:leaked-threads
+           #:forget-leaked-threads
            #:*poll-interval*
            #:*unwind-grace-seconds*
            #:*destroy-grace-seconds*))
@@ -31,6 +35,37 @@ cleanups, so it is always preferable to DESTROY-THREAD.")
 (defparameter *destroy-grace-seconds* 1.0d0
   "Seconds allowed for DESTROY-THREAD to take effect before the thread is
 reported as leaked.")
+
+(defvar %leaked-threads% ()
+  "Threads a deadline could not stop, still running in this image.
+
+Recorded centrally so every deadline call site contributes without plumbing
+one through, and so the process can ask whether it is still carrying any.  A
+thread stays on this list only while it is alive: LEAKED-THREADS prunes, which
+is what lets a run that was given up on but finished later stop counting
+against the image.")
+
+(defvar %leaked-lock% (make-lock "deadline-leaked-threads")
+  "Protects %LEAKED-THREADS%.  Deadlines can be enforced from several threads
+at once -- one per session in a worker, and nested within a run.")
+
+(defun leaked-threads ()
+  "Return the threads a deadline could not stop that are still running.
+
+Pruned on every call, so a run that was given up on and then finished on its
+own stops being reported.  That is the difference between \"this image was
+compromised at some point\" and \"this image is compromised now\": the first
+would retire a worker that had recovered, and the state a session loses to
+that is the very thing the deadline machinery exists to protect."
+  (with-lock-held (%leaked-lock%)
+    (setf %leaked-threads% (remove-if-not #'thread-alive-p %leaked-threads%))))
+
+(defun forget-leaked-threads ()
+  "Drop the record of leaked threads without stopping them.
+For tests, which need to leak a thread deliberately and then leave the image
+as they found it."
+  (with-lock-held (%leaked-lock%)
+    (setf %leaked-threads% ())))
 
 (defun %wait-until-dead (thread seconds)
   "Poll until THREAD is gone or SECONDS elapse.  Returns true when it is gone."
@@ -165,9 +200,17 @@ called SB-THREAD:ABORT-THREAD, say -- is reported as :ERROR rather than
                      (%wait-until-dead thread timeout-seconds)
                      (let ((timed-out (thread-alive-p thread)))
                        (stop)
-                       (multiple-value-prog1 (finish timed-out
-                                                     (thread-alive-p thread))
-                         (setf answered t)))))
+                       (let ((leaked (thread-alive-p thread)))
+                         ;; Recorded, not merely returned: the caller answers
+                         ;; one request and moves on, while the thread it
+                         ;; could not stop outlives every later one.  The
+                         ;; image has to be able to say it is still carrying
+                         ;; it, which is what LEAKED-THREADS answers.
+                         (when leaked
+                           (with-lock-held (%leaked-lock%)
+                             (pushnew thread %leaked-threads%)))
+                         (multiple-value-prog1 (finish timed-out leaked)
+                           (setf answered t))))))
               ;; A non-local exit from the caller -- an outer deadline, a
               ;; kill -- must not leave the run thread executing unnoticed.
               ;; Guarded so the normal path does not pay for a second

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -18,6 +18,9 @@
   (:import-from #:usocket)
   (:import-from #:yason)
   (:import-from #:cl-mcp/src/utils/random #:generate-random-hex-string)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:*retired-leaked-thread-reason*
+                #:+leaked-thread-exit-code+)
   (:export #:worker
            #:make-worker
            #:spawn-worker
@@ -38,8 +41,6 @@
            #:kill-worker
            #:worker-crashed
            #:worker-crashed-reason
-           #:*retired-leaked-thread-reason*
-           #:+leaked-thread-exit-code+
            #:worker-spawn-failed
            #:+max-json-line-bytes+
            #:%read-line-limited
@@ -100,23 +101,6 @@ Each thread terminates and self-removes after reaping its process.")
   (:report (lambda (c s)
              (format s "Failed to spawn worker: ~A"
                      (worker-spawn-failed-message c)))))
-
-(defconstant +leaked-thread-exit-code+ 70
-  "Exit code a worker uses when it retires for carrying a leaked thread.
-
-Lives here rather than with the worker server that uses it because the parent
-is the other half of the contract: this is what it reads to tell a deliberate
-retirement from a crash, and a worker cannot depend on the parent's side.")
-
-(defparameter *retired-leaked-thread-reason* "retired-leaked-thread"
-  "Crash reason for a worker that exited rather than serve a request while
-carrying a thread a deadline could not stop.
-
-It reaches the parent as EOF like any other death, so this is what the reason
-is set to when the worker's last answer said it was carrying one.  Callers
-that treat a crash as evidence about something else -- %MONITOR-INIT, which
-disables runtime initialization when the init owner crashes -- check for it
-rather than blaming an unrelated subsystem for a deliberate retirement.")
 
 (define-condition worker-rpc-error (error)
   ((code :initarg :code :reader worker-rpc-error-code)
@@ -679,7 +663,7 @@ Returns nothing."
   ;; Timeout of 1 second prevents blocking if something goes wrong.
   (let ((th (worker-stderr-thread worker)))
     (when (and th (bt:thread-alive-p th))
-      (ignore-errors (bt:join-thread th :timeout 1))
+      (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil))
       (when (bt:thread-alive-p th)
         (ignore-errors (bt:destroy-thread th)))
       (setf (worker-stderr-thread worker) nil)))
@@ -740,21 +724,36 @@ Returns nothing."
 (defun %retired-for-leaked-thread-p (worker)
   "True when WORKER's death was a deliberate retirement, not a crash.
 
-Decided on the exit code, which the worker sets on its way out and which is
-the only signal that describes the death itself.  The leaked-thread count from
-its last answer is a fallback: it is a proxy, and a stale one -- a worker can
-report a leak, have the thread finish, and then genuinely die on the next
-call, which the count alone would misread as a retirement and so hide a real
-crash from the callers that draw conclusions from one."
+The exit code decides, in both directions: a worker sets it on its way out,
+and it describes the death itself.  The leaked-thread count from the last
+answer is only consulted when the exit status is not yet knowable, because it
+is a proxy and a stale one -- a worker can report a leak, have the thread
+finish, and then genuinely crash, which the count alone reads as a retirement
+and so hides a real crash from the callers that draw conclusions from one.
+
+The status is not terminal the instant the parent reads EOF: SBCL updates the
+process struct from its SIGCHLD handler, which has not run yet.  Measured, it
+settles within a few tens of milliseconds, so this waits briefly for it rather
+than falling back to the count on essentially every real retirement."
   (let ((process (worker-process-info worker)))
-    (or (ignore-errors
-         (and process
-              (member (sb-ext:process-status process) '(:exited))
-              (eql +leaked-thread-exit-code+
-                   (sb-ext:process-exit-code process))))
-        ;; The process may not have been reaped yet, or may be gone entirely.
-        (and (integerp (worker-leaked-threads worker))
-             (plusp (worker-leaked-threads worker))))))
+    (flet ((terminal-status ()
+             (loop repeat 40
+                   for status = (ignore-errors (sb-ext:process-status process))
+                   when (member status '(:exited :signaled))
+                     return status
+                   do (sleep 0.01))))
+      (let ((status (and process (terminal-status))))
+        (cond
+          ;; Known: the code answers, whichever way it answers.
+          ((eq status :exited)
+           (eql +leaked-thread-exit-code+
+                (ignore-errors (sb-ext:process-exit-code process))))
+          ;; Killed by a signal, so not a retirement -- a retiring worker
+          ;; exits under its own power.
+          ((eq status :signaled) nil)
+          ;; Unknowable: no process, already reaped, or still not settled.
+          (t (and (integerp (worker-leaked-threads worker))
+                  (plusp (worker-leaked-threads worker)))))))))
 
 (defun worker-rpc (worker method params &key timeout)
   "Send a JSON-RPC request to WORKER and return the result hash-table.

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -1044,6 +1044,11 @@ Robust against already-dead processes."
       ;; the flag is what carries that owed notification to the replacement.
       ;; It is cleared by whoever actually delivers it.
       ;;
+      ;; Read in one place: GET-OR-ASSIGN-WORKER, when it finds the killed
+      ;; worker still bound to the session.  That is the cancellation path --
+      ;; RELEASE-SESSION and KILL-SESSION-WORKER unbind before killing, and
+      ;; the pool reads what a crashed worker owed before it gets here.
+      ;;
       ;; Written before the state, behind the same barrier %MARK-WORKER-CRASHED
       ;; uses and for the same reason: the pool reads the two together, under
       ;; a different lock than this one.

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -52,7 +52,8 @@
            #:worker-last-crash-reason
            #:worker-last-exit-status
            #:worker-last-exit-code
-           #:worker-retired-p))
+           #:worker-retired-p
+           #:exit-code-says-retired-p))
 
 (in-package #:cl-mcp/src/worker-client)
 
@@ -178,10 +179,20 @@ Handles both LF and CRLF line endings."
   (request-counter 0 :type integer)
   (stderr-thread nil)
   ;; Count of threads the worker last reported a deadline could not stop.
-  ;; Diagnostic only: the worker retires itself rather than waiting to be
-  ;; told, so nothing in the parent acts on this -- it exists so pool-status
-  ;; can show the condition while it lasts.
+  ;; Shown by pool-status, and load-bearing besides: it is the corroborating
+  ;; witness in %RETIRED-FOR-LEAKED-THREAD-P, without which an exit code any
+  ;; evaluated form can produce would be taken as proof of a retirement.
   (leaked-threads 0 :type integer)
+  ;; Whether this worker's *own* death was a deliberate retirement.  Recorded
+  ;; by whoever classified it -- the RPC that saw the EOF, or the pool's
+  ;; health monitor -- and deliberately not derived on demand from
+  ;; LAST-CRASH-REASON: a replacement worker inherits those crash details from
+  ;; its predecessor so the user can be told why it was replaced, and a
+  ;; healthy worker carrying an inherited reason would answer this question
+  ;; about a death that was not its own.  That answer disables the session's
+  ;; circuit breaker, so it would stay disabled for as long as the session
+  ;; lived, re-inherited by every later replacement.
+  (retired-p nil :type boolean)
   (crash-history-pushed-p nil :type boolean)
   (last-crash-reason nil)
   (last-exit-status nil)
@@ -657,7 +668,13 @@ Returns nothing."
   ;; ordinary crash.  It is also set unconditionally now: it used to be set
   ;; alongside the exit code, inside the branch that needs a process object,
   ;; so a worker without one recorded no reason at all.
-  (setf (worker-last-crash-reason worker) reason)
+  (setf (worker-last-crash-reason worker) reason
+        ;; Recorded as a fact about this worker rather than left to be
+        ;; re-derived from the reason later: the reason is copied onto a
+        ;; replacement worker, and a question asked of the string would
+        ;; then be answered about a death that was not this worker's.
+        (worker-retired-p worker) (equal *retired-leaked-thread-reason*
+                                         reason))
   (setf (worker-state worker) :crashed)
   (setf (worker-needs-reset-notification worker) t)
   ;; Close the stream/socket to prevent stale-response corruption.
@@ -668,13 +685,23 @@ Returns nothing."
       (setf (worker-socket worker) nil
             (worker-stream worker) nil)))
   ;; Wait for the stderr drain thread to finish forwarding remaining
-  ;; log output (including worker.fatal crash messages).  The worker
-  ;; process is dead so the pipe's write end is closed, causing
-  ;; read-line to return NIL and the thread to exit naturally.
-  ;; Timeout of 1 second prevents blocking if something goes wrong.
+  ;; log output (including worker.fatal crash messages).  When the worker
+  ;; process is dead its pipe's write end is closed, so read-line returns
+  ;; NIL and the thread exits on its own; the timeout is there in case
+  ;; something goes wrong.
+  ;;
+  ;; Only worth waiting for when the process is actually gone.  Not every
+  ;; caller here has lost one: "timeout" and "stream-error" abandon a worker
+  ;; that is still running, its pipe still open and its drain thread still
+  ;; blocked on read-line, so the wait would run its full second -- with
+  ;; WORKER-STREAM-LOCK held, which is what KILL-WORKER and a cancellation
+  ;; have to take.
   (let ((th (worker-stderr-thread worker)))
     (when (and th (bt:thread-alive-p th))
-      (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil))
+      (let ((process (worker-process-info worker)))
+        (when (and process
+                   (not (ignore-errors (sb-ext:process-alive-p process))))
+          (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil))))
       (when (bt:thread-alive-p th)
         (ignore-errors (bt:destroy-thread th)))
       (setf (worker-stderr-thread worker) nil)))
@@ -788,24 +815,21 @@ than falling back to the count on essentially every real retirement."
           ;; Unknowable: no process, already reaped, or still not settled.
           (t (%reported-a-leak-p worker)))))))
 
-(defun worker-retired-p (worker)
-  "True when WORKER died by retiring for a leaked thread rather than crashing.
+(defun exit-code-says-retired-p (worker)
+  "True when WORKER's recorded exit code and leak count both say it retired.
 
-The same question as %RETIRED-FOR-LEAKED-THREAD-P, asked of the struct after
-the fact rather than of the process at the moment it stopped answering, and
-answered from whichever witness the asking path has.
+For the path where nothing has classified the death yet: the pool's health
+monitor can reach a dead worker before any RPC has seen the EOF, and there the
+exit code it records on its way past is the only witness there is.
 
-The recorded reason is the better one, and the RPC that saw the EOF publishes
-it.  But the pool's health monitor can reach a dead worker before any RPC
-does, and then nothing has classified it yet; there the exit code the monitor
-records on its way past is the only witness there is -- corroborated by the
-count for the same reason the EOF classifier corroborates it.
-
-Kept here, beside the classifier it has to agree with: the two answering the
-same question differently is how this exclusion has failed before."
-  (or (equal *retired-leaked-thread-reason* (worker-last-crash-reason worker))
-      (and (eql +leaked-thread-exit-code+ (worker-last-exit-code worker))
-           (%reported-a-leak-p worker))))
+Read only by a caller that is looking at a worker's own death, and never as a
+standing property of the worker: a replacement inherits its predecessor's exit
+code along with the rest of the crash details it shows the user.  The count is
+not inherited, which is what keeps that inherited code from answering here --
+but the caller is what keeps the question from being asked about the wrong
+worker in the first place."
+  (and (eql +leaked-thread-exit-code+ (worker-last-exit-code worker))
+       (%reported-a-leak-p worker)))
 
 (defun worker-rpc (worker method params &key timeout)
   "Send a JSON-RPC request to WORKER and return the result hash-table.
@@ -830,8 +854,15 @@ without marking the worker as crashed."
       ;; behind the first RPC used to be told "already-dead", which reads as
       ;; an ordinary crash.  The init monitor is not a rare straggler here: it
       ;; polls the same worker every fraction of a second while a load runs.
+      ;; Only a worker that actually crashed has a reason of its own to
+      ;; report.  One that was killed deliberately, or a replacement still
+      ;; carrying the crash details it inherited to show the user, has
+      ;; nothing to say here -- and reporting the inherited string would
+      ;; describe its predecessor's death as its own, which for "timeout"
+      ;; means telling the user an operation they never ran took too long.
       (error 'worker-crashed :worker worker
-                             :reason (or (worker-last-crash-reason worker)
+                             :reason (or (and (eq :crashed (worker-state worker))
+                                              (worker-last-crash-reason worker))
                                          "already-dead")))
     (let ((id (incf (worker-request-counter worker))))
       (handler-case
@@ -948,7 +979,12 @@ Robust against already-dead processes."
       ;; and the thread exits naturally within the timeout.
       (let ((th (worker-stderr-thread worker)))
         (when (and th (bt:thread-alive-p th))
-          (ignore-errors (bt:join-thread th :timeout 1))
+          ;; BT:JOIN-THREAD takes no :TIMEOUT, so this used to signal a
+          ;; program-error that IGNORE-ERRORS swallowed: the documented wait
+          ;; never happened and the thread was destroyed mid-line, losing the
+          ;; worker's last log output -- which after a SIGKILL is the part
+          ;; that says why.
+          (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil))
           (when (bt:thread-alive-p th)
             (ignore-errors (bt:destroy-thread th)))
           (setf (worker-stderr-thread worker) nil)))

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -51,7 +51,8 @@
            #:signal-worker-terminate
            #:worker-last-crash-reason
            #:worker-last-exit-status
-           #:worker-last-exit-code))
+           #:worker-last-exit-code
+           #:worker-retired-p))
 
 (in-package #:cl-mcp/src/worker-client)
 
@@ -647,6 +648,16 @@ stream to prevent further use, and log the event.
 Process reaping (waitpid) is deferred to a background thread to
 avoid blocking the caller, which typically holds stream-lock.
 Returns nothing."
+  ;; The reason is published first, before the state that makes other threads
+  ;; look for it and before the stream that makes them stop using this worker.
+  ;; Everything downstream reads the two together -- the pool's circuit
+  ;; breaker asks whether a :CRASHED worker retired, and a concurrent RPC
+  ;; blocked on the stream lock asks what killed it -- and publishing the
+  ;; state first left a window in which a deliberate retirement reads as an
+  ;; ordinary crash.  It is also set unconditionally now: it used to be set
+  ;; alongside the exit code, inside the branch that needs a process object,
+  ;; so a worker without one recorded no reason at all.
+  (setf (worker-last-crash-reason worker) reason)
   (setf (worker-state worker) :crashed)
   (setf (worker-needs-reset-notification worker) t)
   ;; Close the stream/socket to prevent stale-response corruption.
@@ -680,8 +691,7 @@ Returns nothing."
           (setf exit-status (string-downcase (symbol-name status)))
           (when (member status '(:exited :signaled))
             (setf exit-code (sb-ext:process-exit-code process)))))
-      (setf (worker-last-crash-reason worker) reason
-            (worker-last-exit-status worker) (or exit-status "unknown")
+      (setf (worker-last-exit-status worker) (or exit-status "unknown")
             (worker-last-exit-code worker) (or exit-code "unknown"))
       ;; Reap the OS process in a background thread to avoid blocking
       ;; the caller.  process-close calls waitpid internally, which
@@ -721,15 +731,37 @@ Returns nothing."
                "exit_code" (or exit-code "unknown")
                "reason" reason)))
 
+(defun %reported-a-leak-p (worker)
+  "True when WORKER's last answer said it was still carrying a leaked thread.
+
+A worker retires on the request *after* the one that leaked, so by the time it
+exits the parent has already been told: the count rides on every response,
+including the one that reported the deadline.  That makes it a witness the
+worker cannot produce by accident."
+  (let ((count (worker-leaked-threads worker)))
+    (and (integerp count) (plusp count))))
+
 (defun %retired-for-leaked-thread-p (worker)
   "True when WORKER's death was a deliberate retirement, not a crash.
 
-The exit code decides, in both directions: a worker sets it on its way out,
-and it describes the death itself.  The leaked-thread count from the last
-answer is only consulted when the exit status is not yet knowable, because it
-is a proxy and a stale one -- a worker can report a leak, have the thread
-finish, and then genuinely crash, which the count alone reads as a retirement
-and so hides a real crash from the callers that draw conclusions from one.
+Two witnesses have to agree, because neither is sound alone.
+
+The exit code describes the death itself, and it is the one that can say a
+death was *not* a retirement: a worker can report a leak, have the thread
+finish, and then genuinely crash, and the count alone reads that as a
+retirement -- hiding a real crash from the callers that draw conclusions from
+one.  But WORKER/EVAL runs whatever the user asks, so any exit code is
+reachable from a REPL: (SB-EXT:EXIT :CODE 70) in an otherwise healthy worker
+would otherwise be reported to that user as an earlier timeout leaving a
+thread behind, and excused from the circuit breaker.
+
+The count is what the exit code cannot be: evidence that this worker was in
+the condition the exit code claims.  It is also all there is to go on when the
+status cannot be read at all.
+
+Where the two cannot both be had the answer is \"crash\", which is the
+direction that loses least: a retirement misfiled as a crash costs a breaker
+tick and an init attribution, exactly as it did before any of this existed.
 
 The status is not terminal the instant the parent reads EOF: SBCL updates the
 process struct from its SIGCHLD handler, which has not run yet.  Measured, it
@@ -744,16 +776,36 @@ than falling back to the count on essentially every real retirement."
                    do (sleep 0.01))))
       (let ((status (and process (terminal-status))))
         (cond
-          ;; Known: the code answers, whichever way it answers.
+          ;; Known: the code answers, whichever way it answers -- but only a
+          ;; worker that had said it was carrying one can retire for it.
           ((eq status :exited)
-           (eql +leaked-thread-exit-code+
-                (ignore-errors (sb-ext:process-exit-code process))))
+           (and (eql +leaked-thread-exit-code+
+                     (ignore-errors (sb-ext:process-exit-code process)))
+                (%reported-a-leak-p worker)))
           ;; Killed by a signal, so not a retirement -- a retiring worker
           ;; exits under its own power.
           ((eq status :signaled) nil)
           ;; Unknowable: no process, already reaped, or still not settled.
-          (t (and (integerp (worker-leaked-threads worker))
-                  (plusp (worker-leaked-threads worker)))))))))
+          (t (%reported-a-leak-p worker)))))))
+
+(defun worker-retired-p (worker)
+  "True when WORKER died by retiring for a leaked thread rather than crashing.
+
+The same question as %RETIRED-FOR-LEAKED-THREAD-P, asked of the struct after
+the fact rather than of the process at the moment it stopped answering, and
+answered from whichever witness the asking path has.
+
+The recorded reason is the better one, and the RPC that saw the EOF publishes
+it.  But the pool's health monitor can reach a dead worker before any RPC
+does, and then nothing has classified it yet; there the exit code the monitor
+records on its way past is the only witness there is -- corroborated by the
+count for the same reason the EOF classifier corroborates it.
+
+Kept here, beside the classifier it has to agree with: the two answering the
+same question differently is how this exclusion has failed before."
+  (or (equal *retired-leaked-thread-reason* (worker-last-crash-reason worker))
+      (and (eql +leaked-thread-exit-code+ (worker-last-exit-code worker))
+           (%reported-a-leak-p worker))))
 
 (defun worker-rpc (worker method params &key timeout)
   "Send a JSON-RPC request to WORKER and return the result hash-table.
@@ -770,7 +822,17 @@ the worker handler (e.g. \"symbol not found\").  These are re-signaled
 without marking the worker as crashed."
   (bt:with-lock-held ((worker-stream-lock worker))
     (unless (worker-stream worker)
-      (error 'worker-crashed :worker worker :reason "already-dead"))
+      ;; Whoever got here first has already worked out what killed this
+      ;; worker; say that, rather than a second and weaker answer.  Callers
+      ;; act on the reason -- the init monitor decides whether to disable
+      ;; initialization for every later worker in the pool, and the proxy
+      ;; decides what to tell the user -- and every one of them that arrives
+      ;; behind the first RPC used to be told "already-dead", which reads as
+      ;; an ordinary crash.  The init monitor is not a rare straggler here: it
+      ;; polls the same worker every fraction of a second while a load runs.
+      (error 'worker-crashed :worker worker
+                             :reason (or (worker-last-crash-reason worker)
+                                         "already-dead")))
     (let ((id (incf (worker-request-counter worker))))
       (handler-case
           (progn

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -1099,7 +1099,15 @@ Robust against already-dead processes."
           ;; never happened and the thread was destroyed mid-line, losing the
           ;; worker's last log output -- which after a SIGKILL is the part
           ;; that says why.
-          (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil))
+          ;;
+          ;; Waited for only once the process is actually gone, as in
+          ;; %MARK-WORKER-CRASHED: the drain thread ends when the pipe's
+          ;; write end closes, so with the process still up there is nothing
+          ;; to wait for.  %REPLENISH-STANDBYS calls this under *POOL-LOCK*,
+          ;; which every session's next request goes through.
+          (when (or (null process)
+                    (not (ignore-errors (sb-ext:process-alive-p process))))
+            (ignore-errors (sb-thread:join-thread th :timeout 1 :default nil)))
           (when (bt:thread-alive-p th)
             (ignore-errors (bt:destroy-thread th)))
           (setf (worker-stderr-thread worker) nil)))

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -53,6 +53,7 @@
            #:worker-last-exit-status
            #:worker-last-exit-code
            #:worker-retired-p
+           #:worker-retirement-recorded
            #:exit-code-says-retired-p))
 
 (in-package #:cl-mcp/src/worker-client)
@@ -192,7 +193,11 @@ Handles both LF and CRLF line endings."
   ;; about a death that was not its own.  That answer disables the session's
   ;; circuit breaker, so it would stay disabled for as long as the session
   ;; lived, re-inherited by every later replacement.
-  (retired-p nil :type boolean)
+  ;;
+  ;; Read through WORKER-RETIRED-P rather than directly: the writer and the
+  ;; readers hold different locks, so the pairing that makes this visible is
+  ;; a barrier rather than a lock.
+  (retirement-recorded nil :type boolean)
   (crash-history-pushed-p nil :type boolean)
   (last-crash-reason nil)
   (last-exit-status nil)
@@ -673,8 +678,15 @@ Returns nothing."
         ;; re-derived from the reason later: the reason is copied onto a
         ;; replacement worker, and a question asked of the string would
         ;; then be answered about a death that was not this worker's.
-        (worker-retired-p worker) (equal *retired-leaked-thread-reason*
-                                         reason))
+        (worker-retirement-recorded worker) (equal
+                                             *retired-leaked-thread-reason*
+                                             reason))
+  ;; The state is the flag that publishes all of the above, and the threads
+  ;; that read it hold a different lock than this one -- so the ordering has
+  ;; to be asked for.  Without it a pool thread can see :CRASHED while still
+  ;; seeing the classification it replaced, and count a retirement against
+  ;; the session's breaker.  WORKER-RETIRED-P pays the reader's half.
+  (sb-thread:barrier (:write))
   (setf (worker-state worker) :crashed)
   (setf (worker-needs-reset-notification worker) t)
   ;; Close the stream/socket to prevent stale-response corruption.
@@ -826,6 +838,27 @@ than falling back to the count on essentially every real retirement."
           ;; retirement one breaker tick, exactly as it did before any of
           ;; this existed.
           (t nil))))))
+
+(defun worker-retired-p (worker)
+  "True when WORKER's own death was recorded as a deliberate retirement.
+
+Reads the slot behind a read barrier, which is the half the reader owes.
+
+The writers publish this under WORKER-STREAM-LOCK, or under the pool's own
+lock; the readers that matter are on the other side of a different one --
+GET-OR-ASSIGN-WORKER asks it about a worker it found :CRASHED while holding
+*POOL-LOCK*, and an RPC blocked behind the stream lock asks what killed the
+worker it was holding.  Two threads that never take the same lock have no
+ordering between them from the locks alone, and on a weakly ordered machine
+-- SBCL runs on several -- a reader can see the :CRASHED that publishes this
+answer without yet seeing the answer.  It would then count a deliberate
+retirement against the session's circuit breaker, which is the failure this
+whole exclusion exists to prevent.
+
+Taking *POOL-LOCK* to close that is not available: the stream lock is held
+across the write, and the pool takes its own lock before the stream lock."
+  (sb-thread:barrier (:read))
+  (worker-retirement-recorded worker))
 
 (defun exit-code-says-retired-p (worker)
   "True when WORKER's recorded exit code and leak count both say it retired.
@@ -979,6 +1012,10 @@ Robust against already-dead processes."
           (ignore-errors (usocket:socket-close socket))
           (setf (worker-socket worker) nil
                 (worker-stream worker) nil)))
+      ;; A kill resets the session's Lisp state exactly as a crash does, and
+      ;; the flag is what carries that owed notification to the replacement.
+      ;; It is cleared by whoever actually delivers it.
+      (setf (worker-needs-reset-notification worker) t)
       (setf (worker-state worker) :dead))
     ;; Terminate the OS process outside the lock (may block up to ~2.2s)
     (when process

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -674,6 +674,23 @@ Returns nothing."
   ;; ordinary crash.  It is also set unconditionally now: it used to be set
   ;; alongside the exit code, inside the branch that needs a process object,
   ;; so a worker without one recorded no reason at all.
+  ;; Read before anything is published, so the whole account of this death
+  ;; is written together.  The pool copies these three onto the replacement
+  ;; worker to explain the reset to the user, and it can read them the
+  ;; instant the state below says there was a death -- so a status recorded
+  ;; afterwards is one the message never gets, and "exit_code=70" is the
+  ;; part that says a retirement was deliberate.
+  (let ((process (worker-process-info worker))
+        (exit-status nil)
+        (exit-code nil))
+    (when process
+      (ignore-errors
+        (let ((status (sb-ext:process-status process)))
+          (setf exit-status (string-downcase (symbol-name status)))
+          (when (member status '(:exited :signaled))
+            (setf exit-code (sb-ext:process-exit-code process))))))
+    (setf (worker-last-exit-status worker) (or exit-status "unknown")
+          (worker-last-exit-code worker) (or exit-code "unknown")))
   (setf (worker-last-crash-reason worker) reason
         ;; Recorded as a fact about this worker rather than left to be
         ;; re-derived from the reason later: the reason is copied onto a
@@ -725,21 +742,14 @@ Returns nothing."
       (when (bt:thread-alive-p th)
         (ignore-errors (bt:destroy-thread th)))
       (setf (worker-stderr-thread worker) nil)))
-  ;; Collect the exit code before reaping.  process-status is
-  ;; non-blocking; if the process already exited (typical for crashes)
-  ;; the exit code is immediately available.
+  ;; Read again for the log line below.  The worker's own record was
+  ;; written above, before the death was published, because a reader can be
+  ;; copying it the moment it is.
   (let ((process (worker-process-info worker))
         (wid (worker-id worker))
-        (exit-code nil)
-        (exit-status nil))
+        (exit-code (worker-last-exit-code worker))
+        (exit-status (worker-last-exit-status worker)))
     (when process
-      (ignore-errors
-        (let ((status (sb-ext:process-status process)))
-          (setf exit-status (string-downcase (symbol-name status)))
-          (when (member status '(:exited :signaled))
-            (setf exit-code (sb-ext:process-exit-code process)))))
-      (setf (worker-last-exit-status worker) (or exit-status "unknown")
-            (worker-last-exit-code worker) (or exit-code "unknown"))
       ;; Reap the OS process in a background thread to avoid blocking
       ;; the caller.  process-close calls waitpid internally, which
       ;; blocks if the worker process is still alive.

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -30,6 +30,7 @@
            #:worker-session-id
            #:worker-id
            #:worker-needs-reset-notification
+           #:worker-leaked-threads
            #:worker-stream-lock
            #:clear-reset-notification
            #:check-and-clear-reset-notification
@@ -167,6 +168,11 @@ Handles both LF and CRLF line endings."
   (session-id nil)
   (request-counter 0 :type integer)
   (stderr-thread nil)
+  ;; Count of threads the worker last reported a deadline could not stop.
+  ;; Diagnostic only: the worker retires itself rather than waiting to be
+  ;; told, so nothing in the parent acts on this -- it exists so pool-status
+  ;; can show the condition while it lasts.
+  (leaked-threads 0 :type integer)
   (crash-history-pushed-p nil :type boolean)
   (last-crash-reason nil)
   (last-exit-status nil)
@@ -439,8 +445,13 @@ corruption."
                    (error 'worker-rpc-error
                           :code (gethash "code" err)
                           :message (gethash "message" err))))
-               ;; Return the result
-               (gethash "result" json)))))
+               ;; Return the result, and alongside it the count of threads the
+               ;; worker says a deadline could not stop.  The worker retires
+               ;; itself before serving another request when it is carrying
+               ;; one, so this exists to make the condition visible in
+               ;; pool-status during the window before that happens.
+               (values (gethash "result" json)
+                       (gethash "leaked_threads" json))))))
     (if timeout
         (sb-ext:with-timeout timeout
           (do-read))
@@ -721,7 +732,14 @@ without marking the worker as crashed."
       (handler-case
           (progn
             (%send-json-rpc (worker-stream worker) id method params)
-            (%read-json-rpc-response (worker-stream worker) id timeout))
+            (multiple-value-bind (result leaked)
+                (%read-json-rpc-response (worker-stream worker) id timeout)
+              ;; Recorded for pool-status.  Nothing here acts on it: the
+              ;; worker retires itself rather than waiting to be told, since
+              ;; only it can see whether the thread is still running now.
+              (setf (worker-leaked-threads worker)
+                    (if (integerp leaked) leaked 0))
+              result))
         (end-of-file ()
           (%mark-worker-crashed worker "eof")
           (error 'worker-crashed :worker worker :reason "eof"))

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -38,6 +38,7 @@
            #:kill-worker
            #:worker-crashed
            #:worker-crashed-reason
+           #:*retired-leaked-thread-reason*
            #:worker-spawn-failed
            #:+max-json-line-bytes+
            #:%read-line-limited
@@ -99,9 +100,24 @@ Each thread terminates and self-removes after reaping its process.")
              (format s "Failed to spawn worker: ~A"
                      (worker-spawn-failed-message c)))))
 
+(defparameter *retired-leaked-thread-reason* "retired-leaked-thread"
+  "Crash reason for a worker that exited rather than serve a request while
+carrying a thread a deadline could not stop.
+
+It reaches the parent as EOF like any other death, so this is what the reason
+is set to when the worker's last answer said it was carrying one.  Callers
+that treat a crash as evidence about something else -- %MONITOR-INIT, which
+disables runtime initialization when the init owner crashes -- check for it
+rather than blaming an unrelated subsystem for a deliberate retirement.")
+
 (define-condition worker-rpc-error (error)
   ((code :initarg :code :reader worker-rpc-error-code)
-   (message :initarg :message :reader worker-rpc-error-message))
+   (message :initarg :message :reader worker-rpc-error-message)
+   ;; Carried on the condition because the count rides the same envelope as
+   ;; the error, and the reader signals before it can return anything.  Its
+   ;; only consumer is WORKER-RPC, which records it before re-signalling.
+   (leaked-threads :initarg :leaked-threads :initform nil
+                   :reader worker-rpc-error-leaked-threads))
   (:report (lambda (c s)
              (format s "JSON-RPC error ~A: ~A"
                      (worker-rpc-error-code c)
@@ -444,7 +460,8 @@ corruption."
                  (when err
                    (error 'worker-rpc-error
                           :code (gethash "code" err)
-                          :message (gethash "message" err))))
+                          :message (gethash "message" err)
+                          :leaked-threads (gethash "leaked_threads" json))))
                ;; Return the result, and alongside it the count of threads the
                ;; worker says a deadline could not stop.  The worker retires
                ;; itself before serving another request when it is carrying
@@ -741,8 +758,18 @@ without marking the worker as crashed."
                     (if (integerp leaked) leaked 0))
               result))
         (end-of-file ()
-          (%mark-worker-crashed worker "eof")
-          (error 'worker-crashed :worker worker :reason "eof"))
+          ;; A worker that retired for carrying a leaked thread exits without
+          ;; answering, which arrives here as EOF like any other death.  The
+          ;; count it reported on its last answer is what tells the two apart,
+          ;; and the distinction matters: %MONITOR-INIT treats a crash by the
+          ;; runtime-init owner as init-attributable and disables
+          ;; initialization for every later worker.  A deliberate retirement
+          ;; is not an init failure.
+          (let ((reason (if (plusp (worker-leaked-threads worker))
+                            *retired-leaked-thread-reason*
+                            "eof")))
+            (%mark-worker-crashed worker reason)
+            (error 'worker-crashed :worker worker :reason reason)))
         (sb-ext:timeout ()
           (%mark-worker-crashed worker "timeout")
           (error 'worker-crashed :worker worker :reason "timeout"))
@@ -751,7 +778,13 @@ without marking the worker as crashed."
           (error 'worker-crashed :worker worker :reason "stream-error"))
         (worker-rpc-error (e)
           ;; Legitimate worker-side error (e.g. "symbol not found").
-          ;; Re-signal without marking the worker as crashed.
+          ;; Re-signal without marking the worker as crashed -- but record the
+          ;; count first: a handler can leak its deadline's thread and then
+          ;; return an error, and updating only on success leaves the parent
+          ;; reporting whatever it last saw, stale in both directions.
+          (let ((leaked (worker-rpc-error-leaked-threads e)))
+            (setf (worker-leaked-threads worker)
+                  (if (integerp leaked) leaked 0)))
           (error e))
         (error (e)
           ;; Protocol error (parse failure, ID mismatch, etc.).

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -54,6 +54,7 @@
            #:worker-last-exit-code
            #:worker-retired-p
            #:worker-retirement-recorded
+           #:worker-owes-reset-p
            #:exit-code-says-retired-p))
 
 (in-package #:cl-mcp/src/worker-client)
@@ -681,14 +682,21 @@ Returns nothing."
         (worker-retirement-recorded worker) (equal
                                              *retired-leaked-thread-reason*
                                              reason))
+  ;; Everything a reader will want to know about this death is written
+  ;; before the state that tells it there was one -- the reset this death
+  ;; owes the user included.  The pool reads the flag in the same breath as
+  ;; the state, and writing it afterwards left a window in which a
+  ;; replacement was made carrying no debt, so the user's session was reset
+  ;; without their being told.
+  (setf (worker-needs-reset-notification worker) t)
   ;; The state is the flag that publishes all of the above, and the threads
   ;; that read it hold a different lock than this one -- so the ordering has
   ;; to be asked for.  Without it a pool thread can see :CRASHED while still
-  ;; seeing the classification it replaced, and count a retirement against
-  ;; the session's breaker.  WORKER-RETIRED-P pays the reader's half.
+  ;; seeing what it replaced, and count a retirement against the session's
+  ;; breaker or drop the reset it owes.  WORKER-RETIRED-P and
+  ;; WORKER-OWES-RESET-P pay the reader's half.
   (sb-thread:barrier (:write))
   (setf (worker-state worker) :crashed)
-  (setf (worker-needs-reset-notification worker) t)
   ;; Close the stream/socket to prevent stale-response corruption.
   ;; The next RPC attempt will see :crashed state before trying I/O.
   (ignore-errors
@@ -860,6 +868,16 @@ across the write, and the pool takes its own lock before the stream lock."
   (sb-thread:barrier (:read))
   (worker-retirement-recorded worker))
 
+(defun worker-owes-reset-p (worker)
+  "True when a state-reset notification for WORKER is owed and undelivered.
+
+Behind the same read barrier as WORKER-RETIRED-P, and for the same reason:
+this is published by the writer's state change under a lock the pool does
+not hold, and a pool thread that saw :CRASHED without seeing this would give
+the replacement no debt -- resetting the user's session silently."
+  (sb-thread:barrier (:read))
+  (worker-needs-reset-notification worker))
+
 (defun exit-code-says-retired-p (worker)
   "True when WORKER's recorded exit code and leak count both say it retired.
 
@@ -1015,7 +1033,12 @@ Robust against already-dead processes."
       ;; A kill resets the session's Lisp state exactly as a crash does, and
       ;; the flag is what carries that owed notification to the replacement.
       ;; It is cleared by whoever actually delivers it.
+      ;;
+      ;; Written before the state, behind the same barrier %MARK-WORKER-CRASHED
+      ;; uses and for the same reason: the pool reads the two together, under
+      ;; a different lock than this one.
       (setf (worker-needs-reset-notification worker) t)
+      (sb-thread:barrier (:write))
       (setf (worker-state worker) :dead))
     ;; Terminate the OS process outside the lock (may block up to ~2.2s)
     (when process

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -39,6 +39,7 @@
            #:worker-crashed
            #:worker-crashed-reason
            #:*retired-leaked-thread-reason*
+           #:+leaked-thread-exit-code+
            #:worker-spawn-failed
            #:+max-json-line-bytes+
            #:%read-line-limited
@@ -99,6 +100,13 @@ Each thread terminates and self-removes after reaping its process.")
   (:report (lambda (c s)
              (format s "Failed to spawn worker: ~A"
                      (worker-spawn-failed-message c)))))
+
+(defconstant +leaked-thread-exit-code+ 70
+  "Exit code a worker uses when it retires for carrying a leaked thread.
+
+Lives here rather than with the worker server that uses it because the parent
+is the other half of the contract: this is what it reads to tell a deliberate
+retirement from a crash, and a worker cannot depend on the parent's side.")
 
 (defparameter *retired-leaked-thread-reason* "retired-leaked-thread"
   "Crash reason for a worker that exited rather than serve a request while
@@ -729,6 +737,25 @@ Returns nothing."
                "exit_code" (or exit-code "unknown")
                "reason" reason)))
 
+(defun %retired-for-leaked-thread-p (worker)
+  "True when WORKER's death was a deliberate retirement, not a crash.
+
+Decided on the exit code, which the worker sets on its way out and which is
+the only signal that describes the death itself.  The leaked-thread count from
+its last answer is a fallback: it is a proxy, and a stale one -- a worker can
+report a leak, have the thread finish, and then genuinely die on the next
+call, which the count alone would misread as a retirement and so hide a real
+crash from the callers that draw conclusions from one."
+  (let ((process (worker-process-info worker)))
+    (or (ignore-errors
+         (and process
+              (member (sb-ext:process-status process) '(:exited))
+              (eql +leaked-thread-exit-code+
+                   (sb-ext:process-exit-code process))))
+        ;; The process may not have been reaped yet, or may be gone entirely.
+        (and (integerp (worker-leaked-threads worker))
+             (plusp (worker-leaked-threads worker))))))
+
 (defun worker-rpc (worker method params &key timeout)
   "Send a JSON-RPC request to WORKER and return the result hash-table.
 TIMEOUT, when non-NIL, is the maximum seconds to wait for a response.
@@ -765,7 +792,7 @@ without marking the worker as crashed."
           ;; runtime-init owner as init-attributable and disables
           ;; initialization for every later worker.  A deliberate retirement
           ;; is not an init failure.
-          (let ((reason (if (plusp (worker-leaked-threads worker))
+          (let ((reason (if (%retired-for-leaked-thread-p worker)
                             *retired-leaked-thread-reason*
                             "eof")))
             (%mark-worker-crashed worker reason)

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -783,12 +783,17 @@ would otherwise be reported to that user as an earlier timeout leaving a
 thread behind, and excused from the circuit breaker.
 
 The count is what the exit code cannot be: evidence that this worker was in
-the condition the exit code claims.  It is also all there is to go on when the
-status cannot be read at all.
+the condition the exit code claims.  It is not proof -- it comes from the
+previous answer, so a worker that reported a leak, had the thread finish, and
+was then told by its user to exit with this very code would still be read as
+retiring.  What it rules out is the accident: an exit 70 from a worker that
+never reported carrying anything.
 
 Where the two cannot both be had the answer is \"crash\", which is the
 direction that loses least: a retirement misfiled as a crash costs a breaker
-tick and an init attribution, exactly as it did before any of this existed.
+tick and an init attribution, exactly as it did before any of this existed,
+where a crash misfiled as a retirement suppresses both for something that
+really was one.
 
 The status is not terminal the instant the parent reads EOF: SBCL updates the
 process struct from its SIGCHLD handler, which has not run yet.  Measured, it
@@ -812,8 +817,15 @@ than falling back to the count on essentially every real retirement."
           ;; Killed by a signal, so not a retirement -- a retiring worker
           ;; exits under its own power.
           ((eq status :signaled) nil)
-          ;; Unknowable: no process, already reaped, or still not settled.
-          (t (%reported-a-leak-p worker)))))))
+          ;; Unknowable: no process, already reaped, or still not settled
+          ;; after the wait.  The count alone would answer here, and it is
+          ;; the witness that can be stale -- a worker that reported a leak,
+          ;; had the thread finish, and then genuinely crashed reads as a
+          ;; retirement, which excuses a real crash from the breaker and
+          ;; from init attribution.  Answering \"crash\" instead costs a
+          ;; retirement one breaker tick, exactly as it did before any of
+          ;; this existed.
+          (t nil))))))
 
 (defun exit-code-says-retired-p (worker)
   "True when WORKER's recorded exit code and leak count both say it retired.
@@ -854,16 +866,32 @@ without marking the worker as crashed."
       ;; behind the first RPC used to be told "already-dead", which reads as
       ;; an ordinary crash.  The init monitor is not a rare straggler here: it
       ;; polls the same worker every fraction of a second while a load runs.
-      ;; Only a worker that actually crashed has a reason of its own to
-      ;; report.  One that was killed deliberately, or a replacement still
-      ;; carrying the crash details it inherited to show the user, has
-      ;; nothing to say here -- and reporting the inherited string would
-      ;; describe its predecessor's death as its own, which for "timeout"
-      ;; means telling the user an operation they never ran took too long.
-      (error 'worker-crashed :worker worker
-                             :reason (or (and (eq :crashed (worker-state worker))
-                                              (worker-last-crash-reason worker))
-                                         "already-dead")))
+      ;; What this worker's own death was, for a caller that arrives after
+      ;; someone else established it.
+      ;;
+      ;; The retirement slot answers whatever the state has since become.
+      ;; The pool kills a crashed worker as part of replacing it, which
+      ;; leaves it :DEAD, and the callers that arrive after that are the ones
+      ;; that most need the answer: the init monitor, still polling the
+      ;; worker it was watching, disables initialization for every later
+      ;; worker in the pool when it reads a crash.  The slot is recorded per
+      ;; worker and never copied to a replacement, so it is safe to trust
+      ;; here in a way the reason string is not.
+      ;;
+      ;; The reason string is trusted only while the worker is :CRASHED,
+      ;; because a replacement carries its predecessor's reason so the user
+      ;; can be told why the session was reset.  Reporting that for a worker
+      ;; killed deliberately would describe someone else's death as this
+      ;; one's -- for "timeout", telling the user an operation they never ran
+      ;; took too long.
+      (error 'worker-crashed
+             :worker worker
+             :reason (cond ((worker-retired-p worker)
+                            *retired-leaked-thread-reason*)
+                           ((eq :crashed (worker-state worker))
+                            (or (worker-last-crash-reason worker)
+                                "already-dead"))
+                           (t "already-dead"))))
     (let ((id (incf (worker-request-counter worker))))
       (handler-case
           (progn

--- a/src/worker-client.lisp
+++ b/src/worker-client.lisp
@@ -795,6 +795,11 @@ A worker retires on the request *after* the one that leaked, so by the time it
 exits the parent has already been told: the count rides on every response,
 including the one that reported the deadline.  That makes it a witness the
 worker cannot produce by accident."
+  ;; Behind the same read barrier as the other two slots this publication
+  ;; writes: it is written under the worker's stream lock and read under the
+  ;; pool's.  A stale read here fails safe -- zero reads as "crash" -- but
+  ;; the three are written together and should be read the same way.
+  (sb-thread:barrier (:read))
   (let ((count (worker-leaked-threads worker)))
     (and (integerp count) (plusp count))))
 
@@ -829,6 +834,13 @@ The status is not terminal the instant the parent reads EOF: SBCL updates the
 process struct from its SIGCHLD handler, which has not run yet.  Measured, it
 settles within a few tens of milliseconds, so this waits briefly for it rather
 than falling back to the count on essentially every real retirement."
+  ;; Asked before anything is waited for.  Every answer below requires it --
+  ;; the exit code is only ever half of one -- and this runs under the
+  ;; worker's stream lock, which KILL-WORKER and a cancellation have to take.
+  ;; A worker that never reported a leak is the overwhelmingly common death,
+  ;; and it used to pay the whole wait to be told what a struct read knew.
+  (unless (%reported-a-leak-p worker)
+    (return-from %retired-for-leaked-thread-p nil))
   (let ((process (worker-process-info worker)))
     (flet ((terminal-status ()
              (loop repeat 40

--- a/src/worker/server.lisp
+++ b/src/worker/server.lisp
@@ -77,12 +77,6 @@ that returns a hash-table to be used as the JSON-RPC result."
   "Encode OBJ as a single-line JSON string."
   (with-output-to-string (s) (yason:encode obj s)))
 
-(defconstant +leaked-thread-exit-code+ 70
-  "Exit code a worker uses when it retires for carrying a leaked thread.
-Distinct from a crash so the parent's recorded exit status tells the two
-apart in the logs; the parent treats both the same way, by replacing the
-worker.")
-
 (defparameter *retire-action*
   (lambda (leaked)
     (declare (ignore leaked))
@@ -94,11 +88,24 @@ Called with the list of them.  Indirected so the decision to retire can be
 tested without taking the test process down: exiting is the behaviour under
 test, and a test that could only assert it by dying could not assert it.")
 
+(defparameter *methods-exempt-from-retirement*
+  '("worker/ping" "worker/init-status")
+  "Methods that observe the worker rather than ask it to do anything.
+
+The rule is to retire rather than *serve* a request, and these serve nothing.
+It matters for worker/init-status in particular: the pool polls it every
+fraction of a second while an init runs, so retiring on one would throw away
+a load that can take minutes -- and the poll is how the pool was going to find
+out about the retirement anyway.  Retirement still happens the moment real
+work is asked for.")
+
 (defun %retire-if-carrying-leaked-threads (method)
   "Retire this worker when a deadline left a thread running that is still alive.
 METHOD is logged so the request that found the condition is identifiable.
 Returns normally, and cheaply, when there is nothing to retire for."
-  (let ((leaked (leaked-threads)))
+  (let ((leaked (unless (member method *methods-exempt-from-retirement*
+                                :test #'string=)
+                  (leaked-threads))))
     (when leaked
       (ignore-errors
        (log-event :error "worker.retiring.leaked-threads"
@@ -162,7 +169,19 @@ the shared secret."
               (null (uiop/os:getenv "MCP_WORKER_SECRET")))
     (return-from %dispatch-request
       (%encode-response
-       (%make-error id -32600 "Not authenticated"))))
+       ;; Built without the leaked-thread note.  The retirement gate is
+       ;; deliberately placed after this point, and telling an unauthenticated
+       ;; peer anything about the worker's internal state before it has
+       ;; authenticated would give away before the gate what the gate exists
+       ;; to withhold.
+       (let ((err (make-hash-table :test 'equal))
+             (ht (make-hash-table :test 'equal)))
+         (setf (gethash "code" err) -32600
+               (gethash "message" err) "Not authenticated")
+         (setf (gethash "jsonrpc" ht) "2.0"
+               (gethash "id" ht) id
+               (gethash "error" ht) err)
+         ht))))
   ;; Handle authentication as a built-in method
   (when (string= method "worker/authenticate")
     (let ((expected (uiop/os:getenv "MCP_WORKER_SECRET"))

--- a/src/worker/server.lisp
+++ b/src/worker/server.lisp
@@ -9,7 +9,9 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:import-from #:cl-mcp/src/utils/sanitize #:sanitize-error-message)
-  (:import-from #:cl-mcp/src/utils/deadline #:leaked-threads)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:leaked-threads
+                #:+leaked-thread-exit-code+)
   (:import-from #:cl-mcp/src/worker-client
                 #:%read-line-limited
                 #:+max-json-line-bytes+)
@@ -103,8 +105,9 @@ work is asked for.")
   "Retire this worker when a deadline left a thread running that is still alive.
 METHOD is logged so the request that found the condition is identifiable.
 Returns normally, and cheaply, when there is nothing to retire for."
-  (let ((leaked (unless (member method *methods-exempt-from-retirement*
-                                :test #'string=)
+  (let ((leaked (unless (and (stringp method)
+                             (member method *methods-exempt-from-retirement*
+                                     :test #'string=))
                   (leaked-threads))))
     (when leaked
       (ignore-errors
@@ -120,28 +123,36 @@ Returns normally, and cheaply, when there is nothing to retire for."
       (ignore-errors (finish-output *error-output*))
       (funcall *retire-action* leaked))))
 
-(defun %note-leaked-threads (ht)
+(defun %note-leaked-threads (ht &optional (authenticated t))
   "Add the count of threads this worker could not stop, when there are any.
+
+Withheld from an unauthenticated peer: the retirement gate is placed after the
+auth check on purpose, and telling a peer about this worker's internal state
+before it has authenticated gives away exactly what that placement withholds.
+It has to be a parameter rather than a special case at one call site -- a
+parse error, an invalid request and a failed authentication are all answered
+before or during the gate, and singling out one of them protects nothing.
 
 Reported alongside every response so the parent can show the condition in
 pool-status during the window between a deadline giving up on a thread and the
 next request, which is exactly when someone is likely to be asking what went
 wrong.  Absent from ordinary responses rather than reported as zero, so the
 common case is unchanged on the wire."
-  (let ((leaked (length (leaked-threads))))
-    (when (plusp leaked)
-      (setf (gethash "leaked_threads" ht) leaked)))
+  (when authenticated
+    (let ((leaked (length (leaked-threads))))
+      (when (plusp leaked)
+        (setf (gethash "leaked_threads" ht) leaked))))
   ht)
 
-(defun %make-result (id payload)
+(defun %make-result (id payload &optional (authenticated t))
   "Build a JSON-RPC 2.0 success response hash-table."
   (let ((ht (make-hash-table :test 'equal)))
     (setf (gethash "jsonrpc" ht) "2.0"
           (gethash "id" ht) id
           (gethash "result" ht) payload)
-    (%note-leaked-threads ht)))
+    (%note-leaked-threads ht authenticated)))
 
-(defun %make-error (id code message)
+(defun %make-error (id code message &optional (authenticated t))
   "Build a JSON-RPC 2.0 error response hash-table."
   (let ((err (make-hash-table :test 'equal))
         (ht (make-hash-table :test 'equal)))
@@ -155,7 +166,7 @@ common case is unchanged on the wire."
     ;; on success would keep reporting the count it last saw -- stale in both
     ;; directions, missing a leak that just happened and holding on to one
     ;; that has since ended.
-    (%note-leaked-threads ht)))
+    (%note-leaked-threads ht authenticated)))
 
 (defun %dispatch-request (server id method params)
   "Dispatch a JSON-RPC request to the registered handler.
@@ -165,25 +176,13 @@ the shared secret."
   ;; Auth gate: reject non-authentication requests before handshake.
   ;; Only enforce when MCP_WORKER_SECRET is configured (pool mode).
   (unless (or (worker-server-authenticated-p server)
-              (string= method "worker/authenticate")
+              (equal method "worker/authenticate")
               (null (uiop/os:getenv "MCP_WORKER_SECRET")))
     (return-from %dispatch-request
       (%encode-response
-       ;; Built without the leaked-thread note.  The retirement gate is
-       ;; deliberately placed after this point, and telling an unauthenticated
-       ;; peer anything about the worker's internal state before it has
-       ;; authenticated would give away before the gate what the gate exists
-       ;; to withhold.
-       (let ((err (make-hash-table :test 'equal))
-             (ht (make-hash-table :test 'equal)))
-         (setf (gethash "code" err) -32600
-               (gethash "message" err) "Not authenticated")
-         (setf (gethash "jsonrpc" ht) "2.0"
-               (gethash "id" ht) id
-               (gethash "error" ht) err)
-         ht))))
+       (%make-error id -32600 "Not authenticated" nil))))
   ;; Handle authentication as a built-in method
-  (when (string= method "worker/authenticate")
+  (when (equal method "worker/authenticate")
     (let ((expected (uiop/os:getenv "MCP_WORKER_SECRET"))
            (provided (and params (gethash "secret" params))))
       (cond
@@ -208,7 +207,7 @@ the shared secret."
          (log-event :warn "worker.auth.failed")
          (return-from %dispatch-request
            (%encode-response
-            (%make-error id -32600 "Authentication failed")))))))
+            (%make-error id -32600 "Authentication failed" nil)))))))
   ;; A deadline that could not stop its thread leaves that thread running in
   ;; this image: holding locks it took, mutating the state later work reads,
   ;; and competing for the CPU.  The caller that hit the deadline was answered
@@ -255,11 +254,13 @@ Returns a JSON string response, or NIL for notifications."
                               "error" (princ-to-string e))
                    (return-from %process-line
                      (%encode-response
-                      (%make-error nil -32700 "Parse error")))))))
+                      (%make-error nil -32700 "Parse error"
+                                  (worker-server-authenticated-p server))))))))
       (unless (hash-table-p msg)
         (return-from %process-line
           (%encode-response
-           (%make-error nil -32600 "Invalid Request"))))
+           (%make-error nil -32600 "Invalid Request"
+                        (worker-server-authenticated-p server)))))
       (let ((id (gethash "id" msg))
             (method (gethash "method" msg))
             (params (gethash "params" msg)))
@@ -271,7 +272,8 @@ Returns a JSON string response, or NIL for notifications."
            nil)
           (t
            (%encode-response
-            (%make-error id -32600 "Invalid Request"))))))))
+            (%make-error id -32600 "Invalid Request"
+                         (worker-server-authenticated-p server)))))))))
 
 (defun %handle-connection (server stream)
   "Read JSON-RPC lines from STREAM and write responses until EOF.

--- a/src/worker/server.lisp
+++ b/src/worker/server.lisp
@@ -9,6 +9,7 @@
   (:use #:cl)
   (:import-from #:cl-mcp/src/log #:log-event)
   (:import-from #:cl-mcp/src/utils/sanitize #:sanitize-error-message)
+  (:import-from #:cl-mcp/src/utils/deadline #:leaked-threads)
   (:import-from #:cl-mcp/src/worker-client
                 #:%read-line-limited
                 #:+max-json-line-bytes+)
@@ -76,13 +77,62 @@ that returns a hash-table to be used as the JSON-RPC result."
   "Encode OBJ as a single-line JSON string."
   (with-output-to-string (s) (yason:encode obj s)))
 
+(defconstant +leaked-thread-exit-code+ 70
+  "Exit code a worker uses when it retires for carrying a leaked thread.
+Distinct from a crash so the parent's recorded exit status tells the two
+apart in the logs; the parent treats both the same way, by replacing the
+worker.")
+
+(defparameter *retire-action*
+  (lambda (leaked)
+    (declare (ignore leaked))
+    ;; :ABORT T, because unwinding would run cleanups belonging to the very
+    ;; threads this is retiring for.
+    (sb-ext:exit :code +leaked-thread-exit-code+ :abort t))
+  "What a worker does when it finds it is carrying a leaked thread.
+Called with the list of them.  Indirected so the decision to retire can be
+tested without taking the test process down: exiting is the behaviour under
+test, and a test that could only assert it by dying could not assert it.")
+
+(defun %retire-if-carrying-leaked-threads (method)
+  "Retire this worker when a deadline left a thread running that is still alive.
+METHOD is logged so the request that found the condition is identifiable.
+Returns normally, and cheaply, when there is nothing to retire for."
+  (let ((leaked (leaked-threads)))
+    (when leaked
+      (ignore-errors
+       (log-event :error "worker.retiring.leaked-threads"
+                  "method" method
+                  "threads" (length leaked)
+                  "names" (format nil "~{~A~^,~}"
+                                  (mapcar (lambda (thread)
+                                            (or (ignore-errors
+                                                 (bt:thread-name thread))
+                                                "unnamed"))
+                                          leaked))))
+      (ignore-errors (finish-output *error-output*))
+      (funcall *retire-action* leaked))))
+
+(defun %note-leaked-threads (ht)
+  "Add the count of threads this worker could not stop, when there are any.
+
+Reported alongside every response so the parent can show the condition in
+pool-status during the window between a deadline giving up on a thread and the
+next request, which is exactly when someone is likely to be asking what went
+wrong.  Absent from ordinary responses rather than reported as zero, so the
+common case is unchanged on the wire."
+  (let ((leaked (length (leaked-threads))))
+    (when (plusp leaked)
+      (setf (gethash "leaked_threads" ht) leaked)))
+  ht)
+
 (defun %make-result (id payload)
   "Build a JSON-RPC 2.0 success response hash-table."
   (let ((ht (make-hash-table :test 'equal)))
     (setf (gethash "jsonrpc" ht) "2.0"
           (gethash "id" ht) id
           (gethash "result" ht) payload)
-    ht))
+    (%note-leaked-threads ht)))
 
 (defun %make-error (id code message)
   "Build a JSON-RPC 2.0 error response hash-table."
@@ -135,6 +185,21 @@ the shared secret."
          (return-from %dispatch-request
            (%encode-response
             (%make-error id -32600 "Authentication failed")))))))
+  ;; A deadline that could not stop its thread leaves that thread running in
+  ;; this image: holding locks it took, mutating the state later work reads,
+  ;; and competing for the CPU.  The caller that hit the deadline was answered
+  ;; and told so; every request after it would be served by a process that is
+  ;; quietly wrong.  Retire before serving one.
+  ;;
+  ;; Checked here rather than remembered from when it happened, because the
+  ;; thread may since have finished on its own -- LEAKED-THREADS prunes -- and
+  ;; a worker that recovered should keep the session state it still holds.
+  ;;
+  ;; Exiting rather than answering with an error: the parent's crash handling
+  ;; already replaces a worker that stops answering and tells the caller its
+  ;; state was reset, whereas an error would leave this image in the pool to
+  ;; fail the same way on every later request.  See *RETIRE-ACTION*.
+  (%retire-if-carrying-leaked-threads method)
   ;; Normal dispatch for authenticated connections
   (let ((handler (gethash method (worker-server-methods server))))
     (if (null handler)

--- a/src/worker/server.lisp
+++ b/src/worker/server.lisp
@@ -143,7 +143,12 @@ common case is unchanged on the wire."
     (setf (gethash "jsonrpc" ht) "2.0"
           (gethash "id" ht) id
           (gethash "error" ht) err)
-    ht))
+    ;; Noted on failures as well as successes.  A handler can leak its
+    ;; deadline's thread and then return an error, and a parent updating only
+    ;; on success would keep reporting the count it last saw -- stale in both
+    ;; directions, missing a leak that just happened and holding on to one
+    ;; that has since ended.
+    (%note-leaked-threads ht)))
 
 (defun %dispatch-request (server id method params)
   "Dispatch a JSON-RPC request to the registered handler.

--- a/tests.lisp
+++ b/tests.lisp
@@ -49,6 +49,7 @@
   (:import-from #:cl-mcp/tests/system-loader-test)
   (:import-from #:cl-mcp/tests/worker-test)
   (:import-from #:cl-mcp/tests/worker-init-hook-test)
+  (:import-from #:cl-mcp/tests/worker-leaked-thread-test)
   (:import-from #:cl-mcp/tests/pool-test)
   (:import-from #:cl-mcp/tests/pool-startup-latency-test)
   (:import-from #:cl-mcp/tests/pool-env-config-test)

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -1139,6 +1139,88 @@ next call learns why the session was reset")
       (ok (zerop (hash-table-count cl-mcp/src/pool::*owed-resets*))
           "nothing survives to greet a later session"))))
 
+(deftest an-owed-reset-is-not-handed-out-where-none-is-owed
+  ;; Every other assertion about the debt is that it arrives.  These are the
+  ;; other half: it does not arrive where nothing is owed, it is not
+  ;; recorded a second time once someone has delivered it, and the first
+  ;; debt is the one the session keeps.  Each of these was a mutation the
+  ;; suite could not tell from the real thing.
+  (testing "a session with nothing owed gets a worker that says nothing"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let ((worker (cl-mcp/src/pool:get-or-assign-worker "no-debt-session")))
+        (ok (not (cl-mcp/src/worker-client:worker-needs-reset-notification
+                  worker))
+            "or every session's first call would open with a crash report")
+        (ok (null (cl-mcp/src/worker-client:worker-last-crash-reason worker))
+            "and it has no death to describe"))))
+  (testing "the request that met the death is not made to report it twice"
+    ;; The proxy reports a death it met mid-request and settles the debt.
+    ;; The pool meeting the same worker afterwards -- this is the common
+    ;; path, a user's request finding its crashed worker still bound --
+    ;; must not record it as owed again.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "no-debt-already-told")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed worker "eof")
+        (ok (cl-mcp/src/worker-client:check-and-clear-reset-notification
+             worker)
+            "the request that met it reports the death")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (not (eq worker replacement)))
+          (ok (not (cl-mcp/src/worker-client:worker-needs-reset-notification
+                    replacement))
+              "so the replacement does not report it again")))))
+  (testing "the debt a session already has is the one it keeps"
+    ;; Two deaths can be left with a session before either is delivered.
+    ;; The first is what the user has been waiting to hear about; the second
+    ;; is a worker they never got to use.
+    (let ((cl-mcp/src/pool::*owed-resets* (make-hash-table :test 'equal)))
+      (cl-mcp/src/pool::%leave-owed-reset "two-deaths" (list "first" "e" 1))
+      (cl-mcp/src/pool::%leave-owed-reset "two-deaths" (list "second" "e" 2))
+      (ok (equal "first"
+                 (first (gethash "two-deaths" cl-mcp/src/pool::*owed-resets*))))))
+  (testing "a replacement's inherited exit code does not vote on its own death"
+    ;; A replacement carries its predecessor's exit code to explain the
+    ;; reset.  If it then leaks a thread itself and dies where the status
+    ;; cannot be read, that inherited 70 plus its own count would read as a
+    ;; retirement -- a real crash excused from the breaker and from init
+    ;; attribution, which is the failure the whole per-worker classification
+    ;; exists to prevent.
+    (let ((worker (cl-mcp/src/worker-client::make-worker
+                   :state :bound :leaked-threads 1)))
+      (setf (cl-mcp/src/worker-client:worker-last-exit-code worker)
+            cl-mcp/src/utils/deadline::+leaked-thread-exit-code+
+            (cl-mcp/src/worker-client:worker-last-exit-status worker) "exited")
+      (ok (not (cl-mcp/src/pool::%record-worker-death worker nil nil))
+          "nothing this worker left says it retired")
+      (ok (equal "unknown"
+                 (cl-mcp/src/worker-client:worker-last-exit-code worker))
+          "and the inherited code is not kept as its own")))
+  (testing "a recovery whose own replacement fails leaves the debt behind"
+    ;; The spawn inside crash recovery, rather than the one in
+    ;; get-or-assign-worker: a different handler, and the only thing
+    ;; standing between a failed recovery and a session reset in silence.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "recovery-spawn-fails")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (sb-posix:kill (cl-mcp/src/worker-client:worker-pid worker)
+                       sb-posix:sigkill)
+        (sleep 0.5)
+        (let ((cl-mcp/src/worker-client::*worker-startup-timeout* 0.01))
+          (cl-mcp/src/pool::%handle-worker-crash worker))
+        (ok (gethash session cl-mcp/src/pool::*owed-resets*)
+            "the debt outlives the recovery that could not finish")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "and reaches the next worker the session gets"))))))
+
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"
     ;; The exemption exists so an init-status poll -- sent every fraction of a

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -879,7 +879,22 @@ next call learns why the session was reset")
           (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                      (cl-mcp/src/worker-client:worker-last-crash-reason
                       replacement))
-              "explained by what actually happened"))))))
+              "explained by what actually happened")
+          ;; The whole account travels, not just the headline.  The exit
+          ;; code is the part that says the death was deliberate, and it is
+          ;; recorded by the same write that publishes the death, so a
+          ;; reader copying the debt cannot catch it half-written.
+          (ok (eql cl-mcp/src/utils/deadline::+leaked-thread-exit-code+
+                   (cl-mcp/src/worker-client:worker-last-exit-code
+                    replacement))
+              "down to the exit code it left")
+          (ok (equal "exited"
+                     (cl-mcp/src/worker-client:worker-last-exit-status
+                      replacement)))
+          ;; And the session is no longer owed anything: it is on a worker
+          ;; that someone can find, so a copy left here would arrive twice.
+          (ok (null (gethash session cl-mcp/src/pool::*owed-resets*))
+              "the session's copy is dropped once the worker carries it"))))))
 
 (deftest an-owed-reset-outlives-the-worker-that-owed-it
   ;; The debt belongs to the session, because the paths that throw a dead
@@ -907,6 +922,69 @@ next call learns why the session was reset")
                      (cl-mcp/src/worker-client:worker-last-crash-reason
                       replacement))
               "with what to say about it")))))
+  (testing "a warm standby takes it on just as a fresh spawn does"
+    ;; The two ways a session gets its next worker are different code, and
+    ;; every other test here has an empty standby list, so this one is
+    ;; exercised by nothing.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-standby")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session))
+             (standby (cl-mcp/src/worker-client:spawn-worker)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+          (push standby cl-mcp/src/pool::*standby-workers*)
+          (push standby cl-mcp/src/pool::*all-workers*))
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (eq standby replacement) "the standby is what gets assigned")
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "and it carries the reset")
+          (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                     (cl-mcp/src/worker-client:worker-last-crash-reason
+                      replacement))
+              "with what to say about it")
+          (ok (null (gethash session cl-mcp/src/pool::*owed-resets*))
+              "and the session's copy is dropped once it is bound")))))
+  (testing "the circuit breaker halting recovery does not swallow it"
+    ;; The breaker gives up on recovery and returns, clearing the history as
+    ;; it goes -- so the session is served again on the next request, by a
+    ;; fresh image.  That request is exactly the one that has to be told.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (let ((cl-mcp/src/pool::*crash-breaker-threshold* 1))
+      (with-pool ()
+        (let* ((session "owed-reset-breaker")
+               (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+          (sb-posix:kill (cl-mcp/src/worker-client:worker-pid worker)
+                         sb-posix:sigkill)
+          (sleep 0.5)
+          (cl-mcp/src/pool::%handle-worker-crash worker)
+          (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+            (ok (not (eq worker replacement)))
+            (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+                 replacement)
+                "the session is told, even though recovery gave up"))))))
+  (testing "and a released session leaves none behind for the next one"
+    ;; A debt can outlive the affinity entry -- recovery drops the worker
+    ;; and only then is the session released -- and a session id can come
+    ;; back.  Left behind, it greets whoever reuses the id with a crash that
+    ;; was not theirs.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-released")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (cl-mcp/src/pool::%handle-worker-crash worker)
+        (ok (gethash session cl-mcp/src/pool::*owed-resets*)
+            "the debt is waiting with no worker to hold it")
+        (cl-mcp/src/pool:release-session session)
+        (ok (null (gethash session cl-mcp/src/pool::*owed-resets*))
+            "and goes when the session it belonged to does"))))
   (testing "a replacement that cannot be spawned does not consume it"
     ;; The debt used to live in one call's local variable, so a spawn that
     ;; failed took it with it and the retry came back silently fresh.
@@ -1045,6 +1123,21 @@ next call learns why the session was reset")
                   "a request with no method"
                   (cl-mcp/src/worker/server::%process-line
                    server "{\"id\": 1}"))
+                 ;; And the other direction: once authenticated, the same
+                 ;; routes do report it.  Withholding it from everyone would
+                 ;; pass every assertion above while hiding the condition
+                 ;; from pool-status and from the parent that acts on it.
+                 (setf (cl-mcp/src/worker/server::worker-server-authenticated-p
+                        server)
+                       t)
+                 (let ((json (yason:parse
+                              (cl-mcp/src/worker/server::%process-line
+                               server "{"))))
+                   (ok (eql 1 (gethash "leaked_threads" json))
+                       "an authenticated peer is told, even on a parse error"))
+                 (setf (cl-mcp/src/worker/server::worker-server-authenticated-p
+                        server)
+                       nil)
                  (withholds-p
                   "a failed authentication"
                   (cl-mcp/src/worker/server::%dispatch-request

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -179,7 +179,26 @@ running -- the condition the worker retires for."
                                     :name (format nil "leak-driver-~D" i)))))
         (mapc (lambda (th) (bt:join-thread th)) drivers)
         (ok (= 4 (length (leaked-threads)))
-            "every thread that could not be stopped is on the record")))))
+            "every thread that could not be stopped is on the record"))))
+  (testing "and the record is pruned as it is written, not only as it is read"
+    ;; LEAKED-THREADS prunes, and the worker calls it on every request.  The
+    ;; same deadline machinery runs inline in the parent when the pool is
+    ;; disabled, where nothing ever asks -- so a record only pruned on read
+    ;; holds every finished thread for the life of the process.  Read
+    ;; through the raw list, because reading it the usual way would prune it
+    ;; and prove nothing.
+    (with-clean-leak-record
+      (let ((first (nth-value 1 (leak-one-thread))))
+        ;; Ended without asking the record anything -- RELEASE-PROBE-THREADS
+        ;; and LEAK-ONE-THREAD both read it, and reading is what prunes, so
+        ;; either would do the work under test and prove nothing.
+        (setf *probe-release* t)
+        (loop repeat 200 while (bt:thread-alive-p first) do (sleep 0.02))
+        (setf *probe-release* nil)
+        (call-with-deadline-thread #'unstoppable-probe 0.3
+                                   :name "leak-probe-second")
+        (ok (= 1 (length cl-mcp/src/utils/deadline::%leaked-threads%))
+            "the thread that finished is gone without anyone asking")))))
 
 (deftest worker-retires-rather-than-serve-a-request-while-carrying-one
   ;; Driven through %DISPATCH-REQUEST, the function a real request goes
@@ -693,6 +712,32 @@ parent waited long enough for the status to settle to read it"))
       (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                  (cl-mcp/src/worker-client:worker-last-crash-reason worker))
           "with the reason the user is shown intact")))
+  (testing "nor the exit details it read while the process was still there"
+    ;; The reaper closes the process out from under the pool, so its second
+    ;; look often reads nothing at all.  What the RPC read has to survive
+    ;; that: the exit code is what tells the user the death was deliberate,
+    ;; and it is the pool's only witness if it has to classify again.
+    (let* ((process (sb-ext:run-program
+                     "/bin/sh"
+                     (list "-c"
+                           (format nil "exit ~D"
+                                   cl-mcp/src/utils/deadline::+leaked-thread-exit-code+))
+                     :wait t :search nil))
+           (worker (cl-mcp/src/worker-client::make-worker
+                    :state :bound :leaked-threads 1 :process-info process)))
+      (cl-mcp/src/worker-client::%mark-worker-crashed
+       worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+      (ok (eql cl-mcp/src/utils/deadline::+leaked-thread-exit-code+
+               (cl-mcp/src/worker-client:worker-last-exit-code worker))
+          "the RPC recorded what the worker left")
+      ;; The pool's second look, with nothing of its own to read.
+      (cl-mcp/src/pool::%record-worker-death worker nil nil
+                                             :already-classified t)
+      (ok (eql cl-mcp/src/utils/deadline::+leaked-thread-exit-code+
+               (cl-mcp/src/worker-client:worker-last-exit-code worker))
+          "and it is still there to explain the reset")
+      (ok (equal "exited"
+                 (cl-mcp/src/worker-client:worker-last-exit-status worker)))))
   (testing "and neither does a reason the RPC that met the death recorded"
     ;; The pool's own RPCs die on timeouts, and it only ever knows that a
     ;; process is gone.  "process-died" tells the user less than the

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -1,0 +1,122 @@
+;;;; tests/worker-leaked-thread-test.lisp
+;;;;
+;;;; A deadline that cannot stop its thread leaves that thread running in the
+;;;; worker: holding locks it took, mutating state later work reads, competing
+;;;; for the CPU.  The caller that hit the deadline is told; every request
+;;;; after it would be served by a process that is quietly wrong.  These cover
+;;;; the record of such threads, its pruning, and the worker retiring on it.
+
+(defpackage #:cl-mcp/tests/worker-leaked-thread-test
+  (:use #:cl)
+  (:import-from #:rove
+                #:deftest #:testing #:ok)
+  (:import-from #:cl-mcp/src/utils/deadline
+                #:call-with-deadline-thread
+                #:leaked-threads
+                #:forget-leaked-threads)
+  ;; Named without importing: the worker server's side of this is internal, so
+  ;; the tests reach it with ::, but the dependency still has to be declared
+  ;; for the package-inferred system to load it.
+  (:import-from #:cl-mcp/src/worker/server))
+
+(in-package #:cl-mcp/tests/worker-leaked-thread-test)
+
+(defmacro with-clean-leak-record (&body body)
+  "Run BODY with the leak record empty, and leave it empty.
+Deliberately leaking a thread is the only way to test any of this, and the
+record is image-wide."
+  `(unwind-protect (progn (forget-leaked-threads) ,@body)
+     (forget-leaked-threads)))
+
+(defun leak-one-thread ()
+  "Run a deadline against a thread that cannot be stopped.
+Returns two values: whether the deadline said so, and the thread itself, taken
+from the record rather than from the deadline -- which reports only that a
+thread was left behind, not which one.
+
+SB-SYS:WITHOUT-INTERRUPTS defers both the cooperative unwind and
+DESTROY-THREAD, which is what being unstoppable actually looks like.  The
+thread ends on its own shortly after, so the image is not left carrying it."
+  (let ((reported (nth-value 2 (call-with-deadline-thread
+                                (lambda ()
+                                  (sb-sys:without-interrupts (sleep 3))
+                                  :finished)
+                                0.3))))
+    (values reported (first (leaked-threads)))))
+
+(deftest leaked-threads-records-what-a-deadline-could-not-stop
+  (testing "a run the deadline gave up on is recorded, not merely reported"
+    ;; The caller that hit the deadline is answered and moves on; the thread
+    ;; outlives every later request, so the image has to be able to say it is
+    ;; still carrying it.
+    (with-clean-leak-record
+      (ok (leak-one-thread) "the deadline reports the leak to its caller")
+      (ok (= 1 (length (leaked-threads)))
+          "and the image records it")))
+  (testing "a run stopped at its deadline is not recorded"
+    (with-clean-leak-record
+      (call-with-deadline-thread (lambda () (sleep 30) :done) 0.3)
+      (ok (null (leaked-threads))
+          "an interruptible run leaves nothing behind")))
+  (testing "a run that finished is not recorded"
+    (with-clean-leak-record
+      (call-with-deadline-thread (lambda () :done) 5)
+      (ok (null (leaked-threads))))))
+
+(deftest leaked-threads-stops-reporting-a-thread-that-finished
+  (testing "the record prunes, so a worker that recovered is not retired"
+    ;; This is the whole reason the check is made at the moment of use rather
+    ;; than remembered from when it happened.  The thread below cannot be
+    ;; stopped, but it ends on its own -- and a worker that ends up carrying
+    ;; nothing should keep the session state it still holds rather than be
+    ;; replaced for a condition that has passed.
+    (with-clean-leak-record
+      (let ((thread (nth-value 1 (leak-one-thread))))
+        (ok (= 1 (length (leaked-threads))) "recorded while it runs")
+        (loop repeat 100
+              while (bt:thread-alive-p thread)
+              do (sleep 0.1))
+        (ok (not (bt:thread-alive-p thread)) "the thread finished on its own")
+        (ok (null (leaked-threads))
+            "and stops being counted against the image")))))
+
+(deftest worker-retires-rather-than-serve-a-request-while-carrying-one
+  (testing "a request arriving while a thread is still running retires the worker"
+    ;; Retiring means exiting: the parent's crash handling then replaces the
+    ;; worker and tells the caller its state was reset, whereas answering with
+    ;; an error would leave this image in the pool to fail the same way on
+    ;; every later request.  The action is indirected so the decision can be
+    ;; asserted without taking this process down with it.
+    (with-clean-leak-record
+      (leak-one-thread)
+      (let* ((retired nil)
+             (cl-mcp/src/worker/server::*retire-action*
+               (lambda (leaked) (setf retired (length leaked)))))
+        (cl-mcp/src/worker/server::%retire-if-carrying-leaked-threads
+         "worker/eval")
+        (ok (eql 1 retired)
+            "the worker retires, and is told what for"))))
+  (testing "a worker carrying nothing serves the request"
+    (with-clean-leak-record
+      (let* ((retired nil)
+             (cl-mcp/src/worker/server::*retire-action*
+               (lambda (leaked) (declare (ignore leaked)) (setf retired t))))
+        (cl-mcp/src/worker/server::%retire-if-carrying-leaked-threads
+         "worker/eval")
+        (ok (null retired) "no retirement when there is nothing to retire for")))))
+
+(deftest leaked-threads-are-reported-to-the-parent
+  (testing "a response carries the count so pool-status can show it"
+    ;; The worker retires before serving another request, so this is what
+    ;; makes the condition visible in the window between the deadline giving
+    ;; up and that next request -- which is when someone is likely to be
+    ;; asking what went wrong.
+    (with-clean-leak-record
+      (leak-one-thread)
+      (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
+        (ok (eql 1 (gethash "leaked_threads" ht))))))
+  (testing "and ordinary responses are unchanged on the wire"
+    (with-clean-leak-record
+      (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
+        (ok (null (nth-value 1 (gethash "leaked_threads" ht)))
+            "the key is absent rather than reported as zero")))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -17,6 +17,13 @@
   (:import-from #:cl-mcp/tests/test-helpers
                 #:spawn-available-p
                 #:with-pool)
+  (:import-from #:cl-mcp/src/tools/registry
+                #:get-tool-handler)
+  ;; Named for the dependency alone: the tool registers itself when its file
+  ;; is loaded, and the registry is empty without it.
+  (:import-from #:cl-mcp/src/tools/pool-status)
+  (:import-from #:cl-mcp/src/state
+                #:make-state)
   ;; Named without importing: the worker server's side of this is internal, so
   ;; the tests reach it with ::, but the dependency still has to be declared
   ;; for the package-inferred system to load it.
@@ -318,13 +325,18 @@ running -- the condition the worker retires for."
   ;; version of this guard was inert -- the reader it called was not imported
   ;; and IGNORE-ERRORS swallowed the undefined-function error -- and shipped
   ;; because no test asked the question.
-  (labels ((dead-worker (&key leaked)
-             ;; No process, so classification falls back to the count the
-             ;; worker last reported, which is the path that runs when the
-             ;; process is gone or not yet reaped.
+  (labels ((dead-worker (&key leaked exit-code)
+             ;; A real process when the exit code matters: the classifier
+             ;; asks SB-EXT for it, and with no process to ask there is
+             ;; nothing to go on and the answer is "crash".
              (cl-mcp/src/worker-client::make-worker
               :state :bound
               :leaked-threads (or leaked 0)
+              :process-info
+              (when exit-code
+                (sb-ext:run-program "/bin/sh"
+                                    (list "-c" (format nil "exit ~D" exit-code))
+                                    :wait nil :search nil))
               :stream (make-two-way-stream (make-string-input-stream "")
                                            (make-broadcast-stream))))
            (reason-of (worker)
@@ -335,12 +347,14 @@ running -- the condition the worker retires for."
                (cl-mcp/src/worker-client:worker-crashed (c)
                  (cl-mcp/src/worker-client:worker-crashed-reason c)))))
     (testing "a worker that died carrying one is reported as retired"
-      (let ((reason (reason-of (dead-worker :leaked 1))))
+      (let ((reason (reason-of (dead-worker :leaked 1 :exit-code 70))))
         (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                    reason)
             (format nil "reason was ~S" reason))))
     (testing "a worker that died carrying nothing is reported as a crash"
-      (ok (equal "eof" (reason-of (dead-worker)))))
+      (ok (equal "eof" (reason-of (dead-worker :exit-code 70))))
+      (ok (equal "eof" (reason-of (dead-worker :leaked 1)))
+          "and so is one with nothing to read an exit code from"))
     (testing "and the pool tells the two apart"
       ;; The predicate the init monitor consults.  Asserted through a real
       ;; WORKER-CRASHED condition, because what broke before was the reader
@@ -435,6 +449,20 @@ initialization pool-wide for")
                (make-condition 'cl-mcp/src/worker-client:worker-crashed
                                :worker worker :reason reason))
               "and the exclusion that reads it recognizes what it gets"))))
+    (testing "and still reads it after the worker has been killed and reaped"
+      ;; The pool kills a crashed worker as part of replacing it, which
+      ;; leaves it :DEAD.  The callers that arrive after that are the ones
+      ;; that most need the answer -- the init monitor is still polling the
+      ;; worker it was watching, and reads a crash there as init's fault for
+      ;; every later worker in the pool.
+      (let ((worker (dead-worker :leaked 1)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (setf (cl-mcp/src/worker-client::worker-stream worker) nil
+              (cl-mcp/src/worker-client:worker-state worker) :dead)
+        (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                   (reason-of worker))
+            "a retirement is still reported as one once the worker is :dead")))
     (testing "but a worker that did not crash reports no reason of its own"
       ;; A replacement carries the details of the death that produced it,
       ;; and one killed deliberately -- pool-kill-worker, a cancellation,
@@ -470,10 +498,78 @@ initialization pool-wide for")
              (ok (< (/ (- (get-internal-real-time) start)
                        internal-time-units-per-second)
                     0.5)
-                 "it returns without serving out the join timeout"))
+                 "it returns without serving out the join timeout")
+             ;; Not waiting is not the same as not cleaning up: the thread
+             ;; still has to be stopped and the slot cleared, or the worker
+             ;; leaves a thread of its own behind on every timeout.
+             ;; Polled: DESTROY-THREAD asks the thread to die rather than
+             ;; killing it where it stands, so reading the flag immediately
+             ;; is a race with the scheduler, not a test of anything.
+             (ok (loop repeat 100
+                       thereis (not (bt:thread-alive-p drain))
+                       do (sleep 0.02))
+                 "the drain thread is stopped rather than left running")
+             (ok (null (cl-mcp/src/worker-client::worker-stderr-thread worker))
+                 "and the slot no longer points at it"))
         (ignore-errors (bt:destroy-thread drain))
         (ignore-errors (sb-ext:process-kill process 9))
         (ignore-errors (sb-ext:process-wait process))))))
+
+(deftest killing-a-worker-lets-its-last-words-through
+  ;; KILL-WORKER closes the worker's pipe by killing it, so the drain thread
+  ;; ends on its own with whatever the worker said last -- after a SIGKILL,
+  ;; the part that says why.  The wait for it was written as
+  ;; (BT:JOIN-THREAD th :timeout 1), which that function does not accept, so
+  ;; IGNORE-ERRORS swallowed a program-error and the thread was destroyed
+  ;; mid-line instead.
+  (testing "the drain thread is joined rather than destroyed mid-line"
+    ;; The process is already gone, so KILL-WORKER goes straight to the join
+    ;; rather than spending an unpredictable amount of time on SIGTERM: the
+    ;; wait is what is under test, and it has to be the thing the drain
+    ;; thread outlives.
+    (let* ((finished nil)
+           ;; The process first, and the thread after it: spawning is the
+           ;; slow part here, and a drain thread that finishes during it
+           ;; would look joined whether or not anything waited.
+           (process (sb-ext:run-program "/bin/sh" (list "-c" "exit 0")
+                                        :wait t :search nil))
+           (drain (bt:make-thread (lambda () (sleep 0.5) (setf finished t))
+                                  :name "probe-drain"))
+           (worker (cl-mcp/src/worker-client::make-worker
+                    :state :bound
+                    :process-info process
+                    :stderr-thread drain)))
+      (unwind-protect
+           (progn
+             (cl-mcp/src/worker-client:kill-worker worker)
+             (ok finished "it ran to the end instead of being cut off")
+             (ok (null (cl-mcp/src/worker-client::worker-stderr-thread worker))
+                 "and the slot no longer points at it"))
+        (ignore-errors (bt:destroy-thread drain))))))
+
+(deftest pool-status-shows-a-worker-that-is-carrying-one
+  ;; Between a deadline giving up on a thread and the next request arriving,
+  ;; the worker is still serving and nothing else says so.  pool-status is
+  ;; where someone asking what just went wrong looks, which is the whole
+  ;; reason the count is reported on every response rather than only when
+  ;; the worker finally retires.
+  (testing "the count reaches the tool's data and its summary"
+    (let* ((worker (cl-mcp/src/worker-client::make-worker
+                    :id 99 :state :bound :leaked-threads 2))
+           (cl-mcp/src/pool::*pool-running* t)
+           (cl-mcp/src/pool::*all-workers* (list worker))
+           (cl-mcp/src/pool::*standby-workers* ())
+           (info (cl-mcp/src/pool::pool-worker-info)))
+      (ok (eql 2 (gethash "leaked_threads" (aref info 0)))
+          "the per-worker data carries it")
+      (let* ((response (funcall (get-tool-handler "pool-status")
+                                (make-state) 1 nil))
+             (text (gethash "text"
+                            (aref (gethash "content"
+                                           (gethash "result" response))
+                                  0))))
+        (ok (search "leaked_threads=2" text)
+            "and the summary the user actually reads says so")))))
 
 (deftest a-real-exit-code-decides-over-the-reported-count
   ;; The count is a proxy taken from the worker's *previous* answer.  A worker
@@ -522,15 +618,17 @@ timeout leaving a thread behind, and excused from the circuit breaker"))
       ;; excused from the circuit breaker, and explained to the user as a
       ;; timeout of their own from earlier.
       (ok (not (classify-signaled :leaked 1))))
-    (testing "with no process at all the count is what is left to go on"
-      (ok (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
-           (cl-mcp/src/worker-client::make-worker :state :bound
-                                                  :leaked-threads 1))
-          "reported a leak")
+    (testing "with no exit code to read at all the answer is crash"
+      ;; The count is the witness that can be stale: a worker that reported a
+      ;; leak, had the thread finish, and then genuinely crashed reads as a
+      ;; retirement on the count alone -- excusing a real crash from the
+      ;; breaker and from init attribution.  A retirement misfiled the other
+      ;; way costs one breaker tick, which is what it cost before any of this
+      ;; existed.
       (ok (not (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
                 (cl-mcp/src/worker-client::make-worker :state :bound
-                                                       :leaked-threads 0)))
-          "reported none"))))
+                                                       :leaked-threads 1)))
+          "a reported leak is not on its own a retirement"))))
 
 (deftest a-real-worker-retires-and-the-parent-reads-it-as-a-retirement
   ;; End to end against a real worker process.  Three joints are covered
@@ -638,6 +736,12 @@ retirement, against a threshold of one")
               ;; this session's breaker off for as long as the session lived,
               ;; since every later replacement inherits them again.  A crash
               ;; loop is the thing the breaker exists for.
+              (ok (equal
+                   cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                   (cl-mcp/src/worker-client:worker-last-crash-reason
+                    replacement))
+                  "it carries the reason forward, which is how the user's
+next call learns why the session was reset")
               (ok (not (cl-mcp/src/worker-client::worker-retired-p replacement))
                   "the fresh worker has not retired")
               (sb-posix:kill (cl-mcp/src/worker-client:worker-pid replacement)
@@ -850,4 +954,36 @@ retirement, against a threshold of one")
                    cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
           "a retirement says what actually happened")
       (ok (search "crashed" (text-for "eof"))
-          "and a crash still reads as one"))))
+          "and a crash still reads as one"))
+    ;; The other way the message is delivered, and the one production
+    ;; usually takes: the worker died between requests, the pool replaced it,
+    ;; and the next call gets the one-time notification from the replacement
+    ;; -- which is why the pool copies the dead worker's reason onto it.
+    (flet ((text-after-reset (reason)
+             (let* ((worker (cl-mcp/src/worker-client::make-worker
+                             :state :bound))
+                    (cl-mcp/src/proxy::*current-session-id* "leak-probe-reset")
+                    (cl-mcp/src/proxy::%cached-get-or-assign%
+                      (lambda (session) (declare (ignore session)) worker))
+                    (cl-mcp/src/proxy::%cached-check-and-clear%
+                      (lambda (w) (declare (ignore w)) t))
+                    (cl-mcp/src/proxy::%cached-worker-last-crash-reason%
+                      #'cl-mcp/src/worker-client:worker-last-crash-reason)
+                    (cl-mcp/src/proxy::%cached-worker-last-exit-status%
+                      #'cl-mcp/src/worker-client:worker-last-exit-status)
+                    (cl-mcp/src/proxy::%cached-worker-last-exit-code%
+                      #'cl-mcp/src/worker-client:worker-last-exit-code))
+               (setf (cl-mcp/src/worker-client:worker-last-crash-reason worker)
+                     reason)
+               (gethash "text"
+                        (aref (gethash "content"
+                                       (cl-mcp/src/proxy:proxy-to-worker
+                                        "leak-probe-reset-request"
+                                        "repl-eval" nil))
+                              0)))))
+      (ok (search "left a thread that could not be stopped"
+                  (text-after-reset
+                   cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
+          "the replacement's one-time notification says it too")
+      (ok (search "crashed" (text-after-reset "eof"))
+          "and still reads as a crash when it was one"))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -871,7 +871,78 @@ next call learns why the session was reset")
           (ok (not (eq worker replacement)) "the session gets a new worker")
           (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
                replacement)
-              "which owes the user the notification nobody delivered"))))))
+              "which owes the user the notification nobody delivered")
+          ;; And can say what it was.  The notification is built from the
+          ;; crash details the replacement carries, so handing over the debt
+          ;; without them turns the one message this branch exists to
+          ;; produce back into "your worker crashed".
+          (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                     (cl-mcp/src/worker-client:worker-last-crash-reason
+                      replacement))
+              "explained by what actually happened"))))))
+
+(deftest an-owed-reset-outlives-the-worker-that-owed-it
+  ;; The debt belongs to the session, because the paths that throw a dead
+  ;; worker away do not all have a replacement in hand to give it to.  Each
+  ;; of these lost it, and losing it means the user's next call lands in a
+  ;; fresh image -- systems unloaded, definitions gone -- with nothing said.
+  (testing "recovery that drops the worker without replacing it keeps it"
+    ;; The health monitor reaching a worker another thread has already marked
+    ;; crashed: this arm removes it from the pool and only schedules
+    ;; replenishment, so there is nothing to hand the debt to.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-dropped")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (cl-mcp/src/pool::%handle-worker-crash worker)
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (not (eq worker replacement)))
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "the reset survives the worker it was owed by")
+          (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                     (cl-mcp/src/worker-client:worker-last-crash-reason
+                      replacement))
+              "with what to say about it")))))
+  (testing "a replacement that cannot be spawned does not consume it"
+    ;; The debt used to live in one call's local variable, so a spawn that
+    ;; failed took it with it and the retry came back silently fresh.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-failed-spawn")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        ;; Two ways to fail, because they fail in different places: no room
+        ;; in the pool gives up before the spawn is attempted, while a
+        ;; handshake that times out fails inside it, after the debt has been
+        ;; taken out of the session's hands and put on a worker that is then
+        ;; thrown away.
+        (ok (handler-case
+                (let ((cl-mcp/src/pool:*max-pool-size* 0))
+                  (cl-mcp/src/pool:get-or-assign-worker session)
+                  nil)
+              (error () t))
+            "there is no room to spawn the replacement")
+        (ok (handler-case
+                (let ((cl-mcp/src/worker-client::*worker-startup-timeout*
+                        0.01))
+                  (cl-mcp/src/pool:get-or-assign-worker session)
+                  nil)
+              (error () t))
+            "and then the spawn itself fails")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "the retry still owes the user the reset")
+          (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                     (cl-mcp/src/worker-client:worker-last-crash-reason
+                      replacement))
+              "and still knows why"))))))
 
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -20,6 +20,7 @@
   (:import-from #:cl-mcp/src/worker/server)
   (:import-from #:cl-mcp/src/worker-client)
   (:import-from #:cl-mcp/src/pool)
+  (:import-from #:cl-mcp/src/proxy)
   (:import-from #:yason))
 
 (in-package #:cl-mcp/tests/worker-leaked-thread-test)
@@ -251,7 +252,7 @@ and makes the assertions depend on the runner being fast enough to observe it."
                  (cl-mcp/src/worker-client:worker-crashed-reason c)))))
     (testing "a worker that died carrying one is reported as retired"
       (let ((reason (reason-of (dead-worker :leaked 1))))
-        (ok (equal cl-mcp/src/worker-client::*retired-leaked-thread-reason*
+        (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                    reason)
             (format nil "reason was ~S" reason))))
     (testing "a worker that died carrying nothing is reported as a crash"
@@ -263,7 +264,7 @@ and makes the assertions depend on the runner being fast enough to observe it."
       (let ((retired (make-condition
                       'cl-mcp/src/worker-client:worker-crashed
                       :worker nil
-                      :reason cl-mcp/src/worker-client::*retired-leaked-thread-reason*))
+                      :reason cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
             (crashed (make-condition
                       'cl-mcp/src/worker-client:worker-crashed
                       :worker nil :reason "eof")))
@@ -277,8 +278,135 @@ and makes the assertions depend on the runner being fast enough to observe it."
       (let ((retired (dead-worker))
             (crashed (dead-worker)))
         (setf (cl-mcp/src/worker-client::worker-last-crash-reason retired)
-              cl-mcp/src/worker-client::*retired-leaked-thread-reason*
+              cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
               (cl-mcp/src/worker-client::worker-last-crash-reason crashed)
               "eof")
         (ok (cl-mcp/src/pool::%retired-worker-p retired))
-        (ok (not (cl-mcp/src/pool::%retired-worker-p crashed)))))))
+        (ok (not (cl-mcp/src/pool::%retired-worker-p crashed)))
+        ;; The decision both push sites actually make.  Asserting only
+        ;; %RETIRED-WORKER-P leaves the exclusion deletable from either site
+        ;; without a test noticing.
+        (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p retired))
+            "a retirement is not counted against the session")
+        (ok (cl-mcp/src/pool::%breaker-countable-crash-p crashed)
+            "a real crash still is")
+        ;; One caller has to sample the reason before the surrounding function
+        ;; overwrites it, so the predicate takes it as an argument -- and that
+        ;; path needs its own assertion.
+        (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p
+                  crashed :retired t))
+            "including when the caller had to capture it early")))))
+
+(deftest a-real-exit-code-decides-over-the-reported-count
+  ;; The count is a proxy taken from the worker's *previous* answer.  A worker
+  ;; can report a leak, have the thread finish, and then genuinely crash --
+  ;; and reading the count alone files that as a retirement, which suppresses
+  ;; both the init-failure attribution and the circuit breaker for a real
+  ;; crash.  The exit code describes the death itself, so it decides, in both
+  ;; directions.
+  (labels ((exited-with (code)
+             ;; A real process, because the classification asks SB-EXT for its
+             ;; status and code -- and at the moment the parent sees EOF that
+             ;; status has not settled yet, which is what made the first
+             ;; version of this fall back to the count every time.
+             (sb-ext:run-program "/bin/sh" (list "-c" (format nil "exit ~D" code))
+                                 :wait nil :search nil))
+           (classify (&key code leaked)
+             (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
+              (cl-mcp/src/worker-client::make-worker
+               :state :bound
+               :leaked-threads leaked
+               :process-info (exited-with code)))))
+    (testing "the retirement exit code says retirement, whatever the count"
+      (ok (classify :code 70 :leaked 0)
+          "even with no count, an exit 70 is a retirement"))
+    (testing "any other exit code says crash, whatever the count"
+      (ok (not (classify :code 1 :leaked 1))
+          "a genuine crash is not hidden by a count left over from earlier"))
+    (testing "with no process at all the count is what is left to go on"
+      (ok (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
+           (cl-mcp/src/worker-client::make-worker :state :bound
+                                                  :leaked-threads 1))
+          "reported a leak")
+      (ok (not (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
+                (cl-mcp/src/worker-client::make-worker :state :bound
+                                                       :leaked-threads 0)))
+          "reported none"))))
+
+(deftest retirement-is-visible-where-it-has-to-be
+  (testing "real work retires; only observation is exempt"
+    ;; The exemption exists so an init-status poll -- sent every fraction of a
+    ;; second while a load runs -- cannot throw away that load on a request
+    ;; that asks for nothing.  Putting a working method on that list would
+    ;; produce a worker that carries a leaked thread forever, which is the
+    ;; worst regression this feature can suffer and the cheapest to make.
+    (dolist (method '("worker/eval" "worker/run-tests" "worker/load-system"
+                      "worker/set-project-root"))
+      (ok (not (member method
+                       cl-mcp/src/worker/server::*methods-exempt-from-retirement*
+                       :test #'string=))
+          (format nil "~A retires" method)))
+    (dolist (method '("worker/init-status"))
+      (ok (member method
+                  cl-mcp/src/worker/server::*methods-exempt-from-retirement*
+                  :test #'string=)
+          (format nil "~A does not" method))))
+  (testing "an exempt method is served rather than retiring the worker"
+    (with-clean-leak-record
+      (leak-one-thread)
+      (let* ((served nil)
+             (retired nil)
+             (server (cl-mcp/src/worker/server::%make-worker-server))
+             (cl-mcp/src/worker/server::*retire-action*
+               (lambda (leaked) (declare (ignore leaked)) (setf retired t))))
+        (setf (cl-mcp/src/worker/server::worker-server-authenticated-p server) t)
+        (cl-mcp/src/worker/server:register-method
+         server "worker/init-status"
+         (lambda (params) (declare (ignore params)) (setf served t) "status"))
+        (cl-mcp/src/worker/server::%dispatch-request
+         server 1 "worker/init-status" (make-hash-table :test 'equal))
+        (ok (null retired) "a poll does not retire the worker")
+        (ok served "and is answered"))))
+  (testing "a non-string method cannot take the worker down"
+    ;; The exemption check runs on every authenticated request; reaching
+    ;; STRING= with a non-string would unwind to the worker's toplevel and
+    ;; kill the session on one malformed line.
+    (with-clean-leak-record
+      (let ((server (cl-mcp/src/worker/server::%make-worker-server)))
+        (setf (cl-mcp/src/worker/server::worker-server-authenticated-p server) t)
+        (ok (search "Method not found"
+                    (cl-mcp/src/worker/server::%dispatch-request
+                     server 1 5 (make-hash-table :test 'equal)))
+            "it is answered, not fatal"))))
+  (testing "an unauthenticated peer is told nothing about the worker's state"
+    ;; The retirement gate sits after authentication on purpose; reporting the
+    ;; count before it gives away exactly what that placement withholds.
+    (with-clean-leak-record
+      (leak-one-thread)
+      ;; Driven through %DISPATCH-REQUEST with the gate actually armed, not by
+      ;; calling the builder with NIL by hand: the latter passes even when the
+      ;; call site stops passing it.
+      (let ((had (sb-posix:getenv "MCP_WORKER_SECRET")))
+        (unwind-protect
+             (let ((server (cl-mcp/src/worker/server::%make-worker-server)))
+               (sb-posix:setenv "MCP_WORKER_SECRET" "probe-secret" 1)
+               (let ((json (yason:parse
+                            (cl-mcp/src/worker/server::%dispatch-request
+                             server 1 "worker/eval"
+                             (make-hash-table :test 'equal)))))
+                 (ok (gethash "error" json) "the request is refused")
+                 (ok (null (nth-value 1 (gethash "leaked_threads" json)))
+                     "and says nothing about the worker's internal state")))
+          (if had
+              (sb-posix:setenv "MCP_WORKER_SECRET" had 1)
+              (sb-posix:unsetenv "MCP_WORKER_SECRET"))))))
+  (testing "the user is told a worker was replaced, not that it crashed"
+    (let ((retired (cl-mcp/src/proxy::%crash-notification-result
+                    :reason cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
+          (crashed (cl-mcp/src/proxy::%crash-notification-result :reason "eof")))
+      (flet ((text-of (ht)
+               (gethash "text" (aref (gethash "content" ht) 0))))
+        (ok (search "left a thread that could not be stopped" (text-of retired))
+            "a retirement says what actually happened")
+        (ok (search "crashed" (text-of crashed))
+            "and a crash still reads as one")))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -9,11 +9,14 @@
 (defpackage #:cl-mcp/tests/worker-leaked-thread-test
   (:use #:cl)
   (:import-from #:rove
-                #:deftest #:testing #:ok)
+                #:deftest #:testing #:ok #:skip)
   (:import-from #:cl-mcp/src/utils/deadline
                 #:call-with-deadline-thread
                 #:leaked-threads
                 #:forget-leaked-threads)
+  (:import-from #:cl-mcp/tests/test-helpers
+                #:spawn-available-p
+                #:with-pool)
   ;; Named without importing: the worker server's side of this is internal, so
   ;; the tests reach it with ::, but the dependency still has to be declared
   ;; for the package-inferred system to load it.
@@ -42,34 +45,59 @@ to be cooperative.")
   "Run BODY with the leak record empty, and leave the image as it was found.
 Deliberately leaking a thread is the only way to test any of this, and both
 the record and the thread are image-wide: forgetting the record alone would
-leave a live thread running into whatever runs next."
-  `(unwind-protect (progn (forget-leaked-threads) ,@body)
+leave a live thread running into whatever runs next.
+
+The release flag is cleared on the way in as well as set on the way out: the
+previous block's cleanup left it set, and a probe that starts released is not
+a probe -- it finishes immediately and leaks nothing, which would leave the
+assertions passing for the wrong reason."
+  `(unwind-protect (progn (setf *probe-release* nil)
+                          (forget-leaked-threads)
+                          ,@body)
      (release-probe-threads)
      (forget-leaked-threads)))
 
-(defun leak-one-thread ()
-  "Run a deadline against a thread that cannot be stopped.
-Returns two values: whether the deadline said so, and the thread itself, taken
-from the record rather than from the deadline -- which reports only that a
-thread was left behind, not which one.
+(defun unstoppable-probe ()
+  "Run until released, in a way neither half of the deadline's stop can end.
 
 SB-SYS:WITHOUT-INTERRUPTS defers both the cooperative unwind and
 DESTROY-THREAD, which is what being unstoppable actually looks like.  The
 thread polls *PROBE-RELEASE* rather than sleeping a fixed time so the test can
 end it deliberately: a fixed sleep leaves it running into whatever runs next,
-and makes the assertions depend on the runner being fast enough to observe it."
-  (setf *probe-release* nil)
+and makes the assertions depend on the runner being fast enough to observe
+it."
+  (sb-sys:without-interrupts
+    (let ((stop (+ (get-internal-real-time)
+                   (* 30 internal-time-units-per-second))))
+      (loop until (or *probe-release*
+                      (> (get-internal-real-time) stop))
+            do (sleep 0.02))))
+  :finished)
+
+(defun leak-one-thread (&key (name "leak-probe"))
+  "Run a deadline against a thread that cannot be stopped.
+Returns two values: whether the deadline said so, and the thread itself, taken
+from the record rather than from the deadline -- which reports only that a
+thread was left behind, not which one."
   (let ((reported (nth-value 2 (call-with-deadline-thread
-                                (lambda ()
-                                  (sb-sys:without-interrupts
-                                    (let ((stop (+ (get-internal-real-time)
-                                                   (* 30 internal-time-units-per-second))))
-                                      (loop until (or *probe-release*
-                                                      (> (get-internal-real-time) stop))
-                                            do (sleep 0.02))))
-                                  :finished)
-                                0.3))))
+                                #'unstoppable-probe 0.3 :name name))))
     (values reported (first (leaked-threads)))))
+
+(defun eval-params (code &optional timeout)
+  "Params for a worker/eval request against a real worker process."
+  (let ((ht (make-hash-table :test 'equal)))
+    (setf (gethash "code" ht) code
+          (gethash "package" ht) "CL-USER")
+    (when timeout
+      (setf (gethash "timeout_seconds" ht) timeout))
+    ht))
+
+(defun leaking-params ()
+  "A worker/eval request whose run the worker's own deadline cannot stop.
+SB-SYS:WITHOUT-INTERRUPTS defers both the cooperative unwind and
+DESTROY-THREAD, so the deadline answers its caller and the thread keeps
+running -- the condition the worker retires for."
+  (eval-params "(sb-sys:without-interrupts (sleep 10))" 1))
 
 (deftest leaked-threads-records-what-a-deadline-could-not-stop
   (testing "a run the deadline gave up on is recorded, not merely reported"
@@ -106,6 +134,44 @@ and makes the assertions depend on the runner being fast enough to observe it."
         (ok (not (bt:thread-alive-p thread)) "the thread has finished")
         (ok (null (leaked-threads))
             "and stops being counted against the image")))))
+
+(deftest the-record-is-written-from-cleanups-and-from-several-threads
+  (testing "a deadline unwound by an outer one still records what it left"
+    ;; A run thread can enforce a deadline of its own -- RUN-TESTS inside a
+    ;; REPL-EVAL, say -- and the outer one unwinds the inner before it can
+    ;; return.  Recording on the way out would miss exactly this: the inner
+    ;; call never reaches its own return, so the thread it could not stop
+    ;; would run on with nothing recording it, leaving the image looking
+    ;; clean while still carrying it.  Only the cleanup runs, so that is
+    ;; where the record has to be written.
+    (with-clean-leak-record
+      (call-with-deadline-thread
+       (lambda ()
+         (call-with-deadline-thread #'unstoppable-probe 10
+                                    :name "leak-probe-inner"))
+       0.3 :name "leak-probe-outer")
+      ;; Polled rather than read once: the inner call's stop and the outer's
+      ;; both end around the same moment, and which finishes first is a race
+      ;; the test should not be deciding.  A record that is never written
+      ;; fails here just as surely, only slower.
+      (let ((inner (loop repeat 100
+                         thereis (find "leak-probe-inner" (leaked-threads)
+                                       :key #'bt:thread-name :test #'equal)
+                         do (sleep 0.05))))
+        (ok inner "the unwound call's thread is on the record"))))
+  (testing "deadlines expiring on several threads at once all record"
+    ;; The record is image-wide and written from whichever thread hit its
+    ;; deadline: one per session in a worker, and again from a nested run.
+    ;; An unlocked write keeps the last one and loses the rest, which reads
+    ;; as an image carrying one leaked thread when it is carrying four.
+    (with-clean-leak-record
+      (let ((drivers (loop for i below 4
+                           collect (bt:make-thread
+                                    (lambda () (leak-one-thread))
+                                    :name (format nil "leak-driver-~D" i)))))
+        (mapc (lambda (th) (bt:join-thread th)) drivers)
+        (ok (= 4 (length (leaked-threads)))
+            "every thread that could not be stopped is on the record")))))
 
 (deftest worker-retires-rather-than-serve-a-request-while-carrying-one
   ;; Driven through %DISPATCH-REQUEST, the function a real request goes
@@ -196,8 +262,17 @@ and makes the assertions depend on the runner being fast enough to observe it."
       ;; Updating only on success leaves the parent reporting what it last
       ;; saw, stale in both directions.
       (let ((worker (canned-worker (envelope :error t :leaked 3))))
-        (ignore-errors
-         (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil))
+        ;; The error has to reach the caller, not merely be observed on the
+        ;; way past: recording the count means catching the condition, and a
+        ;; catch that forgets to re-signal turns every worker-side error into
+        ;; a successful NIL result -- "symbol not found" would read as a
+        ;; symbol that was found and evaluated to nothing.
+        (ok (handler-case
+                (progn (cl-mcp/src/worker-client:worker-rpc
+                        worker "worker/probe" nil)
+                       nil)
+              (cl-mcp/src/worker-client:worker-rpc-error () t))
+            "the worker's error is re-signalled to the caller")
         (ok (eql 3 (count-on worker)))))
     (testing "a response without the field clears a count that has passed"
       (let ((worker (canned-worker (envelope))))
@@ -281,21 +356,76 @@ and makes the assertions depend on the runner being fast enough to observe it."
               cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
               (cl-mcp/src/worker-client::worker-last-crash-reason crashed)
               "eof")
-        (ok (cl-mcp/src/pool::%retired-worker-p retired))
-        (ok (not (cl-mcp/src/pool::%retired-worker-p crashed)))
+        (ok (cl-mcp/src/worker-client::worker-retired-p retired))
+        (ok (not (cl-mcp/src/worker-client::worker-retired-p crashed)))
         ;; The decision both push sites actually make.  Asserting only
-        ;; %RETIRED-WORKER-P leaves the exclusion deletable from either site
+        ;; WORKER-RETIRED-P leaves the exclusion deletable from either site
         ;; without a test noticing.
         (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p retired))
             "a retirement is not counted against the session")
         (ok (cl-mcp/src/pool::%breaker-countable-crash-p crashed)
-            "a real crash still is")
-        ;; One caller has to sample the reason before the surrounding function
-        ;; overwrites it, so the predicate takes it as an argument -- and that
-        ;; path needs its own assertion.
-        (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p
-                  crashed :retired t))
-            "including when the caller had to capture it early")))))
+            "a real crash still is"))
+      ;; The health monitor can reach a dead worker before any RPC has seen
+      ;; the EOF, and then nothing has recorded a reason at all.  The exit
+      ;; code is the only witness left on that path -- and on its own it is
+      ;; one a REPL can produce, so it is not taken on its own.
+      (let ((unclassified (dead-worker :leaked 1))
+            (forged (dead-worker :leaked 0)))
+        (setf (cl-mcp/src/worker-client:worker-last-exit-code unclassified) 70
+              (cl-mcp/src/worker-client:worker-last-exit-code forged) 70)
+        (ok (cl-mcp/src/worker-client::worker-retired-p unclassified)
+            "an unclassified death is read from the exit code it left")
+        (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p unclassified))
+            "and is excluded from the breaker on that basis alone")
+        (ok (not (cl-mcp/src/worker-client::worker-retired-p forged))
+            "but a worker that never reported a leak did not retire for one")))))
+
+(deftest the-classification-is-published-for-whoever-asks-next
+  ;; One caller works out what killed a worker; everyone else reads what it
+  ;; recorded.  Those others are not stragglers: the init monitor polls the
+  ;; same worker every fraction of a second while a load runs, and what it
+  ;; reads decides whether initialization is disabled for every later worker
+  ;; in the pool.
+  (labels ((dead-worker (&key leaked)
+             (cl-mcp/src/worker-client::make-worker
+              :state :bound
+              :leaked-threads (or leaked 0)
+              :stream (make-two-way-stream (make-string-input-stream "")
+                                           (make-broadcast-stream))))
+           (reason-of (worker)
+             (handler-case
+                 (progn (cl-mcp/src/worker-client:worker-rpc
+                         worker "worker/probe" nil)
+                        nil)
+               (cl-mcp/src/worker-client:worker-crashed (c)
+                 (cl-mcp/src/worker-client:worker-crashed-reason c)))))
+    (testing "the reason is recorded even when there is no process to ask"
+      ;; It used to be recorded beside the exit code, inside the branch that
+      ;; needs a process object, so a worker without one recorded nothing at
+      ;; all -- and every reader after the first saw an unexplained crash.
+      (let ((worker (dead-worker)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed worker "eof")
+        (ok (equal "eof" (cl-mcp/src/worker-client:worker-last-crash-reason
+                          worker)))))
+    (testing "a caller that arrives after the stream is closed reads it"
+      (let ((worker (dead-worker :leaked 1)))
+        (setf (cl-mcp/src/worker-client::worker-stream worker) nil
+              (cl-mcp/src/worker-client:worker-last-crash-reason worker)
+              cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (let ((reason (reason-of worker)))
+          (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                     reason)
+              "it is told what killed the worker, not that it was already
+dead -- which the init monitor would read as a crash and disable
+initialization pool-wide for")
+          (ok (cl-mcp/src/pool::%retirement-crash-p
+               (make-condition 'cl-mcp/src/worker-client:worker-crashed
+                               :worker worker :reason reason))
+              "and the exclusion that reads it recognizes what it gets"))))
+    (testing "and with nothing recorded it still says something"
+      (let ((worker (dead-worker)))
+        (setf (cl-mcp/src/worker-client::worker-stream worker) nil)
+        (ok (equal "already-dead" (reason-of worker)))))))
 
 (deftest a-real-exit-code-decides-over-the-reported-count
   ;; The count is a proxy taken from the worker's *previous* answer.  A worker
@@ -317,9 +447,14 @@ and makes the assertions depend on the runner being fast enough to observe it."
                :state :bound
                :leaked-threads leaked
                :process-info (exited-with code)))))
-    (testing "the retirement exit code says retirement, whatever the count"
-      (ok (classify :code 70 :leaked 0)
-          "even with no count, an exit 70 is a retirement"))
+    (testing "the exit code and the count have to agree"
+      (ok (classify :code 70 :leaked 1)
+          "a worker that said it was carrying one, and then exited saying so")
+      (ok (not (classify :code 70 :leaked 0))
+          "an exit code on its own is not enough: worker/eval runs whatever
+the user asks, so (sb-ext:exit :code 70) in a healthy worker is one line of
+REPL away -- and it would otherwise be reported to that user as an earlier
+timeout leaving a thread behind, and excused from the circuit breaker"))
     (testing "any other exit code says crash, whatever the count"
       (ok (not (classify :code 1 :leaked 1))
           "a genuine crash is not hidden by a count left over from earlier"))
@@ -332,6 +467,109 @@ and makes the assertions depend on the runner being fast enough to observe it."
                 (cl-mcp/src/worker-client::make-worker :state :bound
                                                        :leaked-threads 0)))
           "reported none"))))
+
+(deftest a-real-worker-retires-and-the-parent-reads-it-as-a-retirement
+  ;; End to end against a real worker process.  Three joints are covered
+  ;; nowhere else: the production *RETIRE-ACTION* -- every other test replaces
+  ;; it, so what it actually does, exit code included, is never run -- the
+  ;; count travelling on a real response, and the parent classifying a real
+  ;; exit through the wait for SBCL's status to settle.
+  (testing "it leaks, says so, retires on the next request, and is read as one"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (let ((worker (cl-mcp/src/worker-client:spawn-worker)))
+      (unwind-protect
+           (progn
+             (handler-case
+                 (cl-mcp/src/worker-client:worker-rpc
+                  worker "worker/eval" (leaking-params))
+               (cl-mcp/src/worker-client:worker-rpc-error () nil))
+             (ok (eql 1 (cl-mcp/src/worker-client::worker-leaked-threads
+                         worker))
+                 "the worker tells the parent it is carrying one")
+             (let ((reason
+                     (handler-case
+                         (progn (cl-mcp/src/worker-client:worker-rpc
+                                 worker "worker/eval" (eval-params "(+ 1 2)"))
+                                nil)
+                       (cl-mcp/src/worker-client:worker-crashed (c)
+                         (cl-mcp/src/worker-client:worker-crashed-reason c)))))
+               (ok (equal
+                    cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                    reason)
+                   (format nil "the next request retires it (reason ~S)"
+                           reason)))
+             (ok (eql cl-mcp/src/utils/deadline::+leaked-thread-exit-code+
+                      (cl-mcp/src/worker-client:worker-last-exit-code worker))
+                 "by exiting with the code the parent classifies on, and the
+parent waited long enough for the status to settle to read it"))
+        (cl-mcp/src/worker-client:kill-worker worker)))))
+
+(deftest a-retirement-is-not-counted-against-the-session-breaker
+  ;; Against a real pool, because what is under test is the two push sites
+  ;; rather than the predicate they call: asking the predicate directly still
+  ;; passes with the call deleted from either site, and a session whose
+  ;; breaker trips is halted -- the failure this exclusion exists to prevent.
+  ;;
+  ;; The threshold is set to one so a single death decides, and the
+  ;; classification is recorded by hand: what the death was is settled
+  ;; elsewhere, and killing a real worker in a way that produces exit 70
+  ;; would be testing the worker again rather than the pool.
+  (testing "neither push site counts a worker that retired"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (let ((cl-mcp/src/pool::*crash-breaker-threshold* 1))
+      (with-pool ()
+        (flet ((kill-and-mark-retired (worker)
+                 (sb-posix:kill (cl-mcp/src/worker-client:worker-pid worker)
+                                sb-posix:sigkill)
+                 (sleep 0.5)
+                 (setf (cl-mcp/src/worker-client:worker-last-crash-reason
+                        worker)
+                       cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)))
+          ;; The health monitor's path: it reaches the dead worker itself and
+          ;; hands it to %HANDLE-WORKER-CRASH.  Retired for real here, and the
+          ;; request that retires it is written straight to the socket so
+          ;; nothing reads the EOF -- which is the state the health monitor
+          ;; finds such a worker in, with no reason recorded by anyone and the
+          ;; exit code the only thing left to go on.
+          (let* ((session "retire-breaker-health-monitor")
+                 (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+            (cl-mcp/src/worker-client:worker-rpc
+             worker "worker/eval" (leaking-params))
+            (cl-mcp/src/worker-client::%send-json-rpc
+             (cl-mcp/src/worker-client::worker-stream worker)
+             99 "worker/eval" (eval-params "(+ 1 2)"))
+            (loop repeat 200
+                  while (ignore-errors
+                         (sb-ext:process-alive-p
+                          (cl-mcp/src/worker-client:worker-process-info worker)))
+                  do (sleep 0.05))
+            (ok (null (cl-mcp/src/worker-client:worker-last-crash-reason
+                       worker))
+                "nothing has classified the death yet")
+            (cl-mcp/src/pool::%handle-worker-crash worker)
+            (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                       (cl-mcp/src/worker-client:worker-last-crash-reason
+                        worker))
+                "the pool classifies it from the exit code it left, and keeps
+that answer rather than flattening it to a generic crash")
+            (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+              (ok (gethash session cl-mcp/src/pool::*affinity-map*)
+                  "the session is recovered rather than halted on its first
+retirement, against a threshold of one")))
+          ;; The other path: the next request finds the crashed worker still
+          ;; in the affinity map and pushes there instead.
+          (let* ((session "retire-breaker-next-request")
+                 (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+            (kill-and-mark-retired worker)
+            (setf (cl-mcp/src/worker-client:worker-state worker) :crashed)
+            (let ((replacement
+                    (handler-case (cl-mcp/src/pool:get-or-assign-worker session)
+                      (error () nil))))
+              (ok replacement "the session is still served after a retirement")
+              (ok (not (eq worker replacement))
+                  "and served by a new worker"))))))))
 
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"
@@ -350,7 +588,17 @@ and makes the assertions depend on the runner being fast enough to observe it."
       (ok (member method
                   cl-mcp/src/worker/server::*methods-exempt-from-retirement*
                   :test #'string=)
-          (format nil "~A does not" method))))
+          (format nil "~A does not" method)))
+    ;; And the list is exactly those two.  Naming four methods that are not
+    ;; on it leaves every method not named free to be added to it --
+    ;; worker/code-find, worker/macroexpand and worker/inspect-object among
+    ;; them -- and each addition is a way for a worker to carry a leaked
+    ;; thread indefinitely while answering requests with it.
+    (ok (null (set-exclusive-or
+               '("worker/ping" "worker/init-status")
+               cl-mcp/src/worker/server::*methods-exempt-from-retirement*
+               :test #'equal))
+        "the exemption list is exactly the methods that ask for nothing"))
   (testing "an exempt method is served rather than retiring the worker"
     (with-clean-leak-record
       (leak-one-thread)
@@ -390,23 +638,80 @@ and makes the assertions depend on the runner being fast enough to observe it."
         (unwind-protect
              (let ((server (cl-mcp/src/worker/server::%make-worker-server)))
                (sb-posix:setenv "MCP_WORKER_SECRET" "probe-secret" 1)
-               (let ((json (yason:parse
-                            (cl-mcp/src/worker/server::%dispatch-request
-                             server 1 "worker/eval"
-                             (make-hash-table :test 'equal)))))
-                 (ok (gethash "error" json) "the request is refused")
-                 (ok (null (nth-value 1 (gethash "leaked_threads" json)))
-                     "and says nothing about the worker's internal state")))
+               (flet ((withholds-p (label json-string)
+                        (let ((json (yason:parse json-string)))
+                          (ok (gethash "error" json)
+                              (format nil "~A is refused" label))
+                          (ok (null (nth-value 1
+                                               (gethash "leaked_threads" json)))
+                              (format nil "~A says nothing about the worker"
+                                      label)))))
+                 ;; Every way a peer can be answered before it has
+                 ;; authenticated, not just the one.  Singling out normal
+                 ;; dispatch protects nothing: a peer that wants the count
+                 ;; can send a malformed line just as easily as a method
+                 ;; name, and each of these is a separate call site that has
+                 ;; to pass the authentication state through.
+                 (withholds-p
+                  "an unauthenticated request"
+                  (cl-mcp/src/worker/server::%dispatch-request
+                   server 1 "worker/eval" (make-hash-table :test 'equal)))
+                 (withholds-p
+                  "a parse error"
+                  (cl-mcp/src/worker/server::%process-line server "{"))
+                 (withholds-p
+                  "a request that is not an object"
+                  (cl-mcp/src/worker/server::%process-line server "[]"))
+                 (withholds-p
+                  "a request with no method"
+                  (cl-mcp/src/worker/server::%process-line
+                   server "{\"id\": 1}"))
+                 (withholds-p
+                  "a failed authentication"
+                  (cl-mcp/src/worker/server::%dispatch-request
+                   server 1 "worker/authenticate"
+                   (let ((ht (make-hash-table :test 'equal)))
+                     (setf (gethash "secret" ht) "wrong")
+                     ht)))))
           (if had
               (sb-posix:setenv "MCP_WORKER_SECRET" had 1)
               (sb-posix:unsetenv "MCP_WORKER_SECRET"))))))
   (testing "the user is told a worker was replaced, not that it crashed"
-    (let ((retired (cl-mcp/src/proxy::%crash-notification-result
-                    :reason cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
-          (crashed (cl-mcp/src/proxy::%crash-notification-result :reason "eof")))
-      (flet ((text-of (ht)
-               (gethash "text" (aref (gethash "content" ht) 0))))
-        (ok (search "left a thread that could not be stopped" (text-of retired))
-            "a retirement says what actually happened")
-        (ok (search "crashed" (text-of crashed))
-            "and a crash still reads as one")))))
+    ;; Driven through PROXY-TO-WORKER, the function a tool call actually
+    ;; reaches, rather than the builder it calls: the builder can be right
+    ;; about every reason while the proxy hands it the wrong one, and then
+    ;; what every user sees is the generic crash text.
+    (flet ((text-for (reason)
+             (let* ((worker (cl-mcp/src/worker-client::make-worker
+                             :state :bound))
+                    (cl-mcp/src/proxy::*current-session-id* "leak-probe-session")
+                    (cl-mcp/src/proxy::%cached-get-or-assign%
+                      (lambda (session) (declare (ignore session)) worker))
+                    (cl-mcp/src/proxy::%cached-check-and-clear%
+                      (lambda (w) (declare (ignore w)) nil))
+                    (cl-mcp/src/proxy::%cached-worker-rpc%
+                      (lambda (w method params &key timeout)
+                        (declare (ignore method params timeout))
+                        (error 'cl-mcp/src/worker-client:worker-crashed
+                               :worker w :reason reason)))
+                    (cl-mcp/src/proxy::%cached-worker-crashed-sym%
+                      'cl-mcp/src/worker-client:worker-crashed)
+                    (cl-mcp/src/proxy::%cached-worker-crashed-reason%
+                      #'cl-mcp/src/worker-client:worker-crashed-reason)
+                    (cl-mcp/src/proxy::%cached-worker-last-crash-reason%
+                      #'cl-mcp/src/worker-client:worker-last-crash-reason)
+                    (cl-mcp/src/proxy::%cached-worker-last-exit-status%
+                      #'cl-mcp/src/worker-client:worker-last-exit-status)
+                    (cl-mcp/src/proxy::%cached-worker-last-exit-code%
+                      #'cl-mcp/src/worker-client:worker-last-exit-code))
+               (gethash "text"
+                        (aref (gethash "content"
+                                       (cl-mcp/src/proxy:proxy-to-worker
+                                        "leak-probe-request" "repl-eval" nil))
+                              0)))))
+      (ok (search "left a thread that could not be stopped"
+                  (text-for
+                   cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
+          "a retirement says what actually happened")
+      (ok (search "crashed" (text-for "eof"))
+          "and a crash still reads as one"))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -544,7 +544,12 @@ initialization pool-wide for")
              (cl-mcp/src/worker-client:kill-worker worker)
              (ok finished "it ran to the end instead of being cut off")
              (ok (null (cl-mcp/src/worker-client::worker-stderr-thread worker))
-                 "and the slot no longer points at it"))
+                 "and the slot no longer points at it")
+             ;; A kill resets the session's state as surely as a crash does,
+             ;; and the flag is how the replacement knows to say so.
+             (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+                  worker)
+                 "the reset it owes the user is recorded"))
         (ignore-errors (bt:destroy-thread drain))))))
 
 (deftest pool-status-shows-a-worker-that-is-carrying-one
@@ -666,6 +671,34 @@ timeout leaving a thread behind, and excused from the circuit breaker"))
                  "by exiting with the code the parent classifies on, and the
 parent waited long enough for the status to settle to read it"))
         (cl-mcp/src/worker-client:kill-worker worker)))))
+
+(deftest a-recorded-retirement-survives-a-second-look
+  ;; Two things classify a death, and the second one sees less.  The RPC that
+  ;; met the EOF reads the exit code while the process is still there; by the
+  ;; time the pool runs over the same worker the reaper may have closed it,
+  ;; leaving the code unreadable -- and killing what it replaces makes the
+  ;; process look signalled rather than exited.  Neither may turn a recorded
+  ;; retirement back into a crash: that would put it in front of the circuit
+  ;; breaker and blame initialization for it.
+  (testing "the pool's own look does not overwrite what the RPC established"
+    (let ((worker (cl-mcp/src/worker-client::make-worker
+                   :state :bound :leaked-threads 1)))
+      (cl-mcp/src/worker-client::%mark-worker-crashed
+       worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+      (ok (cl-mcp/src/pool::%record-worker-death worker "signaled" 9)
+          "it is still a retirement")
+      (ok (cl-mcp/src/worker-client::worker-retired-p worker)
+          "and stays recorded as one")
+      (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
+                 (cl-mcp/src/worker-client:worker-last-crash-reason worker))
+          "with the reason the user is shown intact")))
+  (testing "but a death it has no record of is read from what it can see"
+    (let ((worker (cl-mcp/src/worker-client::make-worker
+                   :state :bound :leaked-threads 1)))
+      (ok (not (cl-mcp/src/pool::%record-worker-death worker "signaled" 9))
+          "a signalled death is not a retirement")
+      (ok (equal "process-died"
+                 (cl-mcp/src/worker-client:worker-last-crash-reason worker))))))
 
 (deftest a-retirement-is-not-counted-against-the-session-breaker
   ;; Against a real pool, because what is under test is the two push sites
@@ -811,6 +844,35 @@ next call learns why the session was reset")
       (ok (init-disabled-after-start "eof")
           "while a real crash there still disables it"))))
 
+(deftest a-retirement-on-the-pools-own-rpc-still-reaches-the-user
+  ;; The pool sends RPCs of its own: the project-root sync after
+  ;; fs-set-project-root, the init monitor's polling.  Their errors are
+  ;; swallowed by design -- they are housekeeping, not the user's request --
+  ;; so when the worker dies on one, nobody has told the user anything.
+  ;;
+  ;; Retirement makes that reachable on purpose rather than by chance: the
+  ;; root sync is a request like any other, so a worker carrying a leaked
+  ;; thread retires on it.  Their next call would otherwise land in a fresh
+  ;; image with their systems unloaded and nothing said about it.
+  (testing "the reset it owes is handed to the replacement"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "retire-on-internal-rpc")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client:worker-rpc
+         worker "worker/eval" (leaking-params))
+        ;; The pool's own RPC, called the way fs-set-project-root calls it.
+        (cl-mcp/src/pool::send-root-to-session-worker
+         session (namestring (uiop:temporary-directory)))
+        (ok (not (eq :bound (cl-mcp/src/worker-client:worker-state worker)))
+            "the worker retired on it")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (not (eq worker replacement)) "the session gets a new worker")
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "which owes the user the notification nobody delivered"))))))
+
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"
     ;; The exemption exists so an init-status poll -- sent every fraction of a
@@ -840,21 +902,27 @@ next call learns why the session was reset")
                :test #'equal))
         "the exemption list is exactly the methods that ask for nothing"))
   (testing "an exempt method is served rather than retiring the worker"
-    (with-clean-leak-record
-      (leak-one-thread)
-      (let* ((served nil)
-             (retired nil)
-             (server (cl-mcp/src/worker/server::%make-worker-server))
-             (cl-mcp/src/worker/server::*retire-action*
-               (lambda (leaked) (declare (ignore leaked)) (setf retired t))))
-        (setf (cl-mcp/src/worker/server::worker-server-authenticated-p server) t)
-        (cl-mcp/src/worker/server:register-method
-         server "worker/init-status"
-         (lambda (params) (declare (ignore params)) (setf served t) "status"))
-        (cl-mcp/src/worker/server::%dispatch-request
-         server 1 "worker/init-status" (make-hash-table :test 'equal))
-        (ok (null retired) "a poll does not retire the worker")
-        (ok served "and is answered"))))
+    ;; Both of them: naming the list is not the same as the dispatcher
+    ;; honouring it, and the entry that is never exercised is the one that
+    ;; quietly stops working.
+    (dolist (method '("worker/init-status" "worker/ping"))
+      (with-clean-leak-record
+        (leak-one-thread)
+        (let* ((served nil)
+               (retired nil)
+               (server (cl-mcp/src/worker/server::%make-worker-server))
+               (cl-mcp/src/worker/server::*retire-action*
+                 (lambda (leaked) (declare (ignore leaked)) (setf retired t))))
+          (setf (cl-mcp/src/worker/server::worker-server-authenticated-p server)
+                t)
+          (cl-mcp/src/worker/server:register-method
+           server method
+           (lambda (params) (declare (ignore params)) (setf served t) "ok"))
+          (cl-mcp/src/worker/server::%dispatch-request
+           server 1 method (make-hash-table :test 'equal))
+          (ok (null retired)
+              (format nil "~A does not retire the worker" method))
+          (ok served (format nil "and ~A is answered" method))))))
   (testing "a non-string method cannot take the worker down"
     ;; The exemption check runs on every authenticated request; reaching
     ;; STRING= with a non-string would unwind to the worker's toplevel and
@@ -986,4 +1054,49 @@ next call learns why the session was reset")
                    cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
           "the replacement's one-time notification says it too")
       (ok (search "crashed" (text-after-reset "eof"))
-          "and still reads as a crash when it was one"))))
+          "and still reads as a crash when it was one"))
+    ;; Delivering the message settles what the death owed the user.  The
+    ;; pool hands an *undelivered* one to the replacement, so a proxy that
+    ;; reports the death without consuming it produces the message twice --
+    ;; and, before the flag meant this, a pool that read it the other way
+    ;; round produced it neither time for a death nobody reported.
+    (let* ((worker (cl-mcp/src/worker-client::make-worker :state :bound))
+           (cl-mcp/src/proxy::*current-session-id* "leak-probe-consume")
+           (cl-mcp/src/proxy::%cached-get-or-assign%
+             (lambda (session) (declare (ignore session)) worker))
+           (cl-mcp/src/proxy::%cached-check-and-clear%
+             #'cl-mcp/src/worker-client:check-and-clear-reset-notification)
+           (cl-mcp/src/proxy::%cached-worker-rpc%
+             (lambda (w method params &key timeout)
+               (declare (ignore method params timeout))
+               ;; What %MARK-WORKER-CRASHED does on its way out.
+               (setf (cl-mcp/src/worker-client:worker-needs-reset-notification
+                      w)
+                     t)
+               (error 'cl-mcp/src/worker-client:worker-crashed
+                      :worker w :reason "eof")))
+           (cl-mcp/src/proxy::%cached-worker-crashed-sym%
+             'cl-mcp/src/worker-client:worker-crashed)
+           (cl-mcp/src/proxy::%cached-worker-crashed-reason%
+             #'cl-mcp/src/worker-client:worker-crashed-reason)
+           (cl-mcp/src/proxy::%cached-worker-last-crash-reason%
+             #'cl-mcp/src/worker-client:worker-last-crash-reason)
+           (cl-mcp/src/proxy::%cached-worker-last-exit-status%
+             #'cl-mcp/src/worker-client:worker-last-exit-status)
+           (cl-mcp/src/proxy::%cached-worker-last-exit-code%
+             #'cl-mcp/src/worker-client:worker-last-exit-code))
+      ;; Bound for PROXY-TO-WORKER to find, not for this body to read: they
+      ;; are the proxy's own cached bindings, and it resolves them itself.
+      (declare (ignorable cl-mcp/src/proxy::%cached-get-or-assign%
+                          cl-mcp/src/proxy::%cached-check-and-clear%
+                          cl-mcp/src/proxy::%cached-worker-rpc%
+                          cl-mcp/src/proxy::%cached-worker-crashed-sym%
+                          cl-mcp/src/proxy::%cached-worker-crashed-reason%
+                          cl-mcp/src/proxy::%cached-worker-last-crash-reason%
+                          cl-mcp/src/proxy::%cached-worker-last-exit-status%
+                          cl-mcp/src/proxy::%cached-worker-last-exit-code%))
+      (cl-mcp/src/proxy:proxy-to-worker "leak-probe-consume-request"
+                                        "repl-eval" nil)
+      (ok (not (cl-mcp/src/worker-client:worker-needs-reset-notification
+                worker))
+          "reporting the death here settles the reset it owed"))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -274,6 +274,15 @@ running -- the condition the worker retires for."
               (cl-mcp/src/worker-client:worker-rpc-error () t))
             "the worker's error is re-signalled to the caller")
         (ok (eql 3 (count-on worker)))))
+    (testing "and with a timeout set, which is what production always sends"
+      ;; The proxy computes a timeout for every call, so the no-timeout path
+      ;; above is the one production never takes.  With one, the response is
+      ;; read inside SB-EXT:WITH-TIMEOUT and the count comes back as a second
+      ;; value through it.
+      (let ((worker (canned-worker (envelope :leaked 4))))
+        (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil
+                                             :timeout 5)
+        (ok (eql 4 (count-on worker)))))
     (testing "a response without the field clears a count that has passed"
       (let ((worker (canned-worker (envelope))))
         (setf (cl-mcp/src/worker-client::worker-leaked-threads worker) 5)
@@ -350,12 +359,14 @@ running -- the condition the worker retires for."
     (testing "a retirement is kept out of the crash breaker too"
       ;; Three uninterruptible timeouts in five minutes would otherwise trip
       ;; the per-session breaker and halt the session.
+      ;; Classified through the function that does the recording, not by
+      ;; setting the slot the pool reads: what a classified death leaves
+      ;; behind is the thing the pool depends on.
       (let ((retired (dead-worker))
             (crashed (dead-worker)))
-        (setf (cl-mcp/src/worker-client::worker-last-crash-reason retired)
-              cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
-              (cl-mcp/src/worker-client::worker-last-crash-reason crashed)
-              "eof")
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         retired cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (cl-mcp/src/worker-client::%mark-worker-crashed crashed "eof")
         (ok (cl-mcp/src/worker-client::worker-retired-p retired))
         (ok (not (cl-mcp/src/worker-client::worker-retired-p crashed)))
         ;; The decision both push sites actually make.  Asserting only
@@ -366,19 +377,21 @@ running -- the condition the worker retires for."
         (ok (cl-mcp/src/pool::%breaker-countable-crash-p crashed)
             "a real crash still is"))
       ;; The health monitor can reach a dead worker before any RPC has seen
-      ;; the EOF, and then nothing has recorded a reason at all.  The exit
-      ;; code is the only witness left on that path -- and on its own it is
-      ;; one a REPL can produce, so it is not taken on its own.
+      ;; the EOF, and then nothing has recorded anything.  The exit code is
+      ;; the only witness left on that path -- and on its own it is one a
+      ;; REPL can produce, so it is not taken on its own.  Which of the two
+      ;; questions the pool asks, and when, is covered against a real pool in
+      ;; A-RETIREMENT-IS-NOT-COUNTED-AGAINST-THE-SESSION-BREAKER.
       (let ((unclassified (dead-worker :leaked 1))
             (forged (dead-worker :leaked 0)))
         (setf (cl-mcp/src/worker-client:worker-last-exit-code unclassified) 70
               (cl-mcp/src/worker-client:worker-last-exit-code forged) 70)
-        (ok (cl-mcp/src/worker-client::worker-retired-p unclassified)
-            "an unclassified death is read from the exit code it left")
-        (ok (not (cl-mcp/src/pool::%breaker-countable-crash-p unclassified))
-            "and is excluded from the breaker on that basis alone")
-        (ok (not (cl-mcp/src/worker-client::worker-retired-p forged))
-            "but a worker that never reported a leak did not retire for one")))))
+        (ok (cl-mcp/src/worker-client::exit-code-says-retired-p unclassified)
+            "an unclassified death can still be read from the code it left")
+        (ok (not (cl-mcp/src/worker-client::worker-retired-p unclassified))
+            "though nothing has recorded that answer yet")
+        (ok (not (cl-mcp/src/worker-client::exit-code-says-retired-p forged))
+            "and a worker that never reported a leak did not retire for one")))))
 
 (deftest the-classification-is-published-for-whoever-asks-next
   ;; One caller works out what killed a worker; everyone else reads what it
@@ -409,9 +422,9 @@ running -- the condition the worker retires for."
                           worker)))))
     (testing "a caller that arrives after the stream is closed reads it"
       (let ((worker (dead-worker :leaked 1)))
-        (setf (cl-mcp/src/worker-client::worker-stream worker) nil
-              (cl-mcp/src/worker-client:worker-last-crash-reason worker)
-              cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (setf (cl-mcp/src/worker-client::worker-stream worker) nil)
         (let ((reason (reason-of worker)))
           (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                      reason)
@@ -422,10 +435,45 @@ initialization pool-wide for")
                (make-condition 'cl-mcp/src/worker-client:worker-crashed
                                :worker worker :reason reason))
               "and the exclusion that reads it recognizes what it gets"))))
-    (testing "and with nothing recorded it still says something"
+    (testing "but a worker that did not crash reports no reason of its own"
+      ;; A replacement carries the details of the death that produced it,
+      ;; and one killed deliberately -- pool-kill-worker, a cancellation,
+      ;; shutdown -- has not crashed at all.  Reporting the carried string
+      ;; would describe someone else's death as this worker's, and for
+      ;; "timeout" the user is then told an operation they never ran took
+      ;; too long.
       (let ((worker (dead-worker)))
-        (setf (cl-mcp/src/worker-client::worker-stream worker) nil)
+        (setf (cl-mcp/src/worker-client::worker-stream worker) nil
+              (cl-mcp/src/worker-client:worker-last-crash-reason worker)
+              "timeout")
         (ok (equal "already-dead" (reason-of worker)))))))
+
+(deftest marking-a-crash-does-not-wait-on-a-worker-that-is-still-running
+  ;; The stderr drain thread ends when the worker's pipe closes, so waiting
+  ;; for it is only meaningful once the process is gone -- and every caller
+  ;; here holds WORKER-STREAM-LOCK, which KILL-WORKER and a cancellation have
+  ;; to take.  "timeout" and "stream-error" abandon a worker that is still
+  ;; running: waiting there would block a cancellation for the full second on
+  ;; the very path a user reaches by asking to cancel something slow.
+  (testing "a still-running worker's drain thread is not waited on"
+    (let* ((process (sb-ext:run-program "/bin/sh" (list "-c" "sleep 30")
+                                        :wait nil :search nil))
+           (drain (bt:make-thread (lambda () (sleep 30)) :name "probe-drain"))
+           (worker (cl-mcp/src/worker-client::make-worker
+                    :state :bound
+                    :process-info process
+                    :stderr-thread drain))
+           (start (get-internal-real-time)))
+      (unwind-protect
+           (progn
+             (cl-mcp/src/worker-client::%mark-worker-crashed worker "timeout")
+             (ok (< (/ (- (get-internal-real-time) start)
+                       internal-time-units-per-second)
+                    0.5)
+                 "it returns without serving out the join timeout"))
+        (ignore-errors (bt:destroy-thread drain))
+        (ignore-errors (sb-ext:process-kill process 9))
+        (ignore-errors (sb-ext:process-wait process))))))
 
 (deftest a-real-exit-code-decides-over-the-reported-count
   ;; The count is a proxy taken from the worker's *previous* answer.  A worker
@@ -441,6 +489,15 @@ initialization pool-wide for")
              ;; version of this fall back to the count every time.
              (sb-ext:run-program "/bin/sh" (list "-c" (format nil "exit ~D" code))
                                  :wait nil :search nil))
+           (classify-signaled (&key leaked)
+             (let ((process (sb-ext:run-program "/bin/sh" (list "-c" "sleep 30")
+                                                :wait nil :search nil)))
+               (sb-ext:process-kill process 9)
+               (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
+                (cl-mcp/src/worker-client::make-worker
+                 :state :bound
+                 :leaked-threads leaked
+                 :process-info process))))
            (classify (&key code leaked)
              (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
               (cl-mcp/src/worker-client::make-worker
@@ -458,6 +515,13 @@ timeout leaving a thread behind, and excused from the circuit breaker"))
     (testing "any other exit code says crash, whatever the count"
       (ok (not (classify :code 1 :leaked 1))
           "a genuine crash is not hidden by a count left over from earlier"))
+    (testing "a worker killed by a signal did not retire"
+      ;; A retiring worker exits under its own power.  Left to the count, a
+      ;; SIGKILL -- the OOM killer, an operator, a segfault -- on a worker
+      ;; that had reported a leak is filed as a deliberate retirement:
+      ;; excused from the circuit breaker, and explained to the user as a
+      ;; timeout of their own from earlier.
+      (ok (not (classify-signaled :leaked 1))))
     (testing "with no process at all the count is what is left to go on"
       (ok (cl-mcp/src/worker-client::%retired-for-leaked-thread-p
            (cl-mcp/src/worker-client::make-worker :state :bound
@@ -520,13 +584,17 @@ parent waited long enough for the status to settle to read it"))
       (skip "worker processes cannot be spawned here"))
     (let ((cl-mcp/src/pool::*crash-breaker-threshold* 1))
       (with-pool ()
-        (flet ((kill-and-mark-retired (worker)
+        (flet ((kill-and-record-retirement (worker)
                  (sb-posix:kill (cl-mcp/src/worker-client:worker-pid worker)
                                 sb-posix:sigkill)
                  (sleep 0.5)
-                 (setf (cl-mcp/src/worker-client:worker-last-crash-reason
-                        worker)
-                       cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)))
+                 ;; Recorded the way the RPC that sees the EOF records it,
+                 ;; rather than by setting the slots the pool reads: what a
+                 ;; classified death leaves behind is part of what is under
+                 ;; test here.
+                 (cl-mcp/src/worker-client::%mark-worker-crashed
+                  worker
+                  cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)))
           ;; The health monitor's path: it reaches the dead worker itself and
           ;; hands it to %HANDLE-WORKER-CRASH.  Retired for real here, and the
           ;; request that retires it is written straight to the socket so
@@ -554,22 +622,90 @@ parent waited long enough for the status to settle to read it"))
                         worker))
                 "the pool classifies it from the exit code it left, and keeps
 that answer rather than flattening it to a generic crash")
-            (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
-              (ok (gethash session cl-mcp/src/pool::*affinity-map*)
+            (ok (cl-mcp/src/worker-client::worker-retired-p worker)
+                "and records it, so a later reader gets the same answer
+without re-deriving it from a string that will be copied elsewhere")
+            (let ((replacement
+                    (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                      (gethash session cl-mcp/src/pool::*affinity-map*))))
+              (ok replacement
                   "the session is recovered rather than halted on its first
-retirement, against a threshold of one")))
+retirement, against a threshold of one")
+              ;; The replacement is handed its predecessor's crash details so
+              ;; the user can be told why the session was reset.  It has not
+              ;; itself retired, and answering otherwise -- by reading those
+              ;; inherited details as its own classification -- would leave
+              ;; this session's breaker off for as long as the session lived,
+              ;; since every later replacement inherits them again.  A crash
+              ;; loop is the thing the breaker exists for.
+              (ok (not (cl-mcp/src/worker-client::worker-retired-p replacement))
+                  "the fresh worker has not retired")
+              (sb-posix:kill (cl-mcp/src/worker-client:worker-pid replacement)
+                             sb-posix:sigkill)
+              (sleep 0.5)
+              (cl-mcp/src/pool::%handle-worker-crash replacement)
+              (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+                (ok (null (gethash session cl-mcp/src/pool::*affinity-map*))
+                    "and its own crash is counted, tripping the breaker"))))
           ;; The other path: the next request finds the crashed worker still
           ;; in the affinity map and pushes there instead.
           (let* ((session "retire-breaker-next-request")
                  (worker (cl-mcp/src/pool:get-or-assign-worker session)))
-            (kill-and-mark-retired worker)
-            (setf (cl-mcp/src/worker-client:worker-state worker) :crashed)
+            (kill-and-record-retirement worker)
             (let ((replacement
                     (handler-case (cl-mcp/src/pool:get-or-assign-worker session)
                       (error () nil))))
               (ok replacement "the session is still served after a retirement")
               (ok (not (eq worker replacement))
                   "and served by a new worker"))))))))
+
+(deftest a-retirement-is-not-an-init-failure
+  ;; The pool runs one worker's initialization as a singleton, and treats a
+  ;; crash by that worker as initialization's fault: it disables init for
+  ;; every later worker in the pool until an operator re-arms it.  A worker
+  ;; that retired did not fail to initialize.
+  ;;
+  ;; This exclusion has the widest blast radius on this branch and had no
+  ;; test of its wiring: deleting it from both handlers left the suite green.
+  ;; Driven through the two functions that hold those handlers rather than
+  ;; through %RETIREMENT-CRASH-P, which is what passed while they were inert.
+  (labels ((dead-worker (reason)
+             (let ((worker (cl-mcp/src/worker-client::make-worker
+                            :state :crashed)))
+               (setf (cl-mcp/src/worker-client:worker-last-crash-reason worker)
+                     reason)
+               worker))
+           (init-disabled-after-monitor (reason)
+             (let* ((worker (dead-worker reason))
+                    (cl-mcp/src/pool::*runtime-owner* (cons "init-probe" worker))
+                    (cl-mcp/src/pool::*runtime-init-disabled* nil)
+                    (cl-mcp/src/pool::*init-attributable-crashes*
+                      (make-hash-table :test 'eql)))
+               (cl-mcp/src/pool::%monitor-init worker "init-probe" 1)
+               cl-mcp/src/pool::*runtime-init-disabled*))
+           (init-disabled-after-start (reason)
+             (let ((worker (dead-worker reason))
+                   (cl-mcp/src/pool::*runtime-owner* nil)
+                    (cl-mcp/src/pool::*runtime-init-failures* 0)
+                   (cl-mcp/src/pool::*runtime-init-disabled* nil)
+                   (cl-mcp/src/pool::*worker-init-config*
+                     (list :system "init-probe-system" :max-failures 1))
+                   (cl-mcp/src/pool::*init-attributable-crashes*
+                     (make-hash-table :test 'eql)))
+               (cl-mcp/src/pool::%ensure-runtime-init worker "init-probe")
+               cl-mcp/src/pool::*runtime-init-disabled*)))
+    (testing "the init monitor does not blame a retirement"
+      (ok (not (init-disabled-after-monitor
+                cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
+          "initialization stays available to every later worker")
+      (ok (init-disabled-after-monitor "eof")
+          "while a real crash of the init owner still disables it"))
+    (testing "nor does the init-start path"
+      (ok (not (init-disabled-after-start
+                cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*))
+          "a worker that retired before answering did not fail to initialize")
+      (ok (init-disabled-after-start "eof")
+          "while a real crash there still disables it"))))
 
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -19,6 +19,7 @@
   ;; for the package-inferred system to load it.
   (:import-from #:cl-mcp/src/worker/server)
   (:import-from #:cl-mcp/src/worker-client)
+  (:import-from #:cl-mcp/src/pool)
   (:import-from #:yason))
 
 (in-package #:cl-mcp/tests/worker-leaked-thread-test)
@@ -203,8 +204,81 @@ and makes the assertions depend on the runner being fast enough to observe it."
         (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil)
         (ok (eql 0 (count-on worker))
             "so pool-status stops reporting a worker that recovered")))
+    (testing "the worker puts the count on both kinds of envelope"
+      ;; The cases above hand WORKER-RPC an envelope built by the test, so
+      ;; they cover the reader and the parent's slot but not the worker
+      ;; actually writing the field -- and a handler that leaks and then
+      ;; returns an error uses the error envelope.
+      (with-clean-leak-record
+        (leak-one-thread)
+        (ok (eql 1 (gethash "leaked_threads"
+                            (cl-mcp/src/worker/server::%make-result 1 "ok")))
+            "on a result")
+        (ok (eql 1 (gethash "leaked_threads"
+                            (cl-mcp/src/worker/server::%make-error
+                             1 -32603 "boom")))
+            "and on an error")))
     (testing "the worker omits the field entirely when carrying nothing"
       (with-clean-leak-record
-        (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
+        (dolist (ht (list (cl-mcp/src/worker/server::%make-result 1 "payload")
+                          (cl-mcp/src/worker/server::%make-error 1 -1 "e")))
           (ok (null (nth-value 1 (gethash "leaked_threads" ht)))
               "the key is absent rather than reported as zero"))))))
+
+(deftest a-retirement-is-classified-apart-from-a-crash
+  ;; The chain nothing covered, and the one with the widest blast radius: a
+  ;; worker that retires reaches the parent as EOF like any other death, and
+  ;; %MONITOR-INIT reads a crash by the runtime-init owner as init's fault and
+  ;; disables initialization for every later worker in the pool.  The first
+  ;; version of this guard was inert -- the reader it called was not imported
+  ;; and IGNORE-ERRORS swallowed the undefined-function error -- and shipped
+  ;; because no test asked the question.
+  (labels ((dead-worker (&key leaked)
+             ;; No process, so classification falls back to the count the
+             ;; worker last reported, which is the path that runs when the
+             ;; process is gone or not yet reaped.
+             (cl-mcp/src/worker-client::make-worker
+              :state :bound
+              :leaked-threads (or leaked 0)
+              :stream (make-two-way-stream (make-string-input-stream "")
+                                           (make-broadcast-stream))))
+           (reason-of (worker)
+             (handler-case
+                 (progn (cl-mcp/src/worker-client:worker-rpc
+                         worker "worker/probe" nil)
+                        nil)
+               (cl-mcp/src/worker-client:worker-crashed (c)
+                 (cl-mcp/src/worker-client:worker-crashed-reason c)))))
+    (testing "a worker that died carrying one is reported as retired"
+      (let ((reason (reason-of (dead-worker :leaked 1))))
+        (ok (equal cl-mcp/src/worker-client::*retired-leaked-thread-reason*
+                   reason)
+            (format nil "reason was ~S" reason))))
+    (testing "a worker that died carrying nothing is reported as a crash"
+      (ok (equal "eof" (reason-of (dead-worker)))))
+    (testing "and the pool tells the two apart"
+      ;; The predicate the init monitor consults.  Asserted through a real
+      ;; WORKER-CRASHED condition, because what broke before was the reader
+      ;; used to get the reason out of one.
+      (let ((retired (make-condition
+                      'cl-mcp/src/worker-client:worker-crashed
+                      :worker nil
+                      :reason cl-mcp/src/worker-client::*retired-leaked-thread-reason*))
+            (crashed (make-condition
+                      'cl-mcp/src/worker-client:worker-crashed
+                      :worker nil :reason "eof")))
+        (ok (cl-mcp/src/pool::%retirement-crash-p retired)
+            "a retirement is recognized, so init is not blamed for it")
+        (ok (not (cl-mcp/src/pool::%retirement-crash-p crashed))
+            "and a real crash still counts against init")))
+    (testing "a retirement is kept out of the crash breaker too"
+      ;; Three uninterruptible timeouts in five minutes would otherwise trip
+      ;; the per-session breaker and halt the session.
+      (let ((retired (dead-worker))
+            (crashed (dead-worker)))
+        (setf (cl-mcp/src/worker-client::worker-last-crash-reason retired)
+              cl-mcp/src/worker-client::*retired-leaked-thread-reason*
+              (cl-mcp/src/worker-client::worker-last-crash-reason crashed)
+              "eof")
+        (ok (cl-mcp/src/pool::%retired-worker-p retired))
+        (ok (not (cl-mcp/src/pool::%retired-worker-p crashed)))))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -17,15 +17,32 @@
   ;; Named without importing: the worker server's side of this is internal, so
   ;; the tests reach it with ::, but the dependency still has to be declared
   ;; for the package-inferred system to load it.
-  (:import-from #:cl-mcp/src/worker/server))
+  (:import-from #:cl-mcp/src/worker/server)
+  (:import-from #:cl-mcp/src/worker-client)
+  (:import-from #:yason))
 
 (in-package #:cl-mcp/tests/worker-leaked-thread-test)
 
+(defvar *probe-release* nil
+  "Set to end the deliberately unstoppable probe threads.
+They cannot be interrupted -- that is the point of them -- so ending them has
+to be cooperative.")
+
+(defun release-probe-threads ()
+  "Let the probe threads finish and wait for them, so the image is left clean."
+  (setf *probe-release* t)
+  (dolist (thread (leaked-threads))
+    (loop repeat 200
+          while (bt:thread-alive-p thread)
+          do (sleep 0.02))))
+
 (defmacro with-clean-leak-record (&body body)
-  "Run BODY with the leak record empty, and leave it empty.
-Deliberately leaking a thread is the only way to test any of this, and the
-record is image-wide."
+  "Run BODY with the leak record empty, and leave the image as it was found.
+Deliberately leaking a thread is the only way to test any of this, and both
+the record and the thread are image-wide: forgetting the record alone would
+leave a live thread running into whatever runs next."
   `(unwind-protect (progn (forget-leaked-threads) ,@body)
+     (release-probe-threads)
      (forget-leaked-threads)))
 
 (defun leak-one-thread ()
@@ -36,10 +53,18 @@ thread was left behind, not which one.
 
 SB-SYS:WITHOUT-INTERRUPTS defers both the cooperative unwind and
 DESTROY-THREAD, which is what being unstoppable actually looks like.  The
-thread ends on its own shortly after, so the image is not left carrying it."
+thread polls *PROBE-RELEASE* rather than sleeping a fixed time so the test can
+end it deliberately: a fixed sleep leaves it running into whatever runs next,
+and makes the assertions depend on the runner being fast enough to observe it."
+  (setf *probe-release* nil)
   (let ((reported (nth-value 2 (call-with-deadline-thread
                                 (lambda ()
-                                  (sb-sys:without-interrupts (sleep 3))
+                                  (sb-sys:without-interrupts
+                                    (let ((stop (+ (get-internal-real-time)
+                                                   (* 30 internal-time-units-per-second))))
+                                      (loop until (or *probe-release*
+                                                      (> (get-internal-real-time) stop))
+                                            do (sleep 0.02))))
                                   :finished)
                                 0.3))))
     (values reported (first (leaked-threads)))))
@@ -66,57 +91,120 @@ thread ends on its own shortly after, so the image is not left carrying it."
 (deftest leaked-threads-stops-reporting-a-thread-that-finished
   (testing "the record prunes, so a worker that recovered is not retired"
     ;; This is the whole reason the check is made at the moment of use rather
-    ;; than remembered from when it happened.  The thread below cannot be
-    ;; stopped, but it ends on its own -- and a worker that ends up carrying
-    ;; nothing should keep the session state it still holds rather than be
-    ;; replaced for a condition that has passed.
+    ;; than remembered from when it happened.  A leaked thread is running, not
+    ;; dead, and it may finish -- and a worker that ends up carrying nothing
+    ;; should keep the session state it still holds rather than be replaced
+    ;; for a condition that has passed.
     (with-clean-leak-record
       (let ((thread (nth-value 1 (leak-one-thread))))
         (ok (= 1 (length (leaked-threads))) "recorded while it runs")
-        (loop repeat 100
-              while (bt:thread-alive-p thread)
-              do (sleep 0.1))
-        (ok (not (bt:thread-alive-p thread)) "the thread finished on its own")
+        ;; Let it finish.  It cannot be interrupted -- that is what made it
+        ;; leak -- so ending it has to be cooperative.
+        (release-probe-threads)
+        (ok (not (bt:thread-alive-p thread)) "the thread has finished")
         (ok (null (leaked-threads))
             "and stops being counted against the image")))))
 
 (deftest worker-retires-rather-than-serve-a-request-while-carrying-one
-  (testing "a request arriving while a thread is still running retires the worker"
-    ;; Retiring means exiting: the parent's crash handling then replaces the
-    ;; worker and tells the caller its state was reset, whereas answering with
-    ;; an error would leave this image in the pool to fail the same way on
-    ;; every later request.  The action is indirected so the decision can be
-    ;; asserted without taking this process down with it.
-    (with-clean-leak-record
-      (leak-one-thread)
-      (let* ((retired nil)
-             (cl-mcp/src/worker/server::*retire-action*
-               (lambda (leaked) (setf retired (length leaked)))))
-        (cl-mcp/src/worker/server::%retire-if-carrying-leaked-threads
-         "worker/eval")
-        (ok (eql 1 retired)
-            "the worker retires, and is told what for"))))
-  (testing "a worker carrying nothing serves the request"
-    (with-clean-leak-record
-      (let* ((retired nil)
-             (cl-mcp/src/worker/server::*retire-action*
-               (lambda (leaked) (declare (ignore leaked)) (setf retired t))))
-        (cl-mcp/src/worker/server::%retire-if-carrying-leaked-threads
-         "worker/eval")
-        (ok (null retired) "no retirement when there is nothing to retire for")))))
+  ;; Driven through %DISPATCH-REQUEST, the function a real request goes
+  ;; through, rather than the helper it calls: a test that invokes the helper
+  ;; directly still passes when the call is deleted from the dispatch path, or
+  ;; moved after the handler, which is exactly the wiring under test.
+  (labels ((server-with-probe (fired)
+             ;; The raw constructor: MAKE-WORKER-SERVER would bind a real
+             ;; listening socket, which this has no use for.
+             (let ((server (cl-mcp/src/worker/server::%make-worker-server)))
+               (setf (cl-mcp/src/worker/server::worker-server-authenticated-p
+                      server)
+                     t)
+               (cl-mcp/src/worker/server:register-method
+                server "worker/probe"
+                (lambda (params) (declare (ignore params))
+                  (setf (car fired) t)
+                  "served"))
+               server))
+           (dispatch (server)
+             (let* ((retired nil)
+                    (cl-mcp/src/worker/server::*retire-action*
+                      (lambda (leaked)
+                        (setf retired (length leaked))
+                        ;; Stands in for the exit: the request must not be
+                        ;; served, so leave the dispatch the way exiting does.
+                        (throw :retired nil))))
+               (catch :retired
+                 (cl-mcp/src/worker/server::%dispatch-request
+                  server 1 "worker/probe" (make-hash-table :test 'equal)))
+               retired)))
+    (testing "a request arriving while a thread is still running is not served"
+      ;; Retiring means exiting: the parent's crash handling already replaces a
+      ;; worker that stops answering and tells the caller its state was reset,
+      ;; whereas answering with an error would leave this image in the pool to
+      ;; fail the same way on every later request.
+      (with-clean-leak-record
+        (leak-one-thread)
+        (let* ((fired (list nil))
+               (retired (dispatch (server-with-probe fired))))
+          (ok (eql 1 retired) "the worker retires, and is told what for")
+          (ok (null (car fired))
+              "and the handler never ran on the compromised image"))))
+    (testing "a worker carrying nothing serves the request"
+      (with-clean-leak-record
+        (let* ((fired (list nil))
+               (retired (dispatch (server-with-probe fired))))
+          (ok (null retired) "no retirement when there is nothing to retire for")
+          (ok (car fired) "and the request is served normally"))))))
 
 (deftest leaked-threads-are-reported-to-the-parent
-  (testing "a response carries the count so pool-status can show it"
-    ;; The worker retires before serving another request, so this is what
-    ;; makes the condition visible in the window between the deadline giving
-    ;; up and that next request -- which is when someone is likely to be
-    ;; asking what went wrong.
-    (with-clean-leak-record
-      (leak-one-thread)
-      (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
-        (ok (eql 1 (gethash "leaked_threads" ht))))))
-  (testing "and ordinary responses are unchanged on the wire"
-    (with-clean-leak-record
-      (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
-        (ok (null (nth-value 1 (gethash "leaked_threads" ht)))
-            "the key is absent rather than reported as zero")))))
+  ;; Driven through WORKER-RPC against a canned response, so the whole chain
+  ;; is covered: the worker putting the count on the envelope, the reader
+  ;; returning it, and the parent storing it where pool-status reads it.
+  ;; Asserting only on %MAKE-RESULT would pass with any link of that broken.
+  (labels ((canned-worker (line)
+             (cl-mcp/src/worker-client::make-worker
+              :state :bound
+              :stream (make-two-way-stream
+                       (make-string-input-stream line)
+                       (make-broadcast-stream))))
+           (count-on (worker)
+             (cl-mcp/src/worker-client::worker-leaked-threads worker))
+           (envelope (&key error leaked)
+             (with-output-to-string (s)
+               (yason:encode
+                (let ((ht (make-hash-table :test 'equal)))
+                  (setf (gethash "jsonrpc" ht) "2.0"
+                        (gethash "id" ht) 1)
+                  (if error
+                      (setf (gethash "error" ht)
+                            (let ((e (make-hash-table :test 'equal)))
+                              (setf (gethash "code" e) -32603
+                                    (gethash "message" e) "boom")
+                              e))
+                      (setf (gethash "result" ht) "ok"))
+                  (when leaked
+                    (setf (gethash "leaked_threads" ht) leaked))
+                  ht)
+                s)
+               (terpri s))))
+    (testing "a successful response carries the count to the parent"
+      (let ((worker (canned-worker (envelope :leaked 2))))
+        (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil)
+        (ok (eql 2 (count-on worker)))))
+    (testing "and an error response carries it too"
+      ;; A handler can leak its deadline's thread and then return an error.
+      ;; Updating only on success leaves the parent reporting what it last
+      ;; saw, stale in both directions.
+      (let ((worker (canned-worker (envelope :error t :leaked 3))))
+        (ignore-errors
+         (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil))
+        (ok (eql 3 (count-on worker)))))
+    (testing "a response without the field clears a count that has passed"
+      (let ((worker (canned-worker (envelope))))
+        (setf (cl-mcp/src/worker-client::worker-leaked-threads worker) 5)
+        (cl-mcp/src/worker-client:worker-rpc worker "worker/probe" nil)
+        (ok (eql 0 (count-on worker))
+            "so pool-status stops reporting a worker that recovered")))
+    (testing "the worker omits the field entirely when carrying nothing"
+      (with-clean-leak-record
+        (let ((ht (cl-mcp/src/worker/server::%make-result 1 "payload")))
+          (ok (null (nth-value 1 (gethash "leaked_threads" ht)))
+              "the key is absent rather than reported as zero"))))))

--- a/tests/worker-leaked-thread-test.lisp
+++ b/tests/worker-leaked-thread-test.lisp
@@ -30,6 +30,7 @@
   (:import-from #:cl-mcp/src/worker/server)
   (:import-from #:cl-mcp/src/worker-client)
   (:import-from #:cl-mcp/src/pool)
+  (:import-from #:cl-mcp/src/project-root)
   (:import-from #:cl-mcp/src/proxy)
   (:import-from #:yason))
 
@@ -692,6 +693,27 @@ parent waited long enough for the status to settle to read it"))
       (ok (equal cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*
                  (cl-mcp/src/worker-client:worker-last-crash-reason worker))
           "with the reason the user is shown intact")))
+  (testing "and neither does a reason the RPC that met the death recorded"
+    ;; The pool's own RPCs die on timeouts, and it only ever knows that a
+    ;; process is gone.  "process-died" tells the user less than the
+    ;; "timeout" it would replace -- and the same slot is what the message
+    ;; is built from.
+    (let ((worker (cl-mcp/src/worker-client::make-worker :state :bound)))
+      (cl-mcp/src/worker-client::%mark-worker-crashed worker "timeout")
+      (cl-mcp/src/pool::%record-worker-death worker nil nil
+                                             :already-classified t)
+      (ok (equal "timeout"
+                 (cl-mcp/src/worker-client:worker-last-crash-reason worker)))))
+  (testing "but a reason it did not establish is not this worker's"
+    ;; A replacement carries its predecessor's reason to explain the reset.
+    ;; Keeping that here would report an earlier worker's death as this
+    ;; one's -- for a retirement, as a leaked thread this worker never had.
+    (let ((worker (cl-mcp/src/worker-client::make-worker :state :bound)))
+      (setf (cl-mcp/src/worker-client:worker-last-crash-reason worker)
+            cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+      (cl-mcp/src/pool::%record-worker-death worker "signaled" 9)
+      (ok (equal "process-died"
+                 (cl-mcp/src/worker-client:worker-last-crash-reason worker)))))
   (testing "but a death it has no record of is read from what it can see"
     (let ((worker (cl-mcp/src/worker-client::make-worker
                    :state :bound :leaked-threads 1)))
@@ -1021,6 +1043,101 @@ next call learns why the session was reset")
                      (cl-mcp/src/worker-client:worker-last-crash-reason
                       replacement))
               "and still knows why"))))))
+
+(deftest an-owed-reset-is-neither-lost-nor-invented
+  ;; The debt has one more way to go missing and one way to be made up, and
+  ;; both are about which worker is holding it when something goes wrong.
+  (testing "a replacement corrupted while being set up hands it back"
+    ;; The last drop site: the project-root sync runs against a worker the
+    ;; pool has just assigned, and when it kills that worker the pool throws
+    ;; it away and signals.  By then the debt is on that worker and the
+    ;; session's copy is gone, so it would be lost from both places at once
+    ;; -- the user's state reset twice with nothing said either time.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-sendroot")
+             ;; The sync only runs when the parent has a root to send.
+             (cl-mcp/src/project-root:*project-root*
+               (uiop:temporary-directory))
+             (worker (cl-mcp/src/pool:get-or-assign-worker session))
+             (real (fdefinition 'cl-mcp/src/pool::send-root-to-session-worker)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed
+         worker cl-mcp/src/utils/deadline:*retired-leaked-thread-reason*)
+        (unwind-protect
+             (progn
+               ;; What a root sync does when it kills the worker it is
+               ;; talking to: worker-rpc marks it crashed and the failure is
+               ;; swallowed.  Replaced by name because the pool calls it
+               ;; directly, from inside the function under test.
+               (setf (fdefinition 'cl-mcp/src/pool::send-root-to-session-worker)
+                     (lambda (session-id path)
+                       (declare (ignore path))
+                       (let ((w (cl-mcp/src/pool::find-session-worker
+                                 session-id)))
+                         (when w
+                           (cl-mcp/src/worker-client::%mark-worker-crashed
+                            w "stream-error")))))
+               (ok (handler-case
+                       (progn (cl-mcp/src/pool:get-or-assign-worker session)
+                              nil)
+                     (error () t))
+                   "the request fails rather than returning a dead worker"))
+          (setf (fdefinition 'cl-mcp/src/pool::send-root-to-session-worker)
+                real))
+        (ok (gethash session cl-mcp/src/pool::*owed-resets*)
+            "and the reset is back with the session")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "so the next request is still told")))))
+  (testing "a death already reported to the user is not recorded as owed"
+    ;; KILL-WORKER sets the flag on anything it kills, and the pool kills a
+    ;; crashed worker before deciding what to do about it.  Reading the flag
+    ;; after that would find a debt the proxy had already delivered and
+    ;; settled, and hand the user the same message twice.
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-already-told")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (cl-mcp/src/worker-client::%mark-worker-crashed worker "eof")
+        ;; The proxy reporting the death, which is what consumes the debt.
+        (ok (cl-mcp/src/worker-client:check-and-clear-reset-notification
+             worker)
+            "the death is reported to the request that met it")
+        (cl-mcp/src/pool::%handle-worker-crash worker)
+        (ok (null (gethash session cl-mcp/src/pool::*owed-resets*))
+            "so nothing is left owed to say again"))))
+  (testing "recovery that does replace the worker takes the debt off the session"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (let* ((session "owed-reset-recovered")
+             (worker (cl-mcp/src/pool:get-or-assign-worker session)))
+        (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+          (setf (gethash session cl-mcp/src/pool::*owed-resets*)
+                (list "eof" "exited" 1)))
+        (sb-posix:kill (cl-mcp/src/worker-client:worker-pid worker)
+                       sb-posix:sigkill)
+        (sleep 0.5)
+        (cl-mcp/src/pool::%handle-worker-crash worker)
+        (ok (null (gethash session cl-mcp/src/pool::*owed-resets*))
+            "the replacement carries it, so the session no longer does")
+        (let ((replacement (cl-mcp/src/pool:get-or-assign-worker session)))
+          (ok (cl-mcp/src/worker-client:worker-needs-reset-notification
+               replacement)
+              "and it is the replacement that carries it")))))
+  (testing "shutting the pool down discards what nobody will be told"
+    (unless (spawn-available-p)
+      (skip "worker processes cannot be spawned here"))
+    (with-pool ()
+      (bt:with-lock-held (cl-mcp/src/pool::*pool-lock*)
+        (setf (gethash "owed-reset-shutdown" cl-mcp/src/pool::*owed-resets*)
+              (list "eof" "exited" 1)))
+      (cl-mcp/src/pool:shutdown-pool)
+      (ok (zerop (hash-table-count cl-mcp/src/pool::*owed-resets*))
+          "nothing survives to greet a later session"))))
 
 (deftest retirement-is-visible-where-it-has-to-be
   (testing "real work retires; only observation is exempt"


### PR DESCRIPTION
Closes #145.

A deadline that cannot stop its run thread leaves it running in the worker:
holding locks it took, mutating the state later work reads, competing for the
CPU. #143 and #144 traded the old behaviour — the thread pinned the connection,
the proxy timed out, the worker was killed and replaced — for answering the
caller gracefully. That was right, but it left no escalation: the caller who
hit the deadline was told, and **every request after it was served by a process
that is quietly wrong**, with `pool-status` showing the worker as healthy.

## What it does

The worker retires instead of serving another request while carrying a leaked
thread. Retiring means exiting: the parent's crash handling already replaces a
worker that stops answering and tells the caller its state was reset, whereas
answering with an error would leave the image in the pool to fail the same way
on every later request.

## The question #145 left open

The issue asked whether to retire immediately after the response or defer until
the next request, noting that deferring keeps the door open for the thread to
finish on its own.

Neither, as stated. **The check is made at the moment of use rather than
remembered from when it happened.** `call-with-deadline-thread` records the
thread it could not stop; `leaked-threads` prunes the record on every call. A
worker that recovered keeps the session state it still holds instead of being
replaced for a condition that has passed — and only the worker can see that,
which is why it decides rather than the pool.

The record lives with the deadline machinery, so all three call sites —
`run-tests`, `repl-eval`, `load-system` — contribute without plumbing a flag
through each.

## Visibility

A worker reports the count alongside every response and the parent stores it on
the worker struct, so `pool-status` shows the condition during the window
between the deadline giving up and the next request — which is when someone is
likely to be asking what went wrong:

```
  #3 [bound] pid=1234 port=39501 session=abc12345 leaked_threads=1 (will be replaced on its next request)
```

Nothing in the parent acts on it. One mechanism retires, the other observes.

## Testing

Full suite in a fresh process (`rove cl-mcp.asd`): 59 test systems, 4,607
assertions, no failures beyond the deliberately red scaffold
`project-scaffold-test` builds. `mallet` reports no problems;
`(asdf:compile-system :cl-mcp :force :all)` is clean apart from pre-existing
warnings.

The new tests were mutation-checked rather than assumed to discriminate:

| mutation | assertions failed |
|---|---|
| registry never prunes | 1 |
| leak never recorded | 5 |
| worker never retires | 1 |
| count never reported to the parent | 1 |

`*retire-action*` is indirected so the decision to exit can be asserted without
taking the test process down with it — a test that could only assert it by
dying could not assert it.

## Not in scope

Threads a suite or an evaluated form spawns of its own are not tracked; only
the run thread the deadline owns. That is unchanged and stated in
`call-with-deadline-thread`'s docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEcTKuWZJKC1MbUp447Uoo
