### PR TITLE
feat(cl-spec): surface function specs, and fix what the end-to-end run found

### DIFF
--- a/docs/cl-spec-adapter-feedback.md
+++ b/docs/cl-spec-adapter-feedback.md
@@ -192,7 +192,7 @@ consumer から見ると、この 2 つが同形であることが projection �
 
 ---
 
-### 2.5 `check-function` の `rejected` が試行数を超える【実測】
+### 2.5 `check-function` の `rejected` が試行数を超える【実測・修正済み】
 
 `src/function-spec.lisp` の合成 property は、`:pre` に弾かれた入力を数えるため
 `countingp` を立てたまま実行し、**認識できた失敗**（`:returns` 違反 /
@@ -214,10 +214,16 @@ run 4: status=:ERROR trials=7  rejected=8    effective=-1
 `executed` も負になります（`:skipped` 判定の `(zerop executed)` はその場合
 成立しません）。
 
-cl-mcp 側は `effective_trials` を出さず `rejected_overcounted` を立てて
-「差は導出できない」と報告する回避を入れましたが、根本は
-`(apply target arguments)` の周りで `countingp` を落とすこと（`unwind-protect`
-か handler）1 箇所です。そちらが直れば cl-mcp のこの分岐は不要になります。
+**修正済み（cl-spec `6d9b6b1`, 2026-09-10 21:42）**。合成 property の本体が
+`handler-bind` で包まれ、対象が signal した時点で `countingp` が落ちるように
+なりました。あわせて `:skipped` 判定が `(zerop executed)` から
+`(not (plusp executed))` になっています。同じ probe を現行 cl-spec で再測定した
+結果、8 回すべてで `effective` が正になりました（修正前は 3/8 が負）。
+
+この節は再現条件と実測値の記録として残します。cl-mcp 側の
+`rejected_overcounted` / `rejected_usable` は削除していません — アダプタは
+インストールされている revision を選べず、この修正より前の cl-spec に対しても
+負の呼び出し回数を報告しないためです。cl-spec 側で対応が必要な項目ではありません。
 
 ## 3. P3: 外部表現に効く観測
 

--- a/docs/cl-spec-adapter-feedback.md
+++ b/docs/cl-spec-adapter-feedback.md
@@ -192,6 +192,33 @@ consumer から見ると、この 2 つが同形であることが projection �
 
 ---
 
+### 2.5 `check-function` の `rejected` が試行数を超える【実測】
+
+`src/function-spec.lisp` の合成 property は、`:pre` に弾かれた入力を数えるため
+`countingp` を立てたまま実行し、**認識できた失敗**（`:returns` 違反 /
+postcondition 違反）でのみ `countingp` を NIL にしています。対象関数が
+**signal** した場合、その 2 つの `setf` を飛び越えて unwind するので
+`countingp` は T のまま残り、続く shrink が `:pre` に弾かれる候補を試すたび
+`rejected` が増え続けます。
+
+実測（`:pre (> value 80)` を持ち value > 90 で signal する契約、`trials 40`、8 回）:
+
+```
+run 0: status=:ERROR trials=13 rejected=13   effective=0
+run 1: status=:ERROR trials=1  rejected=2    effective=-1
+run 3: status=:ERROR trials=4  rejected=5    effective=-1
+run 4: status=:ERROR trials=7  rejected=8    effective=-1
+```
+
+`function-spec.lisp:278` の `executed` も同じ式なので、cl-spec 自身の
+`executed` も負になります（`:skipped` 判定の `(zerop executed)` はその場合
+成立しません）。
+
+cl-mcp 側は `effective_trials` を出さず `rejected_overcounted` を立てて
+「差は導出できない」と報告する回避を入れましたが、根本は
+`(apply target arguments)` の周りで `countingp` を落とすこと（`unwind-protect`
+か handler）1 箇所です。そちらが直れば cl-mcp のこの分岐は不要になります。
+
 ## 3. P3: 外部表現に効く観測
 
 ### 3.1 生成 seed の範囲と受理 seed の範囲が違う【実測】

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -690,7 +690,9 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     `timeout_seconds`
   - `specs_listable`, `properties_listable`, `function_specs_listable` and
     `tag_filterable` say whether this cl-spec can enumerate each half, and
-    whether it can filter by tag at all. False there is not
+    whether it can filter by tag at all — facts about the loaded revision, not
+    about what this call asked for. `filters.tag_applied` says whether the tag
+    actually narrowed this listing. False there is not
     "this project has none" — and the matching entry in `counts` is `null`,
     never `0`. `kind=both` lists the halves it can and reports the rest this
     way rather than failing the whole call.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -731,6 +731,12 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     refuses inputs `:pre` does not admit, and a trial count that includes them
     overstates the work. Raise `trials` — and `timeout_seconds` with it — when
     `effective_trials` comes back small.
+  - `effective_trials` is **null**, never 0, when it could not be derived.
+    `rejected_measured` false means this cl-spec exports no reader for the
+    refused count; `rejected_overcounted` true means cl-spec reported more
+    refusals than trials (its counter keeps running when the function
+    signals); `has_precondition` false means the contract has no `:pre`, so
+    nothing could be refused. A 0 there would read as "never called".
   - `verified` is true only when at least one property was selected, all of
     them passed, and each evaluated at least one trial. Zero properties,
     a timeout, a generator failure and a zero-trial budget are each reported

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -688,8 +688,11 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
   - `kind` (`specs` | `properties` | `function-specs` | `both`, default
     `both`), `package`, `tag`, `limit` (positive integer, default 200),
     `timeout_seconds`
-  - `function_specs_listable` says whether this cl-spec can enumerate
-    contracts at all. False there is not "this project has none".
+  - `specs_listable`, `properties_listable` and `function_specs_listable` say
+    whether this cl-spec can enumerate each half at all. False there is not
+    "this project has none" — and the matching entry in `counts` is `null`,
+    never `0`. `kind=both` lists the halves it can and reports the rest this
+    way rather than failing the whole call.
   - `tag` names a keyword. A tag no loaded code mentions comes back as
     `tag_resolved: "no-such-keyword"` rather than as an empty result — "nothing
     carries this tag" and "this tag does not exist here" are different answers.
@@ -722,7 +725,13 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     `max_value_chars` (positive integer, default 2000)
   - `function` runs the contract. A `symbol` selection does **not** include it
     — `:about` covers properties only — and the response names the contract it
-    left alone rather than letting the verdict read as full coverage.
+    left alone rather than letting the verdict read as full coverage. The
+    reverse holds too: `function=` runs the contract and none of the properties
+    registered about the symbol. Both directions are reported in three places —
+    the headline qualifier, `selection.contract_not_run` /
+    `selection.properties_not_run`, and `verification_gaps`
+    (`contract-not-run` / `properties-not-run`) — so neither has to be read
+    out of prose.
   - `trials` sizes a contract run and `profile` sizes a property run; each is
     **refused**, not ignored, against the other. A contract has no `:trials`
     table for a profile to select from, and `run-property` takes no trial
@@ -732,11 +741,15 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     overstates the work. Raise `trials` — and `timeout_seconds` with it — when
     `effective_trials` comes back small.
   - `effective_trials` is **null**, never 0, when it could not be derived.
-    `rejected_measured` false means this cl-spec exports no reader for the
-    refused count; `rejected_overcounted` true means cl-spec reported more
-    refusals than trials (its counter keeps running when the function
-    signals); `has_precondition` false means the contract has no `:pre`, so
-    nothing could be refused. A 0 there would read as "never called".
+    `rejected_measured` false means no refused count came back — this cl-spec
+    exports no reader for it, or the reader signalled; `rejected_overcounted`
+    true means cl-spec reported more refusals than trials (its counter keeps
+    running when the function signals); `has_precondition` false means the
+    contract has no `:pre`, so nothing could be refused, and `null` means the
+    definition could not be read. A 0 there would read as "never called".
+  - An overcounted run is also not evidence: `verified` is false and
+    `verification_gaps` carries `rejection-counts-unmeasured`, because the
+    count the response would have corrected by is not usable.
   - `verified` is true only when at least one property was selected, all of
     them passed, and each evaluated at least one trial. Zero properties,
     a timeout, a generator failure and a zero-trial budget are each reported

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -760,7 +760,8 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
   - `verification_gaps` values: `zero-trials`, `effective-trials-unknown`,
     `rejection-counts-unmeasured`, `input-coverage-unmeasured`,
     `contract-not-run`, `properties-not-run`, `related-properties-unknown`,
-    `no-properties-selected`, and any non-terminal result status. The tool's
+    `no-properties-selected`, and any result status that is not a verdict
+    (`skipped`, `pending`, `timeout`, `not-run`, the `*-error` statuses). The tool's
     own description defines each one, and `tests/spec-tools-test.lisp` checks
     that description against the code's list so the two cannot drift.
   - `selection.properties_not_run` is `null`, not `[]`, for a selection that

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -742,7 +742,9 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
   - A contract run reports `rejected` and `effective_trials`: cl-spec's checker
     refuses inputs `:pre` does not admit, and a trial count that includes them
     overstates the work. Raise `trials` — and `timeout_seconds` with it — when
-    `effective_trials` comes back small.
+    `effective_trials` comes back small. `rejection-counts-unmeasured` is left
+    off a contract run only when the count is actually usable; a run that timed
+    out, never started, or whose reader failed still carries it.
   - `effective_trials` is **null**, never 0, when it could not be derived.
     `rejected_measured` false means no refused count came back — this cl-spec
     exports no reader for it, or the reader signalled; `rejected_overcounted`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -747,9 +747,16 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     running when the function signals); `has_precondition` false means the
     contract has no `:pre`, so nothing could be refused, and `null` means the
     definition could not be read. A 0 there would read as "never called".
-  - An overcounted run is also not evidence: `verified` is false and
-    `verification_gaps` carries `rejection-counts-unmeasured`, because the
-    count the response would have corrected by is not usable.
+  - A contract run whose effective count is unknown is not evidence:
+    `verified` is false and `verification_gaps` carries
+    `effective-trials-unknown` (plus `rejection-counts-unmeasured` when the
+    refusal count is the reason). The raw trial count is never used as a
+    fallback — it is the number the refusal count exists to correct, and a
+    `:pre` that admits nothing would otherwise read as a hundred trials.
+  - `verification_gaps` values: `zero-trials`, `effective-trials-unknown`,
+    `rejection-counts-unmeasured`, `input-coverage-unmeasured`,
+    `contract-not-run`, `properties-not-run`, `related-properties-unknown`,
+    `no-properties-selected`, and any non-terminal result status.
   - `verified` is true only when at least one property was selected, all of
     them passed, and each evaluated at least one trial. Zero properties,
     a timeout, a generator failure and a zero-trial budget are each reported

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -688,8 +688,9 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
   - `kind` (`specs` | `properties` | `function-specs` | `both`, default
     `both`), `package`, `tag`, `limit` (positive integer, default 200),
     `timeout_seconds`
-  - `specs_listable`, `properties_listable` and `function_specs_listable` say
-    whether this cl-spec can enumerate each half at all. False there is not
+  - `specs_listable`, `properties_listable`, `function_specs_listable` and
+    `tag_filterable` say whether this cl-spec can enumerate each half, and
+    whether it can filter by tag at all. False there is not
     "this project has none" — and the matching entry in `counts` is `null`,
     never `0`. `kind=both` lists the halves it can and reports the rest this
     way rather than failing the whole call.
@@ -744,9 +745,12 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
     `rejected_measured` false means no refused count came back — this cl-spec
     exports no reader for it, or the reader signalled; `rejected_overcounted`
     true means cl-spec reported more refusals than trials (its counter keeps
-    running when the function signals); `has_precondition` false means the
-    contract has no `:pre`, so nothing could be refused, and `null` means the
-    definition could not be read. A 0 there would read as "never called".
+    running when the function signals); `rejected_contradicted` true means
+    refusals were reported for a contract with no `:pre`; `has_precondition`
+    false means the contract has no `:pre`, so nothing could be refused, and
+    `null` means the definition could not be read. `rejected_usable` is the
+    single flag answering whether the count may be subtracted with. A 0 in
+    `effective_trials` would read as "never called".
   - A contract run whose effective count is unknown is not evidence:
     `verified` is false and `verification_gaps` carries
     `effective-trials-unknown` (plus `rejection-counts-unmeasured` when the
@@ -756,7 +760,12 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
   - `verification_gaps` values: `zero-trials`, `effective-trials-unknown`,
     `rejection-counts-unmeasured`, `input-coverage-unmeasured`,
     `contract-not-run`, `properties-not-run`, `related-properties-unknown`,
-    `no-properties-selected`, and any non-terminal result status.
+    `no-properties-selected`, and any non-terminal result status. The tool's
+    own description defines each one, and `tests/spec-tools-test.lisp` checks
+    that description against the code's list so the two cannot drift.
+  - `selection.properties_not_run` is `null`, not `[]`, for a selection that
+    never looks — `property=` and `symbol=` leave the symbol's other
+    registrations unrun without reporting which.
   - `verified` is true only when at least one property was selected, all of
     them passed, and each evaluated at least one trial. Zero properties,
     a timeout, a generator failure and a zero-trial budget are each reported

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -722,7 +722,7 @@ resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
 - `spec-check` — run one property, every property registered `(:about
   <symbol>)`, or one function spec against its function.
   - `property` **or** `symbol` **or** `function` (exactly one), `package`,
-    `profile` (default `normal`), `trials` (positive integer),
+    `profile` (default `normal`), `trials` (positive integer, max 1,000,000),
     `seed` (decimal digits **as a string**), `expect_definition_digest`,
     `timeout_seconds` (number, default 60 — the budget for the whole call),
     `max_value_chars` (positive integer, default 2000)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -675,17 +675,21 @@ is what is missing.
 
 ### Group `cl-spec` — `spec-list`, `spec-symbol`, `spec-describe`, `spec-check`
 
-Fetch the [cl-spec](https://github.com/cl-ai-project/cl-spec) Spec/Property
-registered about a symbol, read one in full, and run it for a structured
-counterexample. cl-mcp does not depend on cl-spec: these tools resolve it at
-call time and report `cl-spec-not-loaded` when it is absent.
+Fetch the [cl-spec](https://github.com/cl-ai-project/cl-spec) Spec, Property or
+function spec registered about a symbol, read one in full, and run it for a
+structured counterexample. cl-mcp does not depend on cl-spec: these tools
+resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
+`unsupported` when the loaded revision lacks the API an operation needs.
 
 - `spec-list` — what is registered at all. The entry point when you do not yet
   know a name: the other three all take one you already have. Returns names,
   and for each property its kind, tags, `(:about ...)` targets and docstring —
   not bodies.
-  - `kind` (`specs` | `properties` | `both`, default `both`), `package`, `tag`,
-    `limit` (positive integer, default 200), `timeout_seconds`
+  - `kind` (`specs` | `properties` | `function-specs` | `both`, default
+    `both`), `package`, `tag`, `limit` (positive integer, default 200),
+    `timeout_seconds`
+  - `function_specs_listable` says whether this cl-spec can enumerate
+    contracts at all. False there is not "this project has none".
   - `tag` names a keyword. A tag no loaded code mentions comes back as
     `tag_resolved: "no-such-keyword"` rather than as an empty result — "nothing
     carries this tag" and "this tag does not exist here" are different answers.
@@ -703,15 +707,30 @@ call time and report `cl-spec-not-loaded` when it is absent.
   - `kind` (`property` | `spec` | `function-spec`, required), `name` (required),
     `package`, `max_chars` (positive integer, default 8000),
     `timeout_seconds` (number, default 30)
-  - `function-spec` answers `unsupported`: the cl-spec revision this was built
-    against has no `function-spec-data`.
-- `spec-check` — run one property, or every property registered `(:about
-  <symbol>)`.
-  - `property` **or** `symbol` (exactly one), `package`, `profile` (default
-    `normal`), `seed` (decimal digits **as a string**),
-    `expect_definition_digest`, `timeout_seconds` (number, default 60 — the
-    budget for the whole call), `max_value_chars` (positive integer, default
-    2000)
+  - `function-spec` projects the contract: the spec of each argument, the spec
+    of the return value, and the `:pre` / `:post` forms. It answers
+    `unsupported` only when the loaded cl-spec exports no `function-spec-data`
+    — a statement about that revision, not about whether a contract exists.
+  - `:pre` and `:post` are cut at `max_chars` with the cut reported, like
+    `body` and `source_form`.
+- `spec-check` — run one property, every property registered `(:about
+  <symbol>)`, or one function spec against its function.
+  - `property` **or** `symbol` **or** `function` (exactly one), `package`,
+    `profile` (default `normal`), `trials` (positive integer),
+    `seed` (decimal digits **as a string**), `expect_definition_digest`,
+    `timeout_seconds` (number, default 60 — the budget for the whole call),
+    `max_value_chars` (positive integer, default 2000)
+  - `function` runs the contract. A `symbol` selection does **not** include it
+    — `:about` covers properties only — and the response names the contract it
+    left alone rather than letting the verdict read as full coverage.
+  - `trials` sizes a contract run and `profile` sizes a property run; each is
+    **refused**, not ignored, against the other. A contract has no `:trials`
+    table for a profile to select from, and `run-property` takes no trial
+    override, so honouring either would report a setting the run did not use.
+  - A contract run reports `rejected` and `effective_trials`: cl-spec's checker
+    refuses inputs `:pre` does not admit, and a trial count that includes them
+    overstates the work. Raise `trials` — and `timeout_seconds` with it — when
+    `effective_trials` comes back small.
   - `verified` is true only when at least one property was selected, all of
     them passed, and each evaluated at least one trial. Zero properties,
     a timeout, a generator failure and a zero-trial budget are each reported

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -642,7 +642,8 @@ differing only past the cut would digest the same -- so a caller comparing
 digests has to be told.
 
 The digest covers the property's own data and the data of every named spec
-reachable from its arguments, transitively.  Covering only the property would
+reachable from its arguments -- and, for a contract, its return spec --
+transitively.  Covering only the property would
 miss the case that matters most in practice: the property text is untouched
 but the spec it generates from was widened, so the same seed now explores a
 different input domain and the run is not a reproduction of the earlier one.
@@ -659,6 +660,12 @@ than skipped, so the digest still changes if it is defined later."
             (specs '()))
         (dolist (argument (getf property :arguments))
           (setf pending (%collect-spec-references (getf argument :spec) pending)))
+        ;; :RETURNS as well, for a function spec.  The contract's own data
+        ;; holds only a reference node naming the spec, so widening that spec
+        ;; leaves every byte of the contract identical -- and the run whose
+        ;; output domain just moved would come back "faithful".  Absent from a
+        ;; property's data, where this is a no-op.
+        (setf pending (%collect-spec-references (getf property :returns) pending))
         (loop while pending
               for name = (pop pending)
               unless (gethash name seen)

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -91,7 +91,13 @@ and fbound for the adapter to report itself usable.")
 (defparameter +optional-functions+
   '((:list-specs . "LIST-SPECS")
     (:list-properties . "LIST-PROPERTIES")
-    (:properties-with-tag . "PROPERTIES-WITH-TAG"))
+    (:list-function-specs . "LIST-FUNCTION-SPECS")
+    (:properties-with-tag . "PROPERTIES-WITH-TAG")
+    (:function-spec-data . "FUNCTION-SPEC-DATA")
+    (:check-function . "CHECK-FUNCTION")
+    (:check-rejected . "FUNCTION-CHECK-RESULT-REJECTED")
+    (:check-failure-reason . "FUNCTION-CHECK-RESULT-FAILURE-REASON")
+    (:check-explanation . "FUNCTION-CHECK-RESULT-EXPLANATION"))
   "Adapter key to cl-spec function name, resolved when present.
 
 Absence costs one operation rather than the whole adapter: a cl-spec without
@@ -112,6 +118,7 @@ calls a function and a stub can supply either.")
     (:generator-unavailable . "GENERATOR-UNAVAILABLE")
     (:unknown-spec . "UNKNOWN-SPEC")
     (:unknown-property . "UNKNOWN-PROPERTY")
+    (:unknown-function-spec . "UNKNOWN-FUNCTION-SPEC")
     (:not-implemented . "NOT-IMPLEMENTED"))
   "Adapter key to cl-spec condition name.  Absence is tolerated: a missing
 condition class only costs a coarser classification, never an error.")

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -97,7 +97,8 @@ and fbound for the adapter to report itself usable.")
     (:check-function . "CHECK-FUNCTION")
     (:check-rejected . "FUNCTION-CHECK-RESULT-REJECTED")
     (:check-failure-reason . "FUNCTION-CHECK-RESULT-FAILURE-REASON")
-    (:check-explanation . "FUNCTION-CHECK-RESULT-EXPLANATION"))
+    (:check-explanation . "FUNCTION-CHECK-RESULT-EXPLANATION")
+    (:check-budget . "FUNCTION-CHECK-RESULT-BUDGET"))
   "Adapter key to cl-spec function name, resolved when present.
 
 Absence costs one operation rather than the whole adapter: a cl-spec without

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -659,10 +659,18 @@ different input domain and the run is not a reproduction of the earlier one.
 A reference to a spec that is not registered is recorded as unresolved rather
 than skipped, so the digest still changes if it is defined later."
   (handler-case
-      (let ((property (if property-p
-                          property
-                          (funcall (api-fn api data-key)
-                                   property-name :registry registry)))
+      (let ((property (or (if property-p
+                              property
+                              (funcall (api-fn api data-key)
+                                       property-name :registry registry))
+                          ;; A reader that answered NIL is not an empty
+                          ;; definition.  Digested as one it gave the same
+                          ;; stable hex for every unreadable name, published
+                          ;; with COMPLETE true -- so a replay against a
+                          ;; definition nothing had read came back "match",
+                          ;; in the field whose whole job is to say the
+                          ;; definition did not move.
+                          (return-from definition-digest (values nil nil))))
             (pending '())
             (seen (make-hash-table :test #'eq))
             (specs '()))

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -628,10 +628,17 @@ followed *PRINT-CASE*, which a digest must not."
                  "|"
                  (symbol-name symbol))))
 
-(defun definition-digest (api property-name registry &key (property nil property-p))
+(defun definition-digest (api property-name registry
+                          &key (property nil property-p)
+                               (data-key :property-data))
   "Return (values DIGEST COMPLETE-P) for PROPERTY-NAME's definition.
 
-PROPERTY, when supplied, is PROPERTY-DATA's plist for the same name, already
+DATA-KEY names the reader to fall back on when PROPERTY is not supplied.  It
+matters when a name carries both a property and a contract: digesting the
+property and stamping the result on the contract's run would report the
+definitions unchanged on the strength of a definition that was not run.
+
+PROPERTY, when supplied, is DATA-KEY's plist for the same name, already
 fetched by the caller.  Passing it is what keeps a listing of N properties to
 N calls rather than 2N: the digest needs exactly the data the summary beside
 it already read.
@@ -653,7 +660,7 @@ than skipped, so the digest still changes if it is defined later."
   (handler-case
       (let ((property (if property-p
                           property
-                          (funcall (api-fn api :property-data)
+                          (funcall (api-fn api data-key)
                                    property-name :registry registry)))
             (pending '())
             (seen (make-hash-table :test #'eq))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -938,6 +938,15 @@ while listing the properties about this symbol: ~A" condition)))))))
                                   (list +contract-not-selected-note+))))
                   nil)))))
 
+(defparameter +trials-needs-a-contract-message+
+  (concatenate 'string
+               "trials applies to a contract run (function=...) only. A "
+               "property's trial count comes from its own :trials table, "
+               "selected by profile; cl-spec's run-property takes no override, "
+               "so honouring trials here would report a budget the run did not "
+               "use.")
+  "Said when trials is given for a property selection.")
+
 (defun %target-argument-error (property symbol function)
   "Return the plist for a bad target selection, or NIL when it is fine.
 
@@ -1066,8 +1075,13 @@ the caveat."
           (definition-digest api name registry))
     (list :value value :complete (and value complete t))))
 
-(defun %trials-budget (api facts profile backend)
+(defun %trials-budget (api facts profile backend &optional requested)
   "Return the trial budget plist for a property described by FACTS under PROFILE.
+
+REQUESTED, when given, is the caller's explicit trial count for a contract run.
+A contract has no :TRIALS table for a profile to select from, so without this
+the only reachable budget is the backend's default -- and a contract whose
+failing region is a boundary needs more trials than that to reach it.
 
 cl-spec resolves this internally in RESOLVE-TRIALS and neither exports that
 function nor records the figure on a PROPERTY-RESULT, so it is derived here
@@ -1083,8 +1097,9 @@ computed from one backend and the run executed under another."
                        (handler-case
                            (funcall (api-fn api :backend-default-trials) backend)
                          (error () nil)))))
-    (list :budget (or from-profile default)
-          :budget-source (cond (from-profile "property-profile")
+    (list :budget (or requested from-profile default)
+          :budget-source (cond (requested "requested")
+                               (from-profile "property-profile")
                                (default "backend-default")
                                (t "unknown"))
           :property-trials (when table (printed-for-display table))
@@ -1444,7 +1459,7 @@ let a property budgeted zero trials report itself verified."
        t))
 
 (defun check-report (api api-status &key property symbol function package profile
-                                         seed expect-definition-digest
+                                         seed trials expect-definition-digest
                                          timeout-seconds
                                          (max-value-chars 2000))
   "Return the plist behind the spec-check tool.
@@ -1473,6 +1488,12 @@ anything holds."
         (list :status :backend-not-loaded
               :verified nil
               :message +backend-missing-message+
+              :environment environment)))
+    (when (and trials (not function))
+      (return-from check-report
+        (list :status :invalid-arguments
+              :verified nil
+              :message +trials-needs-a-contract-message+
               :environment environment)))
     (when (and function (not (and (api-has-p api :check-function)
                                   (api-has-p api :function-spec-data))))
@@ -1539,13 +1560,14 @@ anything holds."
               (let* ((facts (if (eq kind :contract)
                                 (%contract-facts api name registry)
                                 (%property-facts api name registry)))
-                     (trials (%trials-budget api facts profile-keyword backend))
+                     (budget-plist (%trials-budget api facts profile-keyword
+                                                   backend trials))
                      (digest (%digest-facts api name registry facts))
                      (remaining (- budget (%elapsed-since start)))
                      (result (%run-one api name registry kind profile-keyword seed
-                                       trials digest expect-definition-digest
-                                       remaining max-value-chars backend
-                                       facts)))
+                                       budget-plist digest
+                                       expect-definition-digest remaining
+                                       max-value-chars backend facts)))
                 (when (getf result :thread-leaked) (setf thread-leaked t))
                 (push result results)))
             (setf results (nreverse results))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -137,22 +137,6 @@ trailing spaces into every message and every JSON field carrying one.")
                "selected -- run it with property=")
   "Noted on a selection that deliberately left the symbol's own property out.")
 
-(defparameter +symbol-has-a-contract-note+
-  (concatenate 'string
-               "a function spec is registered for this symbol: read it with "
-               "spec-describe kind=function-spec, run it with spec-check "
-               "function=<this symbol>. It says which inputs the function "
-               "accepts and which output it must return, which the properties "
-               "about it do not.")
-  "Said by spec-symbol when a contract is registered for the symbol.")
-
-(defparameter +contract-not-selected-note+
-  (concatenate 'string
-               "a function spec is registered for this symbol and was NOT "
-               "run: an :about selection covers properties only. Run it with "
-               "spec-check function=<this symbol>.")
-  "Said by spec-check when an :about selection leaves a contract unchecked.")
-
 (defparameter +contract-coverage-note+
   (concatenate 'string
                "Only the contract named: its :pre, :returns and :post over "
@@ -370,7 +354,7 @@ is registered about this symbol: ~A" failure)
                         (when (getf routing :property)
                           (list +symbol-is-a-property-note+))
                         (when (getf routing :function-spec)
-                          (list (%symbol-contract-note api))))
+                          (list (%contract-note api))))
                 :environment environment)))))))
 
 ;;; ---------------------------------------------------------------------------
@@ -503,12 +487,14 @@ function-specs or both; got ~S" kind)
     ;; this gate was narrowed to stop giving.  A half it cannot list is
     ;; reported as its own null count, the way FUNCTION-SPECS-LISTABLE already
     ;; reports the third half.
-    (let ((wanted (cond ((string= kind "specs") '("list-specs"))
-                        ((string= kind "properties") '("list-properties"))
-                        ((string= kind "function-specs")
-                         '("list-function-specs with function-spec-data"))
-                        (t '("list-specs" "list-properties"
-                             "list-function-specs with function-spec-data"))))
+    (let ((wanted (remove nil
+                          (list (unless (api-has-p api :list-specs)
+                                  "list-specs")
+                                (unless (api-has-p api :list-properties)
+                                  "list-properties")
+                                (unless (and (api-has-p api :list-function-specs)
+                                             (api-has-p api :function-spec-data))
+                                  "list-function-specs with function-spec-data"))))
           (reachable
              (remove nil
                      (list (when (and (member kind '("specs" "both")
@@ -648,38 +634,44 @@ contract cannot be executed.~@[ ~A~]"
                            "Its text can still be read with spec-describe "
                            "kind=function-spec.")))))
 
-(defun %symbol-contract-note (api)
-  "Return spec-symbol's note about a registered contract, matched to the API.
+(defun %contract-note (api &key not-run)
+  "Return the note about a contract registered for a symbol, matched to the API.
 
-Every message this module prints is meant to be a true statement about the
-loaded revision, and an instruction is a statement too: sending a caller to
-spec-describe kind=function-spec on a cl-spec with no FUNCTION-SPEC-DATA, or
-to spec-check function= with no CHECK-FUNCTION, is a dead end issued by the
-one place that can see it is a dead end."
+NOT-RUN adds what a spec-check :ABOUT selection has to say for itself: the
+contract exists and this run did not cover it.
+
+One builder rather than two near-copies.  Every qualifier here comes off the
+same pair of API answers, and every message this module prints is meant to be
+a true statement about the loaded revision -- an instruction is a statement
+too, so sending a caller to spec-describe kind=function-spec on a cl-spec with
+no FUNCTION-SPEC-DATA is a dead end issued by the one place that can see it is
+one.  Written twice, a wording or capability fix reached one copy and not the
+other."
   (let ((readable (api-has-p api :function-spec-data))
         (runnable (api-has-p api :check-function)))
-    (cond
-      ((and readable runnable) +symbol-has-a-contract-note+)
-      (readable
-       (concatenate 'string
-                    "a function spec is registered for this symbol: read it "
-                    "with spec-describe kind=function-spec. The loaded "
-                    "cl-spec cannot run it -- it exports no check-function."))
-      (t
-       (concatenate 'string
-                    "a function spec is registered for this symbol. The "
-                    "loaded cl-spec exports no function-spec-data, so this "
-                    "adapter can neither project nor run it.")))))
-
-(defun %contract-not-selected-note (api)
-  "Return spec-check's note about the contract an :ABOUT selection left alone."
-  (if (and (api-has-p api :function-spec-data) (api-has-p api :check-function))
-      +contract-not-selected-note+
-      (concatenate 'string
-                   "a function spec is registered for this symbol and was NOT "
-                   "run: an :about selection covers properties only. The "
-                   "loaded cl-spec cannot run it either, so there is nothing "
-                   "to re-run it with.")))
+    (concatenate
+     'string
+     (if not-run
+         (concatenate 'string
+                      "a function spec is registered for this symbol and was "
+                      "NOT run: an :about selection covers properties only. ")
+         "a function spec is registered for this symbol. ")
+     (cond
+       ((and readable runnable)
+        (concatenate 'string
+                     "Read it with spec-describe kind=function-spec, run it "
+                     "with spec-check function=<this symbol>. It says which "
+                     "inputs the function accepts and which output it must "
+                     "return, which the properties about it do not."))
+       (readable
+        (concatenate 'string
+                     "Read it with spec-describe kind=function-spec. The "
+                     "loaded cl-spec cannot run it -- it exports no "
+                     "check-function."))
+       (t
+        (concatenate 'string
+                     "The loaded cl-spec exports no function-spec-data, so "
+                     "this adapter can neither project nor run it."))))))
 
 (defun %spec-tree (spec-plist)
   "Return SPEC-PLIST with its symbols externalized, or NIL when there is none.
@@ -1120,7 +1112,7 @@ while listing the properties about this symbol: ~A" condition)))))))
                                 (when (getf routing :property)
                                   (list +symbol-is-a-property-not-selected-note+))
                                 (when (getf routing :function-spec)
-                                  (list (%contract-not-selected-note api)))))
+                                  (list (%contract-note api :not-run t)))))
                   nil)))))
 
 (defparameter +trials-needs-a-contract-message+
@@ -1170,6 +1162,19 @@ refused only for a profile that was actually asked for."
        (list :status :invalid-arguments
              :message +profile-needs-a-property-message+)))))
 
+(defun %properties-about (api name registry)
+  "Return the properties registered (:about NAME), as symbol plists.
+
+Read for a contract selection so the response can say which properties it left
+alone.  The mirror of what an :ABOUT selection reports about the contract it
+did not run: both are coverage a caller would otherwise have to infer from
+prose, and the argument for naming one is the argument for naming the other."
+  (handler-case
+      (mapcar #'symbol-data
+              (getf (funcall (api-fn api :semantic-data) name :registry registry)
+                    :properties-about))
+    (error () nil)))
+
 (defun %select-properties (api property symbol function package registry)
   "Return (values NAMES SELECTION ERROR KIND DATA) for the requested selection.
 
@@ -1194,7 +1199,19 @@ learns it exists rather than being left to assume the run covered it."
                         :requested-key :function
                         :source "explicit function argument"
                         :coverage +contract-coverage-note+)
-       (values names selection error :contract data)))
+       (values names
+               (if names
+                   (let ((about (%properties-about api (first names) registry)))
+                     (append selection
+                             (list :properties-not-run about)
+                             (when about
+                               (list :notes
+                                     (list (format nil "~D propert~:@P ~
+registered (:about this symbol) ~:*~[~;is~:;are~] NOT covered by a contract ~
+run: run them with spec-check symbol=<this symbol>."
+                                                   (length about)))))))
+                   selection)
+               error :contract data)))
     (property
      (multiple-value-bind (names selection error data)
          (%select-named api property package registry
@@ -1419,7 +1436,10 @@ cl-spec's structured account of a return value that missed its spec."
       (multiple-value-bind (explanation-text explanation-complete
                             explanation-omitted)
           (if explanation
-              (print-form-bounded explanation max-value-chars)
+              ;; %PRINT-BOUNDED-FORM, not PRINT-FORM-BOUNDED: the clamp on a
+              ;; non-positive budget lives in the wrapper, and this was the
+              ;; one bounded print in the file reaching the stream without it.
+              (%print-bounded-form explanation max-value-chars)
               (values nil t nil))
         (list :rejected rejected
               :rejected-measured (and (integerp rejected) t)
@@ -1686,11 +1706,18 @@ For a contract the number that counts is the one with the rejected inputs taken
 out.  A generated argument list its :PRE refused was never passed to the
 function, so counting it here would let a contract nothing exercised report
 itself evaluated."
-  (let ((effective (getf (getf result :contract) :effective-trials))
-        (executed (getf (getf result :trials) :executed)))
-    (if (integerp effective)
-        (plusp effective)
-        (and (integerp executed) (plusp executed)))))
+  (let* ((contract (getf result :contract))
+         (effective (getf contract :effective-trials))
+         (executed (getf (getf result :trials) :executed)))
+    (cond
+      ;; The raw trial count is not a fallback here.  It is the number the
+      ;; rejection count was supposed to correct, and a run whose correction
+      ;; could not be computed has no usable count at all -- falling back to
+      ;; the uncorrected one let VERIFIED read true for a run whose own text
+      ;; says how often the function was called cannot be derived.
+      ((getf contract :rejected-overcounted) nil)
+      ((integerp effective) (plusp effective))
+      (t (and (integerp executed) (plusp executed))))))
 
 (defun %verification-gaps (results &optional selection)
   "Return the reasons RESULTS fall short of a complete verification.
@@ -1717,8 +1744,14 @@ establish -- read full coverage for a function whose contract never ran."
   (let ((gaps '())
         (rejections-measured t))
     (dolist (result results)
-      (unless (getf (getf result :contract) :rejected-measured)
-        (setf rejections-measured nil))
+      ;; Overcounted counts as unmeasured: an integer came back, and it is not
+      ;; a number this response can subtract with.  Keyed on the reader alone,
+      ;; the one case %CONTRACT-PLIST's overcount branch exists for reported
+      ;; no shortfall whatever.
+      (let ((contract (getf result :contract)))
+        (when (or (not (getf contract :rejected-measured))
+                  (getf contract :rejected-overcounted))
+          (setf rejections-measured nil)))
       (let ((status (getf result :status)))
         (case status
           (:passed (unless (%evaluated-p result) (pushnew :zero-trials gaps)))
@@ -1726,6 +1759,8 @@ establish -- read full coverage for a function whose contract never ran."
           (t (pushnew status gaps)))))
     (append (nreverse gaps)
             (when (getf selection :contract-not-run) (list :contract-not-run))
+            (when (getf selection :properties-not-run)
+              (list :properties-not-run))
             (unless rejections-measured (list :rejection-counts-unmeasured))
             (list :input-coverage-unmeasured))))
 

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -157,6 +157,15 @@ trailing spaces into every message and every JSON field carrying one.")
                "change the verdict.")
   "Said when the loaded cl-spec makes a verified contract run impossible.")
 
+(defun %rejections-countable-p (api)
+  "Return true when this cl-spec can be asked for a refused-input count.
+
+Only the presence of the reader can be checked before a run; whether it
+answers is a fact about the run, and %CONTRACT-PLIST's REJECTED-READABLE
+records it there.  Both cases end in the same place -- no contract run can
+reach VERIFIED -- so the note is worded for that rather than for one of them."
+  (api-has-p api :check-rejected))
+
 (defparameter +related-unknown-note+
   (concatenate 'string
                "whether any property is registered about this symbol could "
@@ -437,14 +446,17 @@ this cl-spec cannot enumerate.  One table, read by all four.
 
 (defparameter +contract-operations+
   '((:describe :function-spec-data)
-    (:run :check-function :function-spec-data)
-    (:list :list-function-specs :function-spec-data))
+    (:run :check-function :function-spec-data))
   "The cl-spec handles each contract operation needs.
 
-Written out by hand in three places -- DESCRIBE-REPORT's gate, CHECK-REPORT's
-gate and +LISTING-KINDS+ -- which is the arrangement +LISTING-KINDS+'s own
-docstring says had already disagreed twice on this branch.  Adding a handle to
-one operation is an edit here, not three ANDs no table checks.")
+Written out by hand in DESCRIBE-REPORT's gate and CHECK-REPORT's gate, which
+is the arrangement +LISTING-KINDS+'s own docstring says had already disagreed
+twice on this branch.  Adding a handle to one operation is an edit here, not
+two ANDs no table checks.
+
+The listing is not here: +LISTING-KINDS+ carries the handles for all three
+listing halves, including the contract one, and a second row for it would be
+the duplication both tables exist to remove.")
 
 (defun contract-operation-missing (api operation)
   "Return the handles OPERATION needs that API does not have."
@@ -1241,8 +1253,18 @@ while listing the properties about this symbol: ~A" condition)))))))
                         ;; the headline can say it and a JSON consumer can act
                         ;; on it.  A note several lines under a bare "VERIFIED"
                         ;; is read after the reader has already stopped.
-                        :contract-not-run (let ((contract (getf routing :function-spec)))
-                                            (when contract (symbol-data contract)))
+                        ;; Named only when this cl-spec could run it.  The
+                        ;; prose note qualifies itself for a revision that
+                        ;; cannot; the headline, the gap and this field are
+                        ;; the channels added so the fact need not be read out
+                        ;; of prose, and they were sending the caller to an
+                        ;; operation CHECK-REPORT answers :unsupported.
+                        :contract-not-run (let ((contract
+                                                  (getf routing :function-spec)))
+                                            (when (and contract
+                                                       (not (contract-operation-missing
+                                                             api :run)))
+                                              (symbol-data contract)))
                         :notes (append
                                 (when (getf routing :property)
                                   (list +symbol-is-a-property-not-selected-note+))
@@ -1366,7 +1388,7 @@ learns it exists rather than being left to assume the run covered it."
                                     ;; say so where the caller reads it, or
                                     ;; they retry with a larger trials=
                                     ;; against a gate no budget reaches.
-                                    (unless (api-has-p api :check-rejected)
+                                    (unless (%rejections-countable-p api)
                                       (list +unverifiable-contract-note+))
                                     (when about
                                       (list (format nil "~D propert~:@P ~
@@ -1655,14 +1677,28 @@ cl-spec's structured account of a return value that missed its spec."
                ;; verdict read a sixth.  The booleans below are published from
                ;; this, not computed beside it.
                (rejection-status
-                 ;; COUNTABLE first, and before every clause below it: each of
-                 ;; the others ends in a subtraction, and cl-spec can report a
-                 ;; result whose trial count is NIL -- its own check-function
-                 ;; writes (- (or (property-result-trials result) 0) rejected)
-                 ;; for that reason.  Ordered after :NO-PRECONDITION, a contract
-                 ;; without a :pre reached (- NIL 0) and the TYPE-ERROR was
-                 ;; reported to the caller as "this adapter failed".
-                 (cond ((not countable) :unmeasured)
+                 ;; The countability clauses first, before every one below
+                 ;; them: each of those ends in a subtraction, and cl-spec can
+                 ;; report a result whose trial count is NIL -- its own
+                 ;; check-function writes
+                 ;; (- (or (property-result-trials result) 0) rejected) for
+                 ;; that reason.  Ordered after :NO-PRECONDITION, a contract
+                 ;; without a :pre reached (- NIL 0) and the TYPE-ERROR came
+                 ;; back to the caller as "this adapter failed".
+                 ;;
+                 ;; :UNMEASURED and :TRIALS-UNCOUNTED are separate because
+                 ;; they are separate sentences: one says the refusal count
+                 ;; could not be read, the other that it was read and the
+                 ;; trial count was not.  One keyword for both had the text
+                 ;; denying a number the JSON was publishing beside it.
+                 (cond ((not (integerp rejected)) :unmeasured)
+                       ((not (integerp executed)) :trials-uncounted)
+                       ;; Both directions.  The premise of this plist is that
+                       ;; cl-spec's refusal counter cannot be trusted, and a
+                       ;; count below zero passed every gate: it subtracted to
+                       ;; MORE trials than the budget and carried a verified
+                       ;; verdict on the difference.
+                       ((minusp rejected) :negative)
                        (overcounted :overcounted)
                        ((eq :unknown precondition-p) :precondition-unknown)
                        (contradicted :contradicted)
@@ -1754,12 +1790,17 @@ arguments, or that a failure was somehow argument-free."
           ;; that carries it.
           :trials (let ((recorded (and (eq kind :contract)
                                        (%recorded-budget api result))))
-                    (list* :executed executed
-                           (if recorded
-                               (list :budget recorded
-                                     :budget-source "cl-spec result"
-                                     :budget-derivation nil)
-                               trials)))
+                    ;; Prepended, not substituted.  GETF finds the first
+                    ;; occurrence, so the recorded budget wins while the
+                    ;; derived plist keeps the keys it alone carries --
+                    ;; :BACKEND-DEFAULT among them, which a caller compares
+                    ;; against exactly when a trials= was in play.
+                    (append (list :executed executed)
+                            (when recorded
+                              (list :budget recorded
+                                    :budget-source "cl-spec result"
+                                    :budget-derivation nil))
+                            trials))
           ;; Text, not a number: a cl-spec seed reaches 2^62 and a JSON
           ;; consumer holding it as a number would round it, which turns a
           ;; reproducible failure into one that cannot be reproduced.
@@ -2009,6 +2050,11 @@ counted more refusals than trials."
         (and (integerp effective) (plusp effective))
         (and (integerp executed) (plusp executed)))))
 
+(defun %effective-unknown-p (result)
+  "Return true when RESULT is a contract run whose effective count is missing."
+  (let ((contract (getf result :contract)))
+    (and contract (not (integerp (getf contract :effective-trials))))))
+
 (defun %verification-gaps (results &optional selection)
   "Return the reasons RESULTS fall short of a complete verification.
 
@@ -2047,9 +2093,7 @@ establish -- read full coverage for a function whose contract never ran."
         ;; A contract run that timed out or never started carries no
         ;; contract half at all, so it is neither "measured" nor a property
         ;; run: nothing was counted, and the gap says so.
-        (when (or (null contract)
-                  (not (member (getf contract :rejection-status)
-                               '(:usable :no-precondition))))
+        (when (or (null contract) (not (getf contract :rejected-usable)))
           (setf rejections-measured nil)))
       (let ((status (getf result :status)))
         (case status
@@ -2060,15 +2104,17 @@ establish -- read full coverage for a function whose contract never ran."
              ;; count could not be derived did run trials, and saying its
              ;; budget was zero sends the reader to raise a number that was
              ;; never the problem.
-             (pushnew (if (and (getf result :contract)
-                               (not (integerp
-                                     (getf (getf result :contract)
-                                           :effective-trials))))
+             (pushnew (if (%effective-unknown-p result)
                           :effective-trials-unknown
                           :zero-trials)
                       gaps)))
           ((:failed :error) nil)
-          (t (pushnew status gaps)))))
+          (t (pushnew status gaps))))
+      ;; On every status, not only :PASSED.  A skipped or failed contract run
+      ;; whose count could not be derived is the case where it is least known,
+      ;; and the docs promise the gap is there whenever it is unknown.
+      (when (%effective-unknown-p result)
+        (pushnew :effective-trials-unknown gaps)))
     (append (nreverse gaps)
             (when (getf selection :contract-not-run) (list :contract-not-run))
             (when (or (getf selection :properties-not-run)

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -147,6 +147,23 @@ trailing spaces into every message and every JSON field carrying one.")
                "about the same symbol are NOT included and were not run.")
   "The limit of what an explicit contract selection covers.")
 
+(defparameter +unverifiable-contract-note+
+  (concatenate 'string
+               "this cl-spec exports no refused-input reader "
+               "(function-check-result-rejected), so no contract run here can "
+               "reach verified: how much of the generated input the function "
+               "actually saw cannot be established. Failures and "
+               "counterexamples are still reported. Raising trials will not "
+               "change the verdict.")
+  "Said when the loaded cl-spec makes a verified contract run impossible.")
+
+(defparameter +related-unknown-note+
+  (concatenate 'string
+               "whether any property is registered about this symbol could "
+               "not be read, so this run's coverage is unknown beyond the "
+               "contract.")
+  "Said when the reverse index could not be consulted for a contract run.")
+
 (defparameter +own-property-not-run-note+
   (concatenate 'string
                "this symbol is itself a registered property and was NOT run: "
@@ -417,6 +434,22 @@ this cl-spec cannot enumerate.  One table, read by all four.
 (defun listing-kind-wanted-p (row kind)
   "Return true when KIND asks for the listing half ROW describes."
   (or (string= kind "both") (string= kind (first row))))
+
+(defparameter +contract-operations+
+  '((:describe :function-spec-data)
+    (:run :check-function :function-spec-data)
+    (:list :list-function-specs :function-spec-data))
+  "The cl-spec handles each contract operation needs.
+
+Written out by hand in three places -- DESCRIBE-REPORT's gate, CHECK-REPORT's
+gate and +LISTING-KINDS+ -- which is the arrangement +LISTING-KINDS+'s own
+docstring says had already disagreed twice on this branch.  Adding a handle to
+one operation is an edit here, not three ANDs no table checks.")
+
+(defun contract-operation-missing (api operation)
+  "Return the handles OPERATION needs that API does not have."
+  (remove-if (lambda (key) (api-has-p api key))
+             (rest (assoc operation +contract-operations+))))
 
 (defun %listing-unsupported-message (missing)
   "Return the message for a listing kind this cl-spec cannot enumerate.
@@ -693,11 +726,8 @@ FUNCTION-SPEC-DATA -- and its fallback, \"read it with spec-describe\", is the
 one operation that revision cannot do either.  The whole point of the wording
 is that it is a statement about the loaded revision, so it has to name the
 right fact about it."
-  (let ((missing (remove nil
-                         (list (unless (api-has-p api :check-function)
-                                 "check-function")
-                               (unless (api-has-p api :function-spec-data)
-                                 "function-spec-data")))))
+  (let ((missing (mapcar (lambda (key) (string-downcase (symbol-name key)))
+                         (contract-operation-missing api :run))))
     (format nil "the cl-spec loaded here does not export ~{~A~^ or ~}, so a ~
 contract cannot be executed.~@[ ~A~]"
             missing
@@ -941,7 +971,7 @@ function-spec; got ~S" kind)
           (list :status :unresolved-symbol :reason reason :input name
                 :environment environment)))
       (when (and (string= kind "function-spec")
-                 (not (api-has-p api :function-spec-data)))
+                 (contract-operation-missing api :describe))
         (return-from describe-report
           (list :status :unsupported
                 :name (symbol-data symbol)
@@ -1330,27 +1360,23 @@ learns it exists rather than being left to assume the run covered it."
                              (list :properties-not-run about
                                    :own-property-not-run own
                                    :properties-not-run-read (and read t))
-                             (cond
-                               ((or about own)
-                                (list :notes
-                                      (append
-                                       (when about
-                                         (list (format nil "~D propert~:@P ~
+                             (list :notes
+                                   (append
+                                    ;; A verdict that can never flip has to
+                                    ;; say so where the caller reads it, or
+                                    ;; they retry with a larger trials=
+                                    ;; against a gate no budget reaches.
+                                    (unless (api-has-p api :check-rejected)
+                                      (list +unverifiable-contract-note+))
+                                    (when about
+                                      (list (format nil "~D propert~:@P ~
 registered (:about this symbol) ~:*~[~;is~:;are~] NOT covered by a contract ~
 run: run them with spec-check symbol=<this symbol>."
-                                                       (length about))))
-                                       (when own
-                                         (list +own-property-not-run-note+)))))
-                               ((not read)
-                                (list :notes
-                                      (list (concatenate 'string
-                                                         "whether any property "
-                                                         "is registered about "
-                                                         "this symbol could "
-                                                         "not be read, so "
-                                                         "this run's coverage "
-                                                         "is unknown beyond "
-                                                         "the contract")))))))
+                                                    (length about))))
+                                    (when own
+                                      (list +own-property-not-run-note+))
+                                    (unless read
+                                      (list +related-unknown-note+))))))
                    selection)
                error :contract data)))
     (property
@@ -1387,6 +1413,12 @@ truth is that nothing was read."
       (let ((data (or pre-read
                       (funcall (api-fn api :property-data) name
                                :registry registry))))
+        ;; The same refusal %CONTRACT-FACTS makes.  Read as a real answer, a
+        ;; NIL projection gives :ARGUMENT-COUNT 0 with :KNOWN T, and
+        ;; %RESULT-PLIST then reports an empty counterexample as "this
+        ;; property legitimately generates no arguments" rather than "nothing
+        ;; was read" -- which is what :KNOWN exists to keep apart.
+        (unless data (error 'unreadable-projection))
         (list :argument-count (length (getf data :arguments))
               :kind :property
               :shrink-enabled (and (getf (getf data :metadata) :shrink) t)
@@ -1603,10 +1635,7 @@ cl-spec's structured account of a return value that missed its spec."
       (multiple-value-bind (explanation explanation-read)
           (read-slot :check-explanation)
         (multiple-value-bind (rejected rejected-read) (read-slot :check-rejected)
-      (let* (;; REJECTED-READ, not (integerp rejected).  "no reader" and "the
-             ;; reader signalled" are different facts about the loaded
-             ;; revision, and the description promises the first.
-             (rejected rejected)
+        (let* (
                (countable (and (integerp executed) (integerp rejected)))
                (overcounted (and countable (> rejected executed)))
                ;; A refusal reported against a contract whose projection says it
@@ -1819,6 +1848,7 @@ budget computed from one backend and the trials run under another."
             :reason :budget-exhausted
             :trials trials
             :definition-digest (getf digest :value)
+            :definition-digest-covers (getf digest :covers)
             :definition-digest-complete (getf digest :complete)
             :definition-match :not-checked
             :counterexample-status :not-run
@@ -1865,6 +1895,7 @@ budget computed from one backend and the trials run under another."
                    :thread-leaked leaked
                    :trials trials
                    :definition-digest (getf digest :value)
+                   :definition-digest-covers (getf digest :covers)
                    :definition-digest-complete (getf digest :complete)
                    :definition-match :not-checked
                    :counterexample-status :unavailable
@@ -1879,6 +1910,7 @@ budget computed from one backend and the trials run under another."
                    :status (%classify-condition api value)
                    :trials trials
                    :definition-digest (getf digest :value)
+                   :definition-digest-covers (getf digest :covers)
                    :definition-digest-complete (getf digest :complete)
                    :definition-match :not-checked
                    :counterexample-status :unavailable
@@ -2042,8 +2074,7 @@ establish -- read full coverage for a function whose contract never ran."
             (when (or (getf selection :properties-not-run)
                       (getf selection :own-property-not-run))
               (list :properties-not-run))
-            (when (and (getf selection :kind)
-                       (eq :contract (getf selection :kind))
+            (when (and (eq :contract (getf selection :kind))
                        (not (getf selection :properties-not-run-read)))
               (list :related-properties-unknown))
             (unless rejections-measured (list :rejection-counts-unmeasured))
@@ -2093,8 +2124,7 @@ anything holds."
     ;; the image and does not change when a generator backend is installed.
     ;; Ordered the other way, a caller was sent to load cl-spec/check-it and
     ;; only then told that the cl-spec they have cannot run a contract at all.
-    (when (and function (not (and (api-has-p api :check-function)
-                                  (api-has-p api :function-spec-data))))
+    (when (and function (contract-operation-missing api :run))
       (return-from check-report
         (list :status :unsupported
               :verified nil

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -1197,9 +1197,9 @@ cl-spec's structured account of a return value that missed its spec."
            (when (api-has-p api key)
              (handler-case (funcall (api-fn api key) result)
                (error () nil)))))
-    (let* ((rejected (read-slot :check-rejected))
-           (reason (read-slot :check-failure-reason))
-           (explanation (read-slot :check-explanation)))
+    (let ((rejected (read-slot :check-rejected))
+          (reason (read-slot :check-failure-reason))
+          (explanation (read-slot :check-explanation)))
       (list :rejected rejected
             :rejected-measured (and (integerp rejected) t)
             :effective-trials (when (and (integerp executed) (integerp rejected))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -40,6 +40,9 @@
   (:export #:list-report
            #:+result-statuses+
            #:+call-statuses+
+           #:+verification-gap-values+
+           #:+listing-kinds+
+           #:listing-kind-wanted-p
            #:environment-data
            #:unavailable-report
            #:symbol-report
@@ -375,6 +378,25 @@ UNKNOWN-SPEC reports the failure as a failure."
         (is-a :unknown-property)
         (is-a :unknown-function-spec))))
 
+(defparameter +listing-kinds+
+  '(("specs" "specs" :specs-listable (:list-specs))
+    ("properties" "properties" :properties-listable (:list-properties))
+    ("function-specs" "function specs" :function-specs-listable
+     (:list-function-specs :function-spec-data)))
+  "One row per listing half: KIND name, label, listable key, required API keys.
+
+The kind-to-handle mapping was written four times -- the refusal message, the
+reachability gate, the per-half bindings here and the renderer's notes -- and
+two of those four have already disagreed in this branch: a gate that refused a
+kind reading neither handle, and a tag header claiming a filter over a half
+this cl-spec cannot enumerate.  One table, read by all four.
+
+\"both\" asks for every row; any other KIND asks for the row it names.")
+
+(defun listing-kind-wanted-p (row kind)
+  "Return true when KIND asks for the listing half ROW describes."
+  (or (string= kind "both") (string= kind (first row))))
+
 (defun %listing-unsupported-message (missing)
   "Return the message for a listing kind this cl-spec cannot enumerate.
 
@@ -487,37 +509,18 @@ function-specs or both; got ~S" kind)
     ;; this gate was narrowed to stop giving.  A half it cannot list is
     ;; reported as its own null count, the way FUNCTION-SPECS-LISTABLE already
     ;; reports the third half.
-    (let ((wanted (remove nil
-                          (list (when (and (member kind '("specs" "both")
-                                                   :test #'string=)
-                                           (not (api-has-p api :list-specs)))
-                                  "list-specs")
-                                (when (and (member kind '("properties" "both")
-                                                   :test #'string=)
-                                           (not (api-has-p api :list-properties)))
-                                  "list-properties")
-                                (when (and (member kind '("function-specs" "both")
-                                                   :test #'string=)
-                                           (not (and (api-has-p
-                                                      api :list-function-specs)
-                                                     (api-has-p
-                                                      api :function-spec-data))))
-                                  "list-function-specs with function-spec-data"))))
-          (reachable
-             (remove nil
-                     (list (when (and (member kind '("specs" "both")
-                                              :test #'string=)
-                                      (api-has-p api :list-specs))
-                             t)
-                           (when (and (member kind '("properties" "both")
-                                              :test #'string=)
-                                      (api-has-p api :list-properties))
-                             t)
-                           (when (and (member kind '("function-specs" "both")
-                                              :test #'string=)
-                                      (api-has-p api :list-function-specs)
-                                      (api-has-p api :function-spec-data))
-                             t)))))
+    (let* ((asked (remove-if-not (lambda (row) (listing-kind-wanted-p row kind))
+                                 +listing-kinds+))
+           (reachable (remove-if-not
+                       (lambda (row)
+                         (every (lambda (key) (api-has-p api key)) (fourth row)))
+                       asked))
+           (wanted (mapcar (lambda (row)
+                             (format nil "~{~A~^ with ~}"
+                                     (mapcar (lambda (key)
+                                               (string-downcase (symbol-name key)))
+                                             (fourth row))))
+                           (set-difference asked reachable :test #'eq))))
       (unless reachable
         (return-from list-report
           (list :status :unsupported
@@ -530,10 +533,17 @@ function-specs or both; got ~S" kind)
           (append package-error (list :environment environment))))
       (let* ((registry (funcall (api-fn api :registry)))
              (tag-keyword (and tag (find-keyword tag)))
-             (want-specs (member kind '("specs" "both") :test #'string=))
-             (want-properties (member kind '("properties" "both") :test #'string=))
-             (want-function-specs (member kind '("function-specs" "both")
-                                          :test #'string=))
+             (want-specs (listing-kind-wanted-p (assoc "specs" +listing-kinds+
+                                                       :test #'string=)
+                                                kind))
+             (want-properties (listing-kind-wanted-p
+                               (assoc "properties" +listing-kinds+
+                                      :test #'string=)
+                               kind))
+             (want-function-specs (listing-kind-wanted-p
+                                   (assoc "function-specs" +listing-kinds+
+                                          :test #'string=)
+                                   kind))
              ;; Listed only when cl-spec can enumerate them.  Absence is
              ;; reported as its own answer below rather than as an empty
              ;; list: "this revision cannot enumerate contracts" and "there
@@ -557,17 +567,23 @@ function-specs or both; got ~S" kind)
                (when (and want-specs specs-listable)
                  (remove-if-not (lambda (name) (%in-package-p name package-object))
                                 (funcall (api-fn api :list-specs) registry))))
+             ;; A tag needs a reader of its own, and a revision without one
+             ;; cannot answer the question at all.  Falling through to an
+             ;; empty list published "no property carries this tag" on the
+             ;; evidence of a missing function -- the conflation the three
+             ;; listable flags exist to prevent, for the one filter that had
+             ;; no flag.
+             (tag-filterable (or (null tag)
+                                 (api-has-p api :properties-with-tag)))
              (property-names
-               (when (and want-properties properties-listable)
+               (when (and want-properties properties-listable tag-filterable)
                  (remove-if-not
                   (lambda (name) (%in-package-p name package-object))
                   (cond
                     ((null tag) (funcall (api-fn api :list-properties) registry))
                     ((null tag-keyword) '())
-                    ((api-has-p api :properties-with-tag)
-                     (funcall (api-fn api :properties-with-tag)
-                              tag-keyword registry))
-                    (t '()))))))
+                    (t (funcall (api-fn api :properties-with-tag)
+                                tag-keyword registry)))))))
         (list :status :ok
               :kind kind
               :specs (mapcar #'symbol-data (%take spec-names limit))
@@ -578,6 +594,7 @@ function-specs or both; got ~S" kind)
               :function-specs-listable (and function-specs-listable t)
               :specs-listable (and specs-listable t)
               :properties-listable (and properties-listable t)
+              :tag-filterable (and tag-filterable t)
               ;; NIL, not 0, for a kind that was not asked for.  The count
               ;; is a fact about the registry and the list is what this
               ;; response carries; not looking leaves the first unknown, and
@@ -587,7 +604,8 @@ function-specs or both; got ~S" kind)
               :counts (list :specs (when (and want-specs specs-listable)
                                      (length spec-names))
                             :properties (when (and want-properties
-                                                   properties-listable)
+                                                   properties-listable
+                                                   tag-filterable)
                                           (length property-names))
                             :function-specs (when (and want-function-specs
                                                        function-specs-listable)
@@ -818,7 +836,12 @@ answers."
               :source-form-complete source-complete
               :source-form-omitted-chars source-omitted
               :source-location (getf data :source-location)
-              :definition-digest (definition-digest api name registry))))))
+              ;; The plist this function already read.  Without it the digest
+              ;; reads PROPERTY-DATA a second time and re-normalizes every
+              ;; argument spec -- the 2N that :PROPERTY exists to avoid, in
+              ;; the one describe path that was not passing it.
+              :definition-digest (definition-digest api name registry
+                                                    :property data))))))
 
 (defun %describe-spec (api name registry max-chars)
   "Return the detail plist for spec NAME."
@@ -1468,43 +1491,58 @@ cl-spec's structured account of a return value that missed its spec."
                  (error () (values nil nil)))
                (values nil nil))))
     (multiple-value-bind (reason reason-read) (read-slot :check-failure-reason)
-    (let* ((rejected (read-slot :check-rejected))
-           (explanation (read-slot :check-explanation))
-           (countable (and (integerp executed) (integerp rejected)))
-           (overcounted (and countable (> rejected executed))))
-      (multiple-value-bind (explanation-text explanation-complete
-                            explanation-omitted)
-          (if explanation
-              ;; %PRINT-BOUNDED-FORM, not PRINT-FORM-BOUNDED: the clamp on a
-              ;; non-positive budget lives in the wrapper, and this was the
-              ;; one bounded print in the file reaching the stream without it.
-              (%print-bounded-form explanation max-value-chars)
-              (values nil t nil))
-        (list :rejected rejected
-              :rejected-measured (and (integerp rejected) t)
-              ;; Carried so a renderer does not describe a refusal that
-              ;; cannot happen: "0 of them refused by :pre" told the reader a
-              ;; precondition exists, on a contract written without one.
-              :precondition-p precondition-p
-              :rejected-overcounted (and overcounted t)
-              ;; Absent, not floored, when the two cannot be subtracted: 0 is
-              ;; itself a claim -- "the function was never called" -- about a
-              ;; run that did call it, and the text says the number cannot be
-              ;; derived while the JSON would have said zero.
-              :effective-trials (when (and countable (not overcounted))
-                                  (- executed rejected))
-              :failure-reason reason
-              ;; Whether the reader resolved, not whether it returned something.
-              ;; NIL is a legitimate answer from cl-spec -- a passing run, or a
-              ;; failing one whose counterexample did not reproduce -- so it
-              ;; cannot double as "this adapter could not ask".  Reported for
-              ;; the same reason REJECTED-MEASURED is: without it a renderer
-              ;; tells the caller their function is non-deterministic on the
-              ;; evidence of a name this image could not find.
-              :failure-reason-readable (and reason-read t)
-              :explanation explanation-text
-              :explanation-complete explanation-complete
-              :explanation-omitted-chars explanation-omitted))))))
+      (let* ((rejected (read-slot :check-rejected))
+             (explanation (read-slot :check-explanation))
+             (countable (and (integerp executed) (integerp rejected)))
+             (overcounted (and countable (> rejected executed)))
+             ;; A refusal reported against a contract whose projection says it
+             ;; has nothing to refuse with.  Two readers disagreeing, like the
+             ;; overcount above, and handled the same way rather than only in
+             ;; the text: a subtraction over figures that contradict each
+             ;; other is not a call count, and publishing it while the text
+             ;; says it cannot be derived leaves one response saying both.
+             (contradicted (and countable
+                                (null precondition-p)
+                                (plusp rejected)))
+             (usable (and countable (not overcounted) (not contradicted))))
+        (multiple-value-bind (explanation-text explanation-complete
+                              explanation-omitted)
+            (if explanation
+                ;; %PRINT-BOUNDED-FORM, not PRINT-FORM-BOUNDED: the clamp on a
+                ;; non-positive budget lives in the wrapper, and this was the
+                ;; one bounded print in the file reaching the stream without
+                ;; it.
+                (%print-bounded-form explanation max-value-chars)
+                (values nil :not-applicable nil))
+          (list :rejected rejected
+                :rejected-measured (and (integerp rejected) t)
+                ;; Carried so a renderer does not describe a refusal that
+                ;; cannot happen: "0 of them refused by :pre" told the reader
+                ;; a precondition exists, on a contract written without one.
+                :precondition-p precondition-p
+                :rejected-overcounted (and overcounted t)
+                :rejected-contradicted (and contradicted t)
+                ;; The single question every consumer of this plist asks: is
+                ;; the refusal count one this response may subtract with.
+                :rejected-usable (and usable t)
+                ;; Absent, not floored, when the two cannot be subtracted: 0
+                ;; is itself a claim -- "the function was never called" --
+                ;; about a run that did call it, and the text says the number
+                ;; cannot be derived while the JSON would have said zero.
+                :effective-trials (when usable (- executed rejected))
+                :failure-reason reason
+                ;; Whether the reader resolved, not whether it returned it.
+                ;; NIL is a legitimate answer from cl-spec -- a passing run,
+                ;; or a failing one whose counterexample did not reproduce --
+                ;; so it cannot double as "this adapter could not ask".
+                ;; Reported for the same reason REJECTED-MEASURED is: without
+                ;; it a renderer tells the caller their function is
+                ;; non-deterministic on the evidence of a name this image
+                ;; could not find.
+                :failure-reason-readable (and reason-read t)
+                :explanation explanation-text
+                :explanation-complete explanation-complete
+                :explanation-omitted-chars explanation-omitted))))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
@@ -1697,6 +1735,19 @@ the run's own machinery."
     :unresolved-symbol :not-registered :invalid-arguments :internal-error)
   "Every status a whole spec-check call can carry.")
 
+(defparameter +verification-gap-values+
+  '(:zero-trials :effective-trials-unknown :rejection-counts-unmeasured
+    :input-coverage-unmeasured :contract-not-run :properties-not-run
+    :related-properties-unknown :no-properties-selected)
+  "Every verification_gaps value that is not a per-result status.
+
+A result status that is not a verdict is pushed into the list as itself, and
+those are documented through +RESULT-STATUSES+.  These are the rest, kept here
+for the same reason the status lists are: the tool description is the only
+documentation a model ever sees, this set has grown four times in one branch,
+and a value the code can emit that the description does not name is a value the
+caller has to guess at.")
+
 (defparameter +named-count-statuses+
   '((:passed . :passed) (:failed . :failed) (:error . :errored)
     (:timeout . :timed-out) (:not-run . :not-run))
@@ -1781,13 +1832,14 @@ establish -- read full coverage for a function whose contract never ran."
   (let ((gaps '())
         (rejections-measured t))
     (dolist (result results)
-      ;; Overcounted counts as unmeasured: an integer came back, and it is not
-      ;; a number this response can subtract with.  Keyed on the reader alone,
-      ;; the one case %CONTRACT-PLIST's overcount branch exists for reported
-      ;; no shortfall whatever.
+      ;; Keyed on REJECTED-USABLE, the one flag that answers "may this
+      ;; response subtract with the refusal count".  Keyed on the reader
+      ;; alone, every case %CONTRACT-PLIST withholds the figure for -- an
+      ;; overcount, a refusal against a contract with no :pre -- reported no
+      ;; shortfall whatever.  A property has no contract half at all, and its
+      ;; rejections happen inside the generator where nothing counts them.
       (let ((contract (getf result :contract)))
-        (when (or (not (getf contract :rejected-measured))
-                  (getf contract :rejected-overcounted))
+        (when (or (null contract) (not (getf contract :rejected-usable)))
           (setf rejections-measured nil)))
       (let ((status (getf result :status)))
         (case status
@@ -1891,10 +1943,13 @@ anything holds."
             (return-from check-report
               (list :status :no-properties
                     :verified nil
+                    ;; Through %VERIFICATION-GAPS like every other branch,
+                    ;; rather than assembled here: built by hand this list
+                    ;; omitted input-coverage-unmeasured, which the tool
+                    ;; description says is always in it.
                     :verification-gaps
-                    (append (list :no-properties-selected)
-                            (when (getf selection :contract-not-run)
-                              (list :contract-not-run)))
+                    (cons :no-properties-selected
+                          (%verification-gaps nil selection))
                     :selection selection
                     :results nil
                     :counts (%counts nil)

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -509,12 +509,13 @@ function-specs or both; got ~S" kind)
     ;; this gate was narrowed to stop giving.  A half it cannot list is
     ;; reported as its own null count, the way FUNCTION-SPECS-LISTABLE already
     ;; reports the third half.
-    (let* ((asked (remove-if-not (lambda (row) (listing-kind-wanted-p row kind))
-                                 +listing-kinds+))
-           (reachable (remove-if-not
+    (let* ((available (remove-if-not
                        (lambda (row)
                          (every (lambda (key) (api-has-p api key)) (fourth row)))
-                       asked)))
+                       +listing-kinds+))
+           (asked (remove-if-not (lambda (row) (listing-kind-wanted-p row kind))
+                                 +listing-kinds+))
+           (reachable (intersection asked available :test #'eq)))
       (unless reachable
         (return-from list-report
           (list :status :unsupported
@@ -530,102 +531,117 @@ function-specs or both; got ~S" kind)
                                              (fourth row))))
                            (set-difference asked reachable :test #'eq)))
                 :environment environment)))
-    (multiple-value-bind (package-object package-error)
-        (%listing-package-filter package)
-      (when package-error
-        (return-from list-report
-          (append package-error (list :environment environment))))
-      (let* ((registry (funcall (api-fn api :registry)))
-             (tag-keyword (and tag (find-keyword tag)))
-             (want-specs (assoc "specs" asked :test #'string=))
-             (want-properties (assoc "properties" asked :test #'string=))
-             (want-function-specs (assoc "function-specs" asked :test #'string=))
-             ;; Listed only when cl-spec can enumerate them.  Absence is
-             ;; reported as its own answer below rather than as an empty
-             ;; list: "this revision cannot enumerate contracts" and "there
-             ;; are none" are different, and only one of them is a fact
-             ;; about the project.
-             ;; Off REACHABLE, which the gate above already computed from
-             ;; the same rows and the same handles.  Re-running API-HAS-P here
-             ;; was the fourth copy of the mapping the table exists to hold.
-             (function-specs-listable (assoc "function-specs" reachable
-                                             :test #'string=))
-             (function-spec-names
-               (when (and want-function-specs function-specs-listable)
-                 (remove-if-not
-                  (lambda (name) (%in-package-p name package-object))
-                  (funcall (api-fn api :list-function-specs) registry))))
-             ;; Each half asks only for the reader it uses.  A revision
-             ;; missing one of them still lists the others, and the half it
-             ;; could not look at comes back as a null count beside a false
-             ;; listable flag -- never as an empty list, which would say the
-             ;; registry holds none.
-             (specs-listable (assoc "specs" reachable :test #'string=))
-             (properties-listable (assoc "properties" reachable :test #'string=))
-             (spec-names
-               (when (and want-specs specs-listable)
-                 (remove-if-not (lambda (name) (%in-package-p name package-object))
-                                (funcall (api-fn api :list-specs) registry))))
-             ;; A tag needs a reader of its own, and a revision without one
-             ;; cannot answer the question at all.  Falling through to an
-             ;; empty list published "no property carries this tag" on the
-             ;; evidence of a missing function -- the conflation the three
-             ;; listable flags exist to prevent, for the one filter that had
-             ;; no flag.
-             (tag-filterable (or (null tag)
-                                 (api-has-p api :properties-with-tag)))
-             (property-names
-               (when (and want-properties properties-listable tag-filterable)
-                 (remove-if-not
-                  (lambda (name) (%in-package-p name package-object))
-                  (cond
-                    ((null tag) (funcall (api-fn api :list-properties) registry))
-                    ((null tag-keyword) '())
-                    (t (funcall (api-fn api :properties-with-tag)
-                                tag-keyword registry)))))))
-        (list :status :ok
-              :kind kind
-              :specs (mapcar #'symbol-data (%take spec-names limit))
-              :properties (loop for name in (%take property-names limit)
-                                collect (%property-listing api name registry))
-              :function-specs (loop for name in (%take function-spec-names limit)
-                                    collect (%function-spec-listing api name registry))
-              :function-specs-listable (and function-specs-listable t)
-              :specs-listable (and specs-listable t)
-              :properties-listable (and properties-listable t)
-              :tag-filterable (and tag-filterable t)
-              ;; NIL, not 0, for a kind that was not asked for.  The count
-              ;; is a fact about the registry and the list is what this
-              ;; response carries; not looking leaves the first unknown, and
-              ;; reporting it as zero says the registry holds none -- the
-              ;; same conflation the tag and no-properties answers go out of
-              ;; their way to avoid.
-              :counts (list :specs (when (and want-specs specs-listable)
-                                     (length spec-names))
-                            :properties (when (and want-properties
-                                                   properties-listable
-                                                   tag-filterable)
-                                          (length property-names))
-                            :function-specs (when (and want-function-specs
-                                                       function-specs-listable)
-                                              (length function-spec-names)))
-              :truncated (or (> (length spec-names) limit)
-                             (> (length property-names) limit)
-                             (> (length function-spec-names) limit))
-              :limit limit
-              :filters (list :package (when package-object
-                                        (package-name package-object))
-                             :tag tag
-                             ;; A tag that names no keyword in this image
-                             ;; cannot be carried by any registered property,
-                             ;; so an empty result is correct -- but saying
-                             ;; only "empty" would read as "no property has
-                             ;; it" rather than "no such tag exists here".
-                             :tag-resolved (cond ((null tag) :not-requested)
-                                                 (tag-keyword t)
-                                                 (t nil)))
-              :coverage +listing-coverage-note+
-              :environment environment))))))
+      (multiple-value-bind (package-object package-error)
+          (%listing-package-filter package)
+        (when package-error
+          (return-from list-report
+            (append package-error (list :environment environment))))
+        (let* ((registry (funcall (api-fn api :registry)))
+               (tag-keyword (and tag (find-keyword tag)))
+               (want-specs (assoc "specs" asked :test #'string=))
+               (want-properties (assoc "properties" asked :test #'string=))
+               (want-function-specs (assoc "function-specs" asked :test #'string=))
+               ;; Listed only when cl-spec can enumerate them.  Absence is
+               ;; reported as its own answer below rather than as an empty
+               ;; list: "this revision cannot enumerate contracts" and "there
+               ;; are none" are different, and only one of them is a fact
+               ;; about the project.
+               ;; Off AVAILABLE, not REACHABLE.  REACHABLE is filtered to the
+               ;; kind this call asked for, and these three flags answer a
+               ;; question about the loaded revision: "can it enumerate this
+               ;; half at all".  Read off the filtered list, kind=function-specs
+               ;; reported that properties cannot be listed -- a client that
+               ;; asks contracts first would conclude the revision has no
+               ;; property listing and never ask again.
+               (function-specs-listable (assoc "function-specs" available
+                                               :test #'string=))
+               (function-spec-names
+                 (when (and want-function-specs function-specs-listable)
+                   (remove-if-not
+                    (lambda (name) (%in-package-p name package-object))
+                    (funcall (api-fn api :list-function-specs) registry))))
+               ;; Each half asks only for the reader it uses.  A revision
+               ;; missing one of them still lists the others, and the half it
+               ;; could not look at comes back as a null count beside a false
+               ;; listable flag -- never as an empty list, which would say the
+               ;; registry holds none.
+               (specs-listable (assoc "specs" available :test #'string=))
+               (properties-listable (assoc "properties" available :test #'string=))
+               (spec-names
+                 (when (and want-specs specs-listable)
+                   (remove-if-not (lambda (name) (%in-package-p name package-object))
+                                  (funcall (api-fn api :list-specs) registry))))
+               ;; A tag needs a reader of its own, and a revision without one
+               ;; cannot answer the question at all.  Falling through to an
+               ;; empty list published "no property carries this tag" on the
+               ;; evidence of a missing function -- the conflation the three
+               ;; listable flags exist to prevent, for the one filter that had
+               ;; no flag.
+               (tag-filterable (or (null tag)
+                                   (api-has-p api :properties-with-tag)))
+               (property-names
+                 (when (and want-properties properties-listable tag-filterable)
+                   (remove-if-not
+                    (lambda (name) (%in-package-p name package-object))
+                    (cond
+                      ((null tag) (funcall (api-fn api :list-properties) registry))
+                      ((null tag-keyword) '())
+                      (t (funcall (api-fn api :properties-with-tag)
+                                  tag-keyword registry)))))))
+          (list :status :ok
+                :kind kind
+                :specs (mapcar #'symbol-data (%take spec-names limit))
+                :properties (loop for name in (%take property-names limit)
+                                  collect (%property-listing api name registry))
+                :function-specs (loop for name in (%take function-spec-names limit)
+                                      collect (%function-spec-listing api name registry))
+                :function-specs-listable (and function-specs-listable t)
+                :specs-listable (and specs-listable t)
+                :properties-listable (and properties-listable t)
+                :tag-filterable (and tag-filterable t)
+                ;; NIL, not 0, for a kind that was not asked for.  The count
+                ;; is a fact about the registry and the list is what this
+                ;; response carries; not looking leaves the first unknown, and
+                ;; reporting it as zero says the registry holds none -- the
+                ;; same conflation the tag and no-properties answers go out of
+                ;; their way to avoid.
+                :counts (list :specs (when (and want-specs specs-listable)
+                                       (length spec-names))
+                              :properties (when (and want-properties
+                                                     properties-listable
+                                                     tag-filterable)
+                                            (length property-names))
+                              :function-specs (when (and want-function-specs
+                                                         function-specs-listable)
+                                                (length function-spec-names)))
+                :truncated (or (> (length spec-names) limit)
+                               (> (length property-names) limit)
+                               (> (length function-spec-names) limit))
+                :limit limit
+                :filters (list :package (when package-object
+                                          (package-name package-object))
+                               :tag tag
+                               ;; A tag that names no keyword in this image
+                               ;; cannot be carried by any registered property,
+                               ;; so an empty result is correct -- but saying
+                               ;; only "empty" would read as "no property has
+                               ;; it" rather than "no such tag exists here".
+                               :tag-resolved (cond ((null tag) :not-requested)
+                                                   (tag-keyword t)
+                                                   (t nil))
+                               ;; Whether the tag narrowed anything at all.  The
+                               ;; text said so and the payload did not, so a
+                               ;; JSON consumer reading filters.tag beside
+                               ;; tag_filterable concluded the listing had been
+                               ;; filtered -- the reading SELECTION.CONTRACT_
+                               ;; NOT_RUN was made data to avoid.
+                               :tag-applied (and tag
+                                                 want-properties
+                                                 properties-listable
+                                                 tag-filterable
+                                                 t))
+                :coverage +listing-coverage-note+
+                :environment environment))))))
 
 (defparameter +function-spec-unsupported-message+
   (concatenate 'string
@@ -759,6 +775,21 @@ cl-spec's answer to give, not this adapter's to assemble.
 projected: a function cannot be read, and whether they hold is what spec-check
 answers."
   (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+    ;; NIL is not a contract with no arguments and no :returns.  It renders
+    ;; byte-identically to one, which is the reading %FUNCTION-SPEC-LISTING
+    ;; carries :READ-FAILED to prevent -- and this is the path where a caller
+    ;; actually reads the contract before editing the function.
+    (unless data
+      (return-from %describe-function-spec
+        (list :status :unsupported
+              :kind "function-spec"
+              :name (symbol-data name)
+              :message
+              (concatenate 'string
+                           "cl-spec returned no projection for this contract. "
+                           "It is registered; what it says could not be read, "
+                           "and an empty description would read as a contract "
+                           "with no arguments and no :returns."))))
     (flet ((clause (forms)
              ;; Bounded like the body a property describe carries.  A :PRE or
              ;; :POST form is short in practice, but "in practice" is not a
@@ -1049,7 +1080,7 @@ appears in the property's trials table (see spec-describe)."
                         profile)))))
 
 (defun %registered-p (api data-key name registry)
-  "Return (values FOUND-P MESSAGE DATA) for NAME under the API reader DATA-KEY.
+  "Return (values FOUND-P MESSAGE DATA STATUS) for NAME under DATA-KEY.
 
 DATA-KEY is :PROPERTY-DATA or :FUNCTION-SPEC-DATA.  Every error is read as
 \"not registered\", which is true of cl-spec's unknown-name conditions and an
@@ -1062,7 +1093,16 @@ and FUNCTION-SPEC-DATA normalizes every argument spec and the return spec on
 each call.  Same reason DEFINITION-DIGEST takes a :PROPERTY."
   (handler-case
       (values t nil (funcall (api-fn api data-key) name :registry registry))
-    (error (condition) (values nil (princ-to-string condition) nil))))
+    ;; CL:UNDEFINED-FUNCTION gets its own status rather than being read as
+    ;; "not registered".  cl-spec raises it on purpose for a contract whose
+    ;; target has not been written yet -- the contract IS registered, and the
+    ;; run path already answers :UNDEFINED-FUNCTION for the same condition.
+    ;; Answering not-registered here made the two paths disagree about one
+    ;; fact, and told the caller to register something they already had.
+    (undefined-function (condition)
+      (values nil (princ-to-string condition) nil :undefined-function))
+    (error (condition)
+      (values nil (princ-to-string condition) nil :not-registered))))
 
 (defun %select-named (api designator package registry
                       &key data-key mode requested-key source coverage)
@@ -1081,10 +1121,10 @@ name in NAMES and to no other."
     (if (null name)
         (values nil nil (list :status :unresolved-symbol :reason reason
                               :input designator))
-        (multiple-value-bind (found-p message data)
+        (multiple-value-bind (found-p message data status)
             (%registered-p api data-key name registry)
           (if (not found-p)
-              (values nil nil (list :status :not-registered
+              (values nil nil (list :status (or status :not-registered)
                                     :name (symbol-data name)
                                     :message message))
               (values (list name)
@@ -1462,7 +1502,12 @@ report text is a rendering, not the value."
 
 (defun %contract-plist (api result executed max-value-chars
                         &optional (precondition-p :unknown))
-  "Return the contract-specific half of a CHECK-FUNCTION result, or NIL.
+  "Return the contract-specific half of a CHECK-FUNCTION result.
+
+Always a plist: %RESULT-PLIST decides whether a run had a contract half and
+calls this only then, and %EVALUATED-P reads a non-NIL :CONTRACT as \"this was
+a contract run\" -- a NIL return here would put it back on the raw trial count
+this function exists to withhold.
 
 REJECTED is what separates a run that checked the function from one that only
 generated arguments for it: cl-spec's checker refuses inputs its :PRE does not
@@ -1492,8 +1537,9 @@ cl-spec's structured account of a return value that missed its spec."
                  (error () (values nil nil)))
                (values nil nil))))
     (multiple-value-bind (reason reason-read) (read-slot :check-failure-reason)
+      (multiple-value-bind (explanation explanation-read)
+          (read-slot :check-explanation)
       (let* ((rejected (read-slot :check-rejected))
-             (explanation (read-slot :check-explanation))
              (countable (and (integerp executed) (integerp rejected)))
              (overcounted (and countable (> rejected executed)))
              ;; A refusal reported against a contract whose projection says it
@@ -1505,16 +1551,22 @@ cl-spec's structured account of a return value that missed its spec."
              (contradicted (and countable
                                 (null precondition-p)
                                 (plusp rejected)))
-             (usable (and countable
-                          (not overcounted)
-                          (not contradicted)
-                          ;; :UNKNOWN too.  The text already says a refusal
-                          ;; count cannot be interpreted without knowing
-                          ;; whether there is a :pre to have produced it;
-                          ;; leaving the subtraction in the payload let the
-                          ;; same response publish the figure and verify off
-                          ;; it while saying that.
-                          (not (eq :unknown precondition-p)))))
+             ;; One keyword for one three-valued question, decided in one
+             ;; place.  Five booleans meant the renderer re-derived which
+             ;; reason applied by testing them in an order that could not
+             ;; change -- :UNKNOWN is not NULL, so its clause had to precede
+             ;; the no-:pre one, silently -- while the gap list and the
+             ;; verdict read a sixth.  The booleans below are published from
+             ;; this, not computed beside it.
+             (rejection-status
+               (cond ((not (integerp rejected)) :unmeasured)
+                     (overcounted :overcounted)
+                     ((eq :unknown precondition-p) :precondition-unknown)
+                     (contradicted :contradicted)
+                     ((null precondition-p) :no-precondition)
+                     ((not countable) :unmeasured)
+                     (t :usable)))
+             (usable (member rejection-status '(:usable :no-precondition))))
         (multiple-value-bind (explanation-text explanation-complete
                               explanation-omitted)
             (if explanation
@@ -1525,6 +1577,7 @@ cl-spec's structured account of a return value that missed its spec."
                 (%print-bounded-form explanation max-value-chars)
                 (values nil :not-applicable nil))
           (list :rejected rejected
+                :rejection-status rejection-status
                 :rejected-measured (and (integerp rejected) t)
                 ;; Carried so a renderer does not describe a refusal that
                 ;; cannot happen: "0 of them refused by :pre" told the reader
@@ -1551,8 +1604,9 @@ cl-spec's structured account of a return value that missed its spec."
                 ;; could not find.
                 :failure-reason-readable (and reason-read t)
                 :explanation explanation-text
+                :explanation-readable (and explanation-read t)
                 :explanation-complete explanation-complete
-                :explanation-omitted-chars explanation-omitted))))))
+                :explanation-omitted-chars explanation-omitted)))))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
@@ -1742,7 +1796,8 @@ the run's own machinery."
 (defparameter +call-statuses+
   '(:no-properties :completed :incomplete :unsupported
     :cl-spec-not-loaded :cl-spec-incomplete :backend-not-loaded
-    :unresolved-symbol :not-registered :invalid-arguments :internal-error)
+    :unresolved-symbol :not-registered :undefined-function
+    :invalid-arguments :internal-error)
   "Every status a whole spec-check call can carry.")
 
 (defparameter +verification-gap-values+
@@ -1849,7 +1904,9 @@ establish -- read full coverage for a function whose contract never ran."
       ;; shortfall whatever.  A property has no contract half at all, and its
       ;; rejections happen inside the generator where nothing counts them.
       (let ((contract (getf result :contract)))
-        (when (or (null contract) (not (getf contract :rejected-usable)))
+        (when (or (null contract)
+                  (not (member (getf contract :rejection-status)
+                               '(:usable :no-precondition))))
           (setf rejections-measured nil)))
       (let ((status (getf result :status)))
         (case status

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -1246,11 +1246,17 @@ alone.  The mirror of what an :ABOUT selection reports about the contract it
 did not run: both are coverage a caller would otherwise have to infer from
 prose, and the argument for naming one is the argument for naming the other."
   (handler-case
-      (values (mapcar #'symbol-data
-                      (getf (funcall (api-fn api :semantic-data) name
-                                     :registry registry)
-                            :properties-about))
-              t)
+      (let ((routing (funcall (api-fn api :semantic-data) name
+                              :registry registry)))
+        ;; :PROPERTY as well as :PROPERTIES-ABOUT.  A symbol can be both a
+        ;; contract's subject and a property in its own name, and the :ABOUT
+        ;; path reports that direction explicitly -- dropping it here let a
+        ;; contract run answer "nothing else was left unrun" about a property
+        ;; of the same name, off a routing table already in hand.
+        (values (append (let ((own (getf routing :property)))
+                          (when own (list (symbol-data own))))
+                        (mapcar #'symbol-data (getf routing :properties-about)))
+                t))
     ;; (values NIL NIL) rather than NIL: an empty list here says the symbol has
     ;; no properties registered about it, and a read that failed has no
     ;; evidence for that.  Reported as its own fact, the way every sibling in
@@ -1354,6 +1360,17 @@ truth is that nothing was read."
       (list :argument-count nil :kind :property :shrink-enabled nil
             :trials-table nil :data nil :known nil))))
 
+(define-condition unreadable-projection (error)
+  ()
+  (:report (lambda (condition stream)
+             (declare (ignore condition))
+             (format stream "cl-spec returned no projection for this name.")))
+  (:documentation "Signalled when a cl-spec reader answers NIL for a name.
+
+Caught by the facts readers' own handler-case, which is what turns it into
+:KNOWN NIL -- the state that says nothing about this definition was read,
+rather than a set of answers derived from an empty plist."))
+
 (defun %contract-facts (api name registry &optional pre-read)
   "Return the facts about the contract for NAME a result needs.
 
@@ -1368,6 +1385,13 @@ here rather than things read off a definition."
       (let ((data (or pre-read
                       (funcall (api-fn api :function-spec-data) name
                                :registry registry))))
+        ;; A projection that came back NIL is not a contract with no arguments
+        ;; and no :pre.  %DESCRIBE-FUNCTION-SPEC refuses that inference and
+        ;; %FUNCTION-SPEC-LISTING carries :READ-FAILED for it; read here as a
+        ;; real answer it produced four positive claims -- no :pre, every
+        ;; input passed, a usable refusal count, an effective trial count --
+        ;; and a verified verdict resting on them.
+        (unless data (error 'unreadable-projection))
         (list :argument-count (length (getf data :arguments))
               :kind :contract
               :shrink-enabled t
@@ -1539,74 +1563,80 @@ cl-spec's structured account of a return value that missed its spec."
     (multiple-value-bind (reason reason-read) (read-slot :check-failure-reason)
       (multiple-value-bind (explanation explanation-read)
           (read-slot :check-explanation)
-      (let* ((rejected (read-slot :check-rejected))
-             (countable (and (integerp executed) (integerp rejected)))
-             (overcounted (and countable (> rejected executed)))
-             ;; A refusal reported against a contract whose projection says it
-             ;; has nothing to refuse with.  Two readers disagreeing, like the
-             ;; overcount above, and handled the same way rather than only in
-             ;; the text: a subtraction over figures that contradict each
-             ;; other is not a call count, and publishing it while the text
-             ;; says it cannot be derived leaves one response saying both.
-             (contradicted (and countable
-                                (null precondition-p)
-                                (plusp rejected)))
-             ;; One keyword for one three-valued question, decided in one
-             ;; place.  Five booleans meant the renderer re-derived which
-             ;; reason applied by testing them in an order that could not
-             ;; change -- :UNKNOWN is not NULL, so its clause had to precede
-             ;; the no-:pre one, silently -- while the gap list and the
-             ;; verdict read a sixth.  The booleans below are published from
-             ;; this, not computed beside it.
-             (rejection-status
-               (cond ((not (integerp rejected)) :unmeasured)
-                     (overcounted :overcounted)
-                     ((eq :unknown precondition-p) :precondition-unknown)
-                     (contradicted :contradicted)
-                     ((null precondition-p) :no-precondition)
-                     ((not countable) :unmeasured)
-                     (t :usable)))
-             (usable (member rejection-status '(:usable :no-precondition))))
-        (multiple-value-bind (explanation-text explanation-complete
-                              explanation-omitted)
-            (if explanation
-                ;; %PRINT-BOUNDED-FORM, not PRINT-FORM-BOUNDED: the clamp on a
-                ;; non-positive budget lives in the wrapper, and this was the
-                ;; one bounded print in the file reaching the stream without
-                ;; it.
-                (%print-bounded-form explanation max-value-chars)
-                (values nil :not-applicable nil))
-          (list :rejected rejected
-                :rejection-status rejection-status
-                :rejected-measured (and (integerp rejected) t)
-                ;; Carried so a renderer does not describe a refusal that
-                ;; cannot happen: "0 of them refused by :pre" told the reader
-                ;; a precondition exists, on a contract written without one.
-                :precondition-p precondition-p
-                :rejected-overcounted (and overcounted t)
-                :rejected-contradicted (and contradicted t)
-                ;; The single question every consumer of this plist asks: is
-                ;; the refusal count one this response may subtract with.
-                :rejected-usable (and usable t)
-                ;; Absent, not floored, when the two cannot be subtracted: 0
-                ;; is itself a claim -- "the function was never called" --
-                ;; about a run that did call it, and the text says the number
-                ;; cannot be derived while the JSON would have said zero.
-                :effective-trials (when usable (- executed rejected))
-                :failure-reason reason
-                ;; Whether the reader resolved, not whether it returned it.
-                ;; NIL is a legitimate answer from cl-spec -- a passing run,
-                ;; or a failing one whose counterexample did not reproduce --
-                ;; so it cannot double as "this adapter could not ask".
-                ;; Reported for the same reason REJECTED-MEASURED is: without
-                ;; it a renderer tells the caller their function is
-                ;; non-deterministic on the evidence of a name this image
-                ;; could not find.
-                :failure-reason-readable (and reason-read t)
-                :explanation explanation-text
-                :explanation-readable (and explanation-read t)
-                :explanation-complete explanation-complete
-                :explanation-omitted-chars explanation-omitted)))))))
+        (let* ((rejected (read-slot :check-rejected))
+               (countable (and (integerp executed) (integerp rejected)))
+               (overcounted (and countable (> rejected executed)))
+               ;; A refusal reported against a contract whose projection says it
+               ;; has nothing to refuse with.  Two readers disagreeing, like the
+               ;; overcount above, and handled the same way rather than only in
+               ;; the text: a subtraction over figures that contradict each
+               ;; other is not a call count, and publishing it while the text
+               ;; says it cannot be derived leaves one response saying both.
+               (contradicted (and countable
+                                  (null precondition-p)
+                                  (plusp rejected)))
+               ;; One keyword for one three-valued question, decided in one
+               ;; place.  Five booleans meant the renderer re-derived which
+               ;; reason applied by testing them in an order that could not
+               ;; change -- :UNKNOWN is not NULL, so its clause had to precede
+               ;; the no-:pre one, silently -- while the gap list and the
+               ;; verdict read a sixth.  The booleans below are published from
+               ;; this, not computed beside it.
+               (rejection-status
+                 ;; COUNTABLE first, and before every clause below it: each of
+                 ;; the others ends in a subtraction, and cl-spec can report a
+                 ;; result whose trial count is NIL -- its own check-function
+                 ;; writes (- (or (property-result-trials result) 0) rejected)
+                 ;; for that reason.  Ordered after :NO-PRECONDITION, a contract
+                 ;; without a :pre reached (- NIL 0) and the TYPE-ERROR was
+                 ;; reported to the caller as "this adapter failed".
+                 (cond ((not countable) :unmeasured)
+                       (overcounted :overcounted)
+                       ((eq :unknown precondition-p) :precondition-unknown)
+                       (contradicted :contradicted)
+                       ((null precondition-p) :no-precondition)
+                       (t :usable)))
+               (usable (member rejection-status '(:usable :no-precondition))))
+          (multiple-value-bind (explanation-text explanation-complete
+                                explanation-omitted)
+              (if explanation
+                  ;; %PRINT-BOUNDED-FORM, not PRINT-FORM-BOUNDED: the clamp on a
+                  ;; non-positive budget lives in the wrapper, and this was the
+                  ;; one bounded print in the file reaching the stream without
+                  ;; it.
+                  (%print-bounded-form explanation max-value-chars)
+                  (values nil :not-applicable nil))
+            (list :rejected rejected
+                  :rejection-status rejection-status
+                  :rejected-measured (and (integerp rejected) t)
+                  ;; Carried so a renderer does not describe a refusal that
+                  ;; cannot happen: "0 of them refused by :pre" told the reader
+                  ;; a precondition exists, on a contract written without one.
+                  :precondition-p precondition-p
+                  :rejected-overcounted (and overcounted t)
+                  :rejected-contradicted (and contradicted t)
+                  ;; The single question every consumer of this plist asks: is
+                  ;; the refusal count one this response may subtract with.
+                  :rejected-usable (and usable t)
+                  ;; Absent, not floored, when the two cannot be subtracted: 0
+                  ;; is itself a claim -- "the function was never called" --
+                  ;; about a run that did call it, and the text says the number
+                  ;; cannot be derived while the JSON would have said zero.
+                  :effective-trials (when usable (- executed rejected))
+                  :failure-reason reason
+                  ;; Whether the reader resolved, not whether it returned it.
+                  ;; NIL is a legitimate answer from cl-spec -- a passing run,
+                  ;; or a failing one whose counterexample did not reproduce --
+                  ;; so it cannot double as "this adapter could not ask".
+                  ;; Reported for the same reason REJECTED-MEASURED is: without
+                  ;; it a renderer tells the caller their function is
+                  ;; non-deterministic on the evidence of a name this image
+                  ;; could not find.
+                  :failure-reason-readable (and reason-read t)
+                  :explanation explanation-text
+                  :explanation-readable (and explanation-read t)
+                  :explanation-complete explanation-complete
+                  :explanation-omitted-chars explanation-omitted)))))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
@@ -1668,6 +1698,14 @@ counterexample cannot be told from a missing one")
           :elapsed (funcall (api-fn api :result-elapsed) result)
           :definition-digest (getf digest :value)
           :definition-digest-complete (getf digest :complete)
+          ;; What the digest is a digest OF.  It covers the definition
+          ;; cl-spec holds and the specs reachable from it -- which for a
+          ;; property is the thing that ran, and for a contract is not: the
+          ;; code under test is the function, and nothing here reads a
+          ;; function body.  Editing TRANSFER and replaying its contract from
+          ;; the same seed is faithful by this digest and is not a
+          ;; reproduction, so the field has to say which it measured.
+          :definition-digest-covers (getf digest :covers)
           :definition-match (%definition-match digest expected-digest))))
 
 (defun %definition-match (digest expected)
@@ -1904,6 +1942,9 @@ establish -- read full coverage for a function whose contract never ran."
       ;; shortfall whatever.  A property has no contract half at all, and its
       ;; rejections happen inside the generator where nothing counts them.
       (let ((contract (getf result :contract)))
+        ;; A contract run that timed out or never started carries no
+        ;; contract half at all, so it is neither "measured" nor a property
+        ;; run: nothing was counted, and the gap says so.
         (when (or (null contract)
                   (not (member (getf contract :rejection-status)
                                '(:usable :no-precondition))))
@@ -2063,7 +2104,10 @@ anything holds."
                                 (%property-facts api name registry selected-data)))
                      (budget-plist (%trials-budget api facts profile-keyword
                                                    backend trials))
-                     (digest (%digest-facts api name registry facts))
+                     (digest (append (%digest-facts api name registry facts)
+                                     (list :covers (if (eq kind :contract)
+                                                       :contract
+                                                       :property))))
                      (remaining (- budget (%elapsed-since start)))
                      (result (%run-one api name registry kind profile-keyword seed
                                        budget-plist digest

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -439,7 +439,12 @@ finding a name, not for reading a contract."
               :precondition-count (length (getf data :preconditions))
               :postcondition-count (length (getf data :postconditions))
               :documentation (getf data :documentation)))
-    (error () (list :name (symbol-data name)))))
+    ;; Marked, not merely emptied.  An entry with no parameters and no
+    ;; :RETURNS renders exactly like a genuine zero-argument contract with no
+    ;; return spec, so a read that failed came out as a positive claim about
+    ;; the contract -- and telling a reader whether an entry answers "which
+    ;; output must this return" is the listing's whole job.
+    (error () (list :name (symbol-data name) :read-failed t))))
 
 (defun %listing-package-filter (package)
   "Return (values PACKAGE-OBJECT ERROR) for the listing's package filter."
@@ -461,10 +466,17 @@ image, so nothing can be listed from it. It was looked up, not created."
 (defun list-report (api api-status &key kind package tag (limit 200))
   "Return the plist behind the spec-list tool.
 
-KIND is \"specs\", \"properties\" or \"both\".  PACKAGE and TAG narrow the
-result; TAG applies to properties only, and a tag no loaded code mentions is
-reported as unresolved rather than as an empty result, because the two are
-different answers."
+KIND is \"specs\", \"properties\", \"function-specs\" or \"both\", and each is
+gated on the cl-spec handles it actually reads.  \"specs\" needs LIST-SPECS,
+\"properties\" needs LIST-PROPERTIES, \"both\" needs the two of them, and
+\"function-specs\" needs neither -- it reads LIST-FUNCTION-SPECS and
+FUNCTION-SPEC-DATA, whose absence is fatal to no kind: contracts are left out
+and FUNCTION-SPECS-LISTABLE says so, because \"cannot look\" and \"none here\"
+are different answers.
+
+PACKAGE and TAG narrow the result; TAG applies to properties only, and a tag
+no loaded code mentions is reported as unresolved rather than as an empty
+result, for the same reason."
   (let ((environment (environment-data api api-status)))
     (unless (eq api-status :ok)
       (return-from list-report (unavailable-report api-status environment)))
@@ -575,13 +587,27 @@ function-specs or both; got ~S" kind)
                "whether a contract is registered for the symbol.")
   "Said when spec-describe is asked for a function spec cl-spec cannot project.")
 
-(defparameter +check-function-unsupported-message+
-  (concatenate 'string
-               "the cl-spec loaded here does not export check-function, so a "
-               "contract cannot be executed. Its text can still be read with "
-               "spec-describe kind=function-spec when function-spec-data is "
-               "available.")
-  "Said when spec-check is asked to run a contract cl-spec cannot run.")
+(defun %contract-unsupported-message (api)
+  "Return the message for a contract the loaded cl-spec cannot run.
+
+Names the handle that is actually absent.  A single sentence blaming
+CHECK-FUNCTION was wrong for the revision that has it and lacks
+FUNCTION-SPEC-DATA -- and its fallback, \"read it with spec-describe\", is the
+one operation that revision cannot do either.  The whole point of the wording
+is that it is a statement about the loaded revision, so it has to name the
+right fact about it."
+  (let ((missing (remove nil
+                         (list (unless (api-has-p api :check-function)
+                                 "check-function")
+                               (unless (api-has-p api :function-spec-data)
+                                 "function-spec-data")))))
+    (format nil "the cl-spec loaded here does not export ~{~A~^ or ~}, so a ~
+contract cannot be executed.~@[ ~A~]"
+            missing
+            (when (api-has-p api :function-spec-data)
+              (concatenate 'string
+                           "Its text can still be read with spec-describe "
+                           "kind=function-spec.")))))
 
 (defun %spec-tree (spec-plist)
   "Return SPEC-PLIST with its symbols externalized, or NIL when there is none.
@@ -908,31 +934,39 @@ appears in the property's trials table (see spec-describe)."
                         profile)))))
 
 (defun %registered-p (api data-key name registry)
-  "Return (values FOUND-P MESSAGE) for NAME under the API reader DATA-KEY.
+  "Return (values FOUND-P MESSAGE DATA) for NAME under the API reader DATA-KEY.
 
 DATA-KEY is :PROPERTY-DATA or :FUNCTION-SPEC-DATA.  Every error is read as
 \"not registered\", which is true of cl-spec's unknown-name conditions and an
 approximation for anything else it might signal; the message is carried so the
-approximation is at least visible."
+approximation is at least visible.
+
+DATA is the projection the probe already paid for.  Handed back rather than
+thrown away: the caller reads the same definition again a few frames later,
+and FUNCTION-SPEC-DATA normalizes every argument spec and the return spec on
+each call.  Same reason DEFINITION-DIGEST takes a :PROPERTY."
   (handler-case
-      (progn (funcall (api-fn api data-key) name :registry registry)
-             (values t nil))
-    (error (condition) (values nil (princ-to-string condition)))))
+      (values t nil (funcall (api-fn api data-key) name :registry registry))
+    (error (condition) (values nil (princ-to-string condition) nil))))
 
 (defun %select-named (api designator package registry
                       &key data-key mode requested-key source coverage)
-  "Return (values NAMES SELECTION ERROR) for one explicitly named definition.
+  "Return (values NAMES SELECTION ERROR DATA) for one explicitly named definition.
 
 Serves both explicit selections -- a property by name and a contract by name.
 They resolve, check and describe identically, and differ only in the reader
 they ask and the five literals they put in the selection plist; kept apart,
-each fix to one had to be remembered for the other."
+each fix to one had to be remembered for the other.
+
+DATA is the definition the registration check already read, passed on so the
+facts derived from it next need not read it again.  It belongs to the single
+name in NAMES and to no other."
   (multiple-value-bind (name reason)
       (resolve-symbol-designator designator :package package)
     (if (null name)
         (values nil nil (list :status :unresolved-symbol :reason reason
                               :input designator))
-        (multiple-value-bind (found-p message)
+        (multiple-value-bind (found-p message data)
             (%registered-p api data-key name registry)
           (if (not found-p)
               (values nil nil (list :status :not-registered
@@ -945,7 +979,8 @@ each fix to one had to be remembered for the other."
                             :count 1
                             :source source
                             :coverage coverage)
-                      nil))))))
+                      nil
+                      data))))))
 
 (defun %select-about (api symbol package registry)
   "Return (values NAMES SELECTION ERROR) for an :ABOUT reverse-index request."
@@ -1034,7 +1069,10 @@ refused only for a profile that was actually asked for."
              :message +profile-needs-a-property-message+)))))
 
 (defun %select-properties (api property symbol function package registry)
-  "Return (values NAMES SELECTION ERROR KIND) for the requested selection.
+  "Return (values NAMES SELECTION ERROR KIND DATA) for the requested selection.
+
+DATA is the definition an explicit selection already read, or NIL: an :ABOUT
+selection names many and reads none of them here.
 
 Exactly one of PROPERTY, SYMBOL and FUNCTION is supplied; %TARGET-ARGUMENT-ERROR
 has already rejected the other shapes.  KIND is :PROPERTY or :CONTRACT and says
@@ -1047,30 +1085,33 @@ reported coverage wrong.  The contract is named in a note instead, so a caller
 learns it exists rather than being left to assume the run covered it."
   (cond
     (function
-     (multiple-value-bind (names selection error)
+     (multiple-value-bind (names selection error data)
          (%select-named api function package registry
                         :data-key :function-spec-data
                         :mode "contract"
                         :requested-key :function
                         :source "explicit function argument"
                         :coverage +contract-coverage-note+)
-       (values names selection error :contract)))
+       (values names selection error :contract data)))
     (property
-     (multiple-value-bind (names selection error)
+     (multiple-value-bind (names selection error data)
          (%select-named api property package registry
                         :data-key :property-data
                         :mode "explicit"
                         :requested-key :property
                         :source "explicit property argument"
                         :coverage +explicit-coverage-note+)
-       (values names selection error :property)))
+       (values names selection error :property data)))
     (t
      (multiple-value-bind (names selection error)
          (%select-about api symbol package registry)
        (values names selection error :property)))))
 
-(defun %property-facts (api name registry)
+(defun %property-facts (api name registry &optional pre-read)
   "Return the facts about property NAME a result needs to describe itself.
+
+PRE-READ is the definition a caller has already projected, used instead of
+reading it a second time.
 
   (:argument-count <integer-or-nil> :shrink-enabled <boolean>
    :trials-table <plist-or-nil> :known <boolean>)
@@ -1083,7 +1124,9 @@ an empty list on its own cannot carry.  :KNOWN is false when PROPERTY-DATA
 could not be read at all, so a consumer is not told zero arguments when the
 truth is that nothing was read."
   (handler-case
-      (let ((data (funcall (api-fn api :property-data) name :registry registry)))
+      (let ((data (or pre-read
+                      (funcall (api-fn api :property-data) name
+                               :registry registry))))
         (list :argument-count (length (getf data :arguments))
               :shrink-enabled (and (getf (getf data :metadata) :shrink) t)
               :trials-table (getf data :trials)
@@ -1095,15 +1138,20 @@ truth is that nothing was read."
       (list :argument-count nil :shrink-enabled nil :trials-table nil
             :data nil :known nil))))
 
-(defun %contract-facts (api name registry)
+(defun %contract-facts (api name registry &optional pre-read)
   "Return the facts about the contract for NAME a result needs.
+
+PRE-READ is the definition a caller has already projected, used instead of
+reading it a second time.
 
 The same shape %PROPERTY-FACTS returns, so everything downstream reads one
 plist.  A contract has no :TRIALS table -- cl-spec's CHECK-FUNCTION takes a
 count, not a profile -- and shrinking is always on, so those two are constants
 here rather than things read off a definition."
   (handler-case
-      (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+      (let ((data (or pre-read
+                      (funcall (api-fn api :function-spec-data) name
+                               :registry registry))))
         (list :argument-count (length (getf data :arguments))
               :shrink-enabled t
               :trials-table nil
@@ -1162,7 +1210,15 @@ computed from one backend and the run executed under another."
 
 The condition classes are looked up on the API rather than named here, so an
 image whose cl-spec predates one of them degrades to a coarser status instead
-of failing to load."
+of failing to load.
+
+:INTERNAL-ERROR is the last resort and is documented as \"this adapter
+failed\", so anything cl-spec raises on purpose has to be recognized before it.
+A contract for a function nobody has written yet is the case that matters:
+cl-spec's FUNCTION-SPEC-TARGET signals CL:UNDEFINED-FUNCTION deliberately, so
+that a project can adopt cl-spec one function at a time, and reading that as
+an adapter fault tells the caller cl-mcp is broken when the fact is that they
+have not written the function."
   (flet ((is-a (key)
            (let ((class (api-class api key)))
              (and class (typep condition class)))))
@@ -1170,6 +1226,13 @@ of failing to load."
       ((or (is-a :no-generator-backend) (is-a :generator-unavailable))
        :generator-error)
       ((is-a :unknown-property) :not-registered)
+      ;; Both ahead of :CL-SPEC-ERROR, which they specialize.
+      ((is-a :unknown-function-spec) :not-registered)
+      ((is-a :not-implemented) :unsupported)
+      ;; Not a cl-spec condition, so it cannot be asked for by class: the
+      ;; named function is absent from this image, which is a fact about the
+      ;; image and not about either side of the adapter boundary.
+      ((typep condition 'undefined-function) :undefined-function)
       ((is-a :cl-spec-error) :backend-error)
       ;; A cl-spec that predates the condition hierarchy, or a condition from
       ;; somewhere else entirely.  The message is the only evidence available,
@@ -1216,7 +1279,7 @@ admit, and a trial count that includes them overstates the work.  It is
 reported with REJECTED-MEASURED beside it, because a cl-spec whose readers this
 adapter could not resolve gives NIL, which must not read as zero rejections.
 
-REJECTED can exceed EXECUTED, so the difference is floored at zero and the
+REJECTED can exceed EXECUTED, in which case the difference is withheld and the
 overshoot reported rather than published as a negative count.  cl-spec stops
 counting refusals at the first failure it recognizes, but a target that
 SIGNALS unwinds past that point with the counter still running, and shrinking
@@ -1243,7 +1306,12 @@ cl-spec's structured account of a return value that missed its spec."
         (list :rejected rejected
               :rejected-measured (and (integerp rejected) t)
               :rejected-overcounted (and overcounted t)
-              :effective-trials (when countable (max 0 (- executed rejected)))
+              ;; Absent, not floored, when the two cannot be subtracted: 0 is
+              ;; itself a claim -- "the function was never called" -- about a
+              ;; run that did call it, and the text says the number cannot be
+              ;; derived while the JSON would have said zero.
+              :effective-trials (when (and countable (not overcounted))
+                                  (- executed rejected))
               :failure-reason reason
               ;; Whether the reader resolved, not whether it returned something.
               ;; NIL is a legitimate answer from cl-spec -- a passing run, or a
@@ -1286,7 +1354,12 @@ arguments, or that a failure was somehow argument-free."
           ;; consumer holding it as a number would round it, which turns a
           ;; reproducible failure into one that cannot be reproduced.
           :seed (when seed (format nil "~D" seed))
-          :profile (funcall (api-fn api :result-profile) result)
+          ;; NIL for a contract, which has no profile.  CHECK-FUNCTION takes
+          ;; none; :NORMAL appears on the result only because RUN-PROPERTY
+          ;; defaults it on the synthetic property cl-spec builds underneath.
+          ;; Publishing that is the same mis-report profile= is refused for.
+          :profile (unless (eq kind :contract)
+                     (funcall (api-fn api :result-profile) result))
           :counterexample (%named-values counterexample max-value-chars)
           :counterexample-status
           (cond ((not verdict) :not-applicable)
@@ -1426,14 +1499,8 @@ the run's own machinery."
 (defparameter +result-statuses+
   '(:passed :failed :error :skipped :pending
     :timeout :not-run :generator-error :backend-error :not-registered
-    :internal-error)
-  "Every status one property's result can carry.
-
-Listed in one place so the tool description can be checked against it.  The
-set grew three times while the adapter was being reviewed and the description
-did not follow, which left an agent reading about seven statuses that a run
-could answer with eleven -- and the description is the only documentation a
-model ever sees.")
+    :undefined-function :unsupported :internal-error)
+  "Every status one property's result can carry.")
 
 (defparameter +call-statuses+
   '(:no-properties :completed :incomplete :unsupported
@@ -1495,17 +1562,24 @@ itself evaluated."
         (plusp effective)
         (and (integerp executed) (plusp executed)))))
 
-(defun %verification-gaps (results)
+(defun %verification-gaps (results &optional selection)
   "Return the reasons RESULTS fall short of a complete verification.
 
 Input coverage holds on every run this adapter can make and is listed anyway:
 nothing reports which parts of the input domain were reached, so a caller must
 not read a trial count as that (cl-spec specification 72.1).
 
-Rejection counts are listed only when they were in fact not measured.  A
-property has no precondition and no rejection to count, and a contract check
-reports one; claiming the gap where the number is right there would train a
-reader to ignore the list."
+Rejection counts are listed whenever they were not measured, which is every
+property run -- a property has no precondition, so there is no refused-input
+count to have and nothing here can say how much of the generated input the
+body actually exercised.  A contract check measures it, and claiming the gap
+where the number is right there would train a reader to ignore the list.
+
+SELECTION is read for what did not run at all.  A contract an :ABOUT selection
+left alone is a coverage shortfall like any other, and until it was listed
+here the only place that said so was the headline: a consumer branching on
+VERIFIED and this list -- the documented pair for what a run could not
+establish -- read full coverage for a function whose contract never ran."
   (let ((gaps '())
         (rejections-measured t))
     (dolist (result results)
@@ -1517,6 +1591,7 @@ reader to ignore the list."
           ((:failed :error) nil)
           (t (pushnew status gaps)))))
     (append (nreverse gaps)
+            (when (getf selection :contract-not-run) (list :contract-not-run))
             (unless rejections-measured (list :rejection-counts-unmeasured))
             (list :input-coverage-unmeasured))))
 
@@ -1570,7 +1645,7 @@ anything holds."
       (return-from check-report
         (list :status :unsupported
               :verified nil
-              :message +check-function-unsupported-message+
+              :message (%contract-unsupported-message api)
               :environment environment)))
     (multiple-value-bind (profile-keyword profile-error) (%resolve-profile profile)
       (when profile-error
@@ -1578,7 +1653,7 @@ anything holds."
           (list :status :invalid-arguments :verified nil
                 :message profile-error :environment environment)))
       (let ((registry (funcall (api-fn api :registry))))
-        (multiple-value-bind (names selection selection-error kind)
+        (multiple-value-bind (names selection selection-error kind selected-data)
             (%select-properties api property symbol function package registry)
           (when selection-error
             (return-from check-report
@@ -1588,7 +1663,10 @@ anything holds."
             (return-from check-report
               (list :status :no-properties
                     :verified nil
-                    :verification-gaps (list :no-properties-selected)
+                    :verification-gaps
+                    (append (list :no-properties-selected)
+                            (when (getf selection :contract-not-run)
+                              (list :contract-not-run)))
                     :selection selection
                     :results nil
                     :counts (%counts nil)
@@ -1627,9 +1705,12 @@ anything holds."
                              (funcall (api-fn api :generator-backend))
                            (error () nil))))
             (dolist (name names)
+              ;; SELECTED-DATA is set only by an explicit selection, which
+              ;; names exactly one definition -- this one.  An :ABOUT
+              ;; selection leaves it NIL and each name is read here.
               (let* ((facts (if (eq kind :contract)
-                                (%contract-facts api name registry)
-                                (%property-facts api name registry)))
+                                (%contract-facts api name registry selected-data)
+                                (%property-facts api name registry selected-data)))
                      (budget-plist (%trials-budget api facts profile-keyword
                                                    backend trials))
                      (digest (%digest-facts api name registry facts))
@@ -1647,11 +1728,14 @@ anything holds."
                               :completed
                               :incomplete)
                   :verified (%verified-p results)
-                  :verification-gaps (%verification-gaps results)
+                  :verification-gaps (%verification-gaps results selection)
                   :selection selection
                   :results results
                   :counts (%counts results)
-                  :profile profile-keyword
+                  ;; Absent on a contract run for the same reason it is
+                  ;; refused as an argument there: nothing selected it and
+                  ;; nothing used it.
+                  :profile (unless (eq kind :contract) profile-keyword)
                   :timeout-seconds budget
                   :thread-leaked thread-leaked
                   ;; Reported for any timeout, not only a leaked one.  A

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -951,6 +951,12 @@ while listing the properties about this symbol: ~A" condition)))))))
                         :count (length about)
                         :source +about-source+
                         :coverage +about-coverage-note+
+                        ;; Carried as a name, not only as prose in a note, so
+                        ;; the headline can say it and a JSON consumer can act
+                        ;; on it.  A note several lines under a bare "VERIFIED"
+                        ;; is read after the reader has already stopped.
+                        :contract-not-run (let ((contract (getf routing :function-spec)))
+                                            (when contract (symbol-data contract)))
                         :notes (append
                                 (when (getf routing :property)
                                   (list +symbol-is-a-property-not-selected-note+))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -137,6 +137,29 @@ trailing spaces into every message and every JSON field carrying one.")
                "selected -- run it with property=")
   "Noted on a selection that deliberately left the symbol's own property out.")
 
+(defparameter +symbol-has-a-contract-note+
+  (concatenate 'string
+               "a function spec is registered for this symbol: read it with "
+               "spec-describe kind=function-spec, run it with spec-check "
+               "function=<this symbol>. It says which inputs the function "
+               "accepts and which output it must return, which the properties "
+               "about it do not.")
+  "Said by spec-symbol when a contract is registered for the symbol.")
+
+(defparameter +contract-not-selected-note+
+  (concatenate 'string
+               "a function spec is registered for this symbol and was NOT "
+               "run: an :about selection covers properties only. Run it with "
+               "spec-check function=<this symbol>.")
+  "Said by spec-check when an :about selection leaves a contract unchecked.")
+
+(defparameter +contract-coverage-note+
+  (concatenate 'string
+               "Only the contract named: its :pre, :returns and :post over "
+               "arguments generated from its :args. Properties registered "
+               "about the same symbol are NOT included and were not run.")
+  "The limit of what an explicit contract selection covers.")
+
 (defparameter +about-source+
   (concatenate 'string
                "cl-spec:semantic-data -> :properties-about "
@@ -345,7 +368,9 @@ is registered about this symbol: ~A" failure)
                 :notes (append
                         (list "properties_about lists direct (:about ...) registrations only")
                         (when (getf routing :property)
-                          (list +symbol-is-a-property-note+)))
+                          (list +symbol-is-a-property-note+))
+                        (when (getf routing :function-spec)
+                          (list +symbol-has-a-contract-note+)))
                 :environment environment)))))))
 
 ;;; ---------------------------------------------------------------------------
@@ -362,7 +387,9 @@ UNKNOWN-SPEC reports the failure as a failure."
   (flet ((is-a (key)
            (let ((class (api-class api key)))
              (and class (typep condition class)))))
-    (or (is-a :unknown-spec) (is-a :unknown-property))))
+    (or (is-a :unknown-spec)
+        (is-a :unknown-property)
+        (is-a :unknown-function-spec))))
 
 (defparameter +listing-unsupported-message+
   (concatenate 'string
@@ -395,6 +422,25 @@ exists\" is the shape of question that should stay cheap."
               :documentation (getf data :documentation)))
     (error () (list :name (symbol-data name)))))
 
+(defun %function-spec-listing (api name registry)
+  "Return the one-line listing entry for the contract registered for NAME.
+
+Reports the parameter names and whether the contract carries a :RETURNS, which
+is what tells a reader whether the entry answers \"which output must this
+return\" at all.  The specs themselves stay in spec-describe: a listing is for
+finding a name, not for reading a contract."
+  (handler-case
+      (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+        (list :name (symbol-data name)
+              :parameters (mapcar (lambda (argument)
+                                    (symbol-data (getf argument :variable)))
+                                  (getf data :arguments))
+              :returns-specified (and (getf data :returns) t)
+              :precondition-count (length (getf data :preconditions))
+              :postcondition-count (length (getf data :postconditions))
+              :documentation (getf data :documentation)))
+    (error () (list :name (symbol-data name)))))
+
 (defun %listing-package-filter (package)
   "Return (values PACKAGE-OBJECT ERROR) for the listing's package filter."
   (if (null package)
@@ -423,11 +469,12 @@ different answers."
     (unless (eq api-status :ok)
       (return-from list-report (unavailable-report api-status environment)))
     (unless (and (stringp kind)
-                 (member kind '("specs" "properties" "both") :test #'string=))
+                 (member kind '("specs" "properties" "function-specs" "both")
+                         :test #'string=))
       (return-from list-report
         (list :status :invalid-arguments
-              :message (format nil "kind must be one of specs, properties or ~
-both; got ~S" kind)
+              :message (format nil "kind must be one of specs, properties, ~
+function-specs or both; got ~S" kind)
               :environment environment)))
     (unless (and (api-has-p api :list-specs) (api-has-p api :list-properties))
       (return-from list-report
@@ -443,6 +490,20 @@ both; got ~S" kind)
              (tag-keyword (and tag (find-keyword tag)))
              (want-specs (member kind '("specs" "both") :test #'string=))
              (want-properties (member kind '("properties" "both") :test #'string=))
+             (want-function-specs (member kind '("function-specs" "both")
+                                          :test #'string=))
+             ;; Listed only when cl-spec can enumerate them.  Absence is
+             ;; reported as its own answer below rather than as an empty
+             ;; list: "this revision cannot enumerate contracts" and "there
+             ;; are none" are different, and only one of them is a fact
+             ;; about the project.
+             (function-specs-listable (and (api-has-p api :list-function-specs)
+                                           (api-has-p api :function-spec-data)))
+             (function-spec-names
+               (when (and want-function-specs function-specs-listable)
+                 (remove-if-not
+                  (lambda (name) (%in-package-p name package-object))
+                  (funcall (api-fn api :list-function-specs) registry))))
              (spec-names
                (when want-specs
                  (remove-if-not (lambda (name) (%in-package-p name package-object))
@@ -463,6 +524,9 @@ both; got ~S" kind)
               :specs (mapcar #'symbol-data (%take spec-names limit))
               :properties (loop for name in (%take property-names limit)
                                 collect (%property-listing api name registry))
+              :function-specs (loop for name in (%take function-spec-names limit)
+                                    collect (%function-spec-listing api name registry))
+              :function-specs-listable (and function-specs-listable t)
               ;; NIL, not 0, for a kind that was not asked for.  The count
               ;; is a fact about the registry and the list is what this
               ;; response carries; not looking leaves the first unknown, and
@@ -471,9 +535,13 @@ both; got ~S" kind)
               ;; their way to avoid.
               :counts (list :specs (when want-specs (length spec-names))
                             :properties (when want-properties
-                                          (length property-names)))
+                                          (length property-names))
+                            :function-specs (when (and want-function-specs
+                                                       function-specs-listable)
+                                              (length function-spec-names)))
               :truncated (or (> (length spec-names) limit)
-                             (> (length property-names) limit))
+                             (> (length property-names) limit)
+                             (> (length function-spec-names) limit))
               :limit limit
               :filters (list :package (when package-object
                                         (package-name package-object))
@@ -491,12 +559,21 @@ both; got ~S" kind)
 
 (defparameter +function-spec-unsupported-message+
   (concatenate 'string
-               "cl-spec provides no function-spec-data projection in this "
-               "revision, and defspec-function is still a stub, so there is "
-               "nothing to describe. cl-mcp will not assemble one out of the "
-               "individual readers: that would duplicate cl-spec's "
-               "introspection responsibility on this side of the boundary.")
-  "Said when spec-describe is asked for a function spec.")
+               "the cl-spec loaded here does not export function-spec-data, "
+               "so there is nothing to project. cl-mcp will not assemble one "
+               "out of the individual readers: that would duplicate cl-spec's "
+               "introspection responsibility on this side of the boundary. "
+               "This is a statement about the loaded revision, not about "
+               "whether a contract is registered for the symbol.")
+  "Said when spec-describe is asked for a function spec cl-spec cannot project.")
+
+(defparameter +check-function-unsupported-message+
+  (concatenate 'string
+               "the cl-spec loaded here does not export check-function, so a "
+               "contract cannot be executed. Its text can still be read with "
+               "spec-describe kind=function-spec when function-spec-data is "
+               "available.")
+  "Said when spec-check is asked to run a contract cl-spec cannot run.")
 
 (defun %spec-tree (spec-plist)
   "Return SPEC-PLIST with its symbols externalized, or NIL when there is none.
@@ -531,6 +608,39 @@ to the caller as one that exists."
           :source-form (printed-for-display (getf spec-plist :source-form))
           :source-location (getf spec-plist :source-location)
           :children (mapcar #'%spec-tree (getf spec-plist :children)))))
+
+(defun %describe-function-spec (api name registry max-chars)
+  "Return the detail plist for the contract registered for NAME.
+
+Built from cl-spec's own FUNCTION-SPEC-DATA, for the same reason the spec and
+property projections are: the two halves a caller asks about before editing a
+function -- which inputs are accepted, which output is required -- are
+cl-spec's answer to give, not this adapter's to assemble.
+
+:PRE and :POST are the author's forms.  Their compiled counterparts are not
+projected: a function cannot be read, and whether they hold is what spec-check
+answers."
+  (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+    (multiple-value-bind (source source-complete source-omitted)
+        (%print-bounded-form (getf data :source-form) max-chars)
+      (list :status :ok
+            :kind "function-spec"
+            :name (symbol-data name)
+            :documentation (getf data :documentation)
+            :arguments (loop for argument in (getf data :arguments)
+                             collect (list :variable
+                                           (symbol-data (getf argument :variable))
+                                           :spec (%spec-tree (getf argument :spec))))
+            :returns (%spec-tree (getf data :returns))
+            :preconditions (let ((forms (getf data :preconditions)))
+                             (when forms (printed-for-display forms)))
+            :postconditions (let ((forms (getf data :postconditions)))
+                              (when forms (printed-for-display forms)))
+            :source-form source
+            :source-form-complete source-complete
+            :source-form-omitted-chars source-omitted
+            :source-location (getf data :source-location)
+            :definition-digest (definition-digest api name registry :property data)))))
 
 (defun %describe-property (api name registry max-chars)
   "Return the detail plist for property NAME."
@@ -596,7 +706,8 @@ function-spec; got ~S" kind)
         (return-from describe-report
           (list :status :unresolved-symbol :reason reason :input name
                 :environment environment)))
-      (when (string= kind "function-spec")
+      (when (and (string= kind "function-spec")
+                 (not (api-has-p api :function-spec-data)))
         (return-from describe-report
           (list :status :unsupported
                 :name (symbol-data symbol)
@@ -604,9 +715,12 @@ function-spec; got ~S" kind)
                 :environment environment)))
       (handler-case
           (let ((registry (funcall (api-fn api :registry))))
-            (append (if (string= kind "property")
-                        (%describe-property api symbol registry max-chars)
-                        (%describe-spec api symbol registry max-chars))
+            (append (cond
+                      ((string= kind "property")
+                       (%describe-property api symbol registry max-chars))
+                      ((string= kind "function-spec")
+                       (%describe-function-spec api symbol registry max-chars))
+                      (t (%describe-spec api symbol registry max-chars)))
                     (list :environment environment)))
         (error (condition)
           ;; Only cl-spec's own "no such name" conditions become
@@ -817,36 +931,83 @@ while listing the properties about this symbol: ~A" condition)))))))
                         :count (length about)
                         :source +about-source+
                         :coverage +about-coverage-note+
-                        :notes (when (getf routing :property)
-                                 (list +symbol-is-a-property-not-selected-note+)))
+                        :notes (append
+                                (when (getf routing :property)
+                                  (list +symbol-is-a-property-not-selected-note+))
+                                (when (getf routing :function-spec)
+                                  (list +contract-not-selected-note+))))
                   nil)))))
 
-(defun %target-argument-error (property symbol)
-  "Return the plist for a bad property/symbol pair, or NIL when it is fine.
+(defun %target-argument-error (property symbol function)
+  "Return the plist for a bad target selection, or NIL when it is fine.
 
-Checked before cl-spec is consulted.  Naming both or neither is a mistake in
-the call itself, and answering \"cl-spec is not loaded\" would send the caller
-to fix the wrong thing -- the same reason SPEC-ENTRY validates the seed before
-it resolves the API."
+Checked before cl-spec is consulted.  Naming more than one or none of them is
+a mistake in the call itself, and answering \"cl-spec is not loaded\" would
+send the caller to fix the wrong thing -- the same reason SPEC-ENTRY validates
+the seed before it resolves the API."
+  (let ((given (count-if-not #'null (list property symbol function))))
+    (cond
+      ((> given 1)
+       (list :status :invalid-arguments
+             :message "give exactly one of property, symbol or function"))
+      ((zerop given)
+       (list :status :invalid-arguments
+             :message "give one of property, symbol or function")))))
+
+(defun %registered-contract-p (api name registry)
+  "Return (values FOUND-P MESSAGE) for the contract registered for NAME."
+  (handler-case
+      (progn (funcall (api-fn api :function-spec-data) name :registry registry)
+             (values t nil))
+    (error (condition) (values nil (princ-to-string condition)))))
+
+(defun %select-contract (api function package registry)
+  "Return (values NAMES SELECTION ERROR) for an explicit contract request."
+  (multiple-value-bind (name reason)
+      (resolve-symbol-designator function :package package)
+    (if (null name)
+        (values nil nil (list :status :unresolved-symbol :reason reason
+                              :input function))
+        (multiple-value-bind (found-p message)
+            (%registered-contract-p api name registry)
+          (if (not found-p)
+              (values nil nil (list :status :not-registered
+                                    :name (symbol-data name)
+                                    :message message))
+              (values (list name)
+                      (list :mode "contract"
+                            :requested (list :function (symbol-data name))
+                            :selected (list (symbol-data name))
+                            :count 1
+                            :source "explicit function argument"
+                            :coverage +contract-coverage-note+)
+                      nil))))))
+
+(defun %select-properties (api property symbol function package registry)
+  "Return (values NAMES SELECTION ERROR KIND) for the requested selection.
+
+Exactly one of PROPERTY, SYMBOL and FUNCTION is supplied; %TARGET-ARGUMENT-ERROR
+has already rejected the other shapes.  KIND is :PROPERTY or :CONTRACT and says
+which runner the names go to.
+
+A symbol that is itself a registered property is deliberately not added to an
+:ABOUT selection, and neither is a contract registered for it: those are
+different relationships, and quietly widening what gets executed would make the
+reported coverage wrong.  The contract is named in a note instead, so a caller
+learns it exists rather than being left to assume the run covered it."
   (cond
-    ((and property symbol)
-     (list :status :invalid-arguments
-           :message "give either property or symbol, not both"))
-    ((not (or property symbol))
-     (list :status :invalid-arguments
-           :message "give one of property or symbol"))))
-
-(defun %select-properties (api property symbol package registry)
-  "Return (values NAMES SELECTION ERROR) for the requested selection.
-
-Exactly one of PROPERTY and SYMBOL is supplied; %TARGET-ARGUMENT-ERROR has
-already rejected the other two shapes.  A symbol that is itself a registered
-property is deliberately not added to an :ABOUT selection: that is a different
-relationship, and quietly widening what gets executed would make the reported
-coverage wrong."
-  (if property
-      (%select-explicit api property package registry)
-      (%select-about api symbol package registry)))
+    (function
+     (multiple-value-bind (names selection error)
+         (%select-contract api function package registry)
+       (values names selection error :contract)))
+    (property
+     (multiple-value-bind (names selection error)
+         (%select-explicit api property package registry)
+       (values names selection error :property)))
+    (t
+     (multiple-value-bind (names selection error)
+         (%select-about api symbol package registry)
+       (values names selection error :property)))))
 
 (defun %property-facts (api name registry)
   "Return the facts about property NAME a result needs to describe itself.
@@ -872,6 +1033,24 @@ truth is that nothing was read."
               :known t))
     (error ()
       (list :argument-count nil :shrink-enabled nil :trials-table nil
+            :data nil :known nil))))
+
+(defun %contract-facts (api name registry)
+  "Return the facts about the contract for NAME a result needs.
+
+The same shape %PROPERTY-FACTS returns, so everything downstream reads one
+plist.  A contract has no :TRIALS table -- cl-spec's CHECK-FUNCTION takes a
+count, not a profile -- and shrinking is always on, so those two are constants
+here rather than things read off a definition."
+  (handler-case
+      (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+        (list :argument-count (length (getf data :arguments))
+              :shrink-enabled t
+              :trials-table nil
+              :data data
+              :known t))
+    (error ()
+      (list :argument-count nil :shrink-enabled t :trials-table nil
             :data nil :known nil))))
 
 (defun %digest-facts (api name registry facts)
@@ -962,7 +1141,33 @@ report text is a rendering, not the value."
                       :value (externalize-value value
                                                 :max-chars max-value-chars))))
 
-(defun %result-plist (api result name trials digest expected-digest
+(defun %contract-plist (api result executed max-value-chars)
+  "Return the contract-specific half of a CHECK-FUNCTION result, or NIL.
+
+REJECTED is what separates a run that checked the function from one that only
+generated arguments for it: cl-spec's checker refuses inputs its :PRE does not
+admit, and a trial count that includes them overstates the work.  It is
+reported with REJECTED-MEASURED beside it, because a cl-spec whose readers this
+adapter could not resolve gives NIL, which must not read as zero rejections.
+
+FAILURE-REASON names which half of the contract broke; EXPLANATION carries
+cl-spec's structured account of a return value that missed its spec."
+  (flet ((read-slot (key)
+           (when (api-has-p api key)
+             (handler-case (funcall (api-fn api key) result)
+               (error () nil)))))
+    (let* ((rejected (read-slot :check-rejected))
+           (reason (read-slot :check-failure-reason))
+           (explanation (read-slot :check-explanation)))
+      (list :rejected rejected
+            :rejected-measured (and (integerp rejected) t)
+            :effective-trials (when (and (integerp executed) (integerp rejected))
+                                (- executed rejected))
+            :failure-reason reason
+            :explanation (when explanation
+                           (print-form-bounded explanation max-value-chars))))))
+
+(defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
   "Return the per-property plist for a cl-spec RESULT.
 
@@ -979,11 +1184,14 @@ arguments, or that a failure was somehow argument-free."
          (seed (funcall (api-fn api :result-seed) result))
          (argument-count (getf facts :argument-count))
          (zero-argument-property (eql 0 argument-count))
+         (executed (funcall (api-fn api :result-trials) result))
          (verdict (member status '(:failed :error))))
     (list :property (symbol-data name)
+          :kind kind
+          :contract (when (eq kind :contract)
+                      (%contract-plist api result executed max-value-chars))
           :status status
-          :trials (list* :executed (funcall (api-fn api :result-trials) result)
-                         trials)
+          :trials (list* :executed executed trials)
           ;; Text, not a number: a cl-spec seed reaches 2^62 and a JSON
           ;; consumer holding it as a number would round it, which turns a
           ;; reproducible failure into one that cannot be reproduced.
@@ -1034,9 +1242,14 @@ reproduction that was in fact faithful."
   (/ (float (- (get-internal-real-time) start))
      internal-time-units-per-second))
 
-(defun %run-one (api name registry profile seed trials digest expected-digest
+(defun %run-one (api name registry kind profile seed trials digest expected-digest
                  remaining max-value-chars backend facts)
-  "Run property NAME within REMAINING seconds and return its result plist.
+  "Run property or contract NAME within REMAINING seconds and return its plist.
+
+KIND is :PROPERTY or :CONTRACT.  A contract goes to CHECK-FUNCTION, which takes
+a trial count rather than a profile: cl-spec resolves a property's count from
+its own :TRIALS table and a contract has none, so the budget derived here is
+handed over directly.
 
 The deadline covers rendering as well as running.  Generation, evaluation,
 shrinking and the printing of the counterexample all happen inside it, because
@@ -1049,6 +1262,7 @@ bindings, so without this a caller who rebound the backend would have the
 budget computed from one backend and the trials run under another."
   (if (< remaining *minimum-run-budget-seconds*)
       (list :property (symbol-data name)
+            :kind kind
             :status :not-run
             :reason :budget-exhausted
             :trials trials
@@ -1071,10 +1285,14 @@ budget computed from one backend and the trials run under another."
              (lambda ()
                (progv names settings
                  (%result-plist api
-                                (funcall (api-fn api :run-property) name
-                                         :profile profile :seed seed
-                                         :registry registry)
-                                name trials digest expected-digest
+                                (if (eq kind :contract)
+                                    (funcall (api-fn api :check-function) name
+                                             :trials (getf trials :budget)
+                                             :seed seed :registry registry)
+                                    (funcall (api-fn api :run-property) name
+                                             :profile profile :seed seed
+                                             :registry registry))
+                                name kind trials digest expected-digest
                                 max-value-chars facts)))
              remaining
              :name "mcp-spec-check")
@@ -1082,6 +1300,7 @@ budget computed from one backend and the trials run under another."
             (:ok (first value))
             (:timeout
              (list :property (symbol-data name)
+                   :kind kind
                    :status :timeout
                    :timeout-seconds value
                    :thread-leaked leaked
@@ -1097,6 +1316,7 @@ budget computed from one backend and the trials run under another."
                    (if leaked +timeout-leaked-message+ +timeout-stopped-message+)))
             (:error
              (list :property (symbol-data name)
+                   :kind kind
                    :status (%classify-condition api value)
                    :trials trials
                    :definition-digest (getf digest :value)
@@ -1173,26 +1393,42 @@ same total in one number, and SELECTED always equals the sum."
 
 cl-spec reports :PASSED for a property whose profile resolves to a budget of
 zero -- the trial loop simply never runs -- and a passing status with nothing
-behind it is precisely the shape of a verification that did not happen."
-  (let ((executed (getf (getf result :trials) :executed)))
-    (and (integerp executed) (plusp executed))))
+behind it is precisely the shape of a verification that did not happen.
+
+For a contract the number that counts is the one with the rejected inputs taken
+out.  A generated argument list its :PRE refused was never passed to the
+function, so counting it here would let a contract nothing exercised report
+itself evaluated."
+  (let ((effective (getf (getf result :contract) :effective-trials))
+        (executed (getf (getf result :trials) :executed)))
+    (if (integerp effective)
+        (plusp effective)
+        (and (integerp executed) (plusp executed)))))
 
 (defun %verification-gaps (results)
   "Return the reasons RESULTS fall short of a complete verification.
 
-Two of these hold on every run this adapter can make, and are listed anyway:
-cl-spec's runner reports neither how many generated inputs a precondition
-rejected nor which parts of the input domain were reached, so a caller must
-not read a trial count as either (cl-spec specification 72.1)."
-  (let ((gaps '()))
+Input coverage holds on every run this adapter can make and is listed anyway:
+nothing reports which parts of the input domain were reached, so a caller must
+not read a trial count as that (cl-spec specification 72.1).
+
+Rejection counts are listed only when they were in fact not measured.  A
+property has no precondition and no rejection to count, and a contract check
+reports one; claiming the gap where the number is right there would train a
+reader to ignore the list."
+  (let ((gaps '())
+        (rejections-measured t))
     (dolist (result results)
+      (unless (getf (getf result :contract) :rejected-measured)
+        (setf rejections-measured nil))
       (let ((status (getf result :status)))
         (case status
           (:passed (unless (%evaluated-p result) (pushnew :zero-trials gaps)))
           ((:failed :error) nil)
           (t (pushnew status gaps)))))
     (append (nreverse gaps)
-            (list :rejection-counts-unmeasured :input-coverage-unmeasured))))
+            (unless rejections-measured (list :rejection-counts-unmeasured))
+            (list :input-coverage-unmeasured))))
 
 (defun %verified-p (results)
   "Return true only when RESULTS are evidence that every property held.
@@ -1207,22 +1443,23 @@ let a property budgeted zero trials report itself verified."
               results)
        t))
 
-(defun check-report (api api-status &key property symbol package profile seed
-                                         expect-definition-digest
+(defun check-report (api api-status &key property symbol function package profile
+                                         seed expect-definition-digest
                                          timeout-seconds
                                          (max-value-chars 2000))
   "Return the plist behind the spec-check tool.
 
-Runs either the property named by PROPERTY or every property registered
-:ABOUT the symbol named by SYMBOL.  TIMEOUT-SECONDS is the budget for the
-whole call, spent across the selection in order.
+Runs the property named by PROPERTY, every property registered :ABOUT the
+symbol named by SYMBOL, or the function spec named by FUNCTION.
+TIMEOUT-SECONDS is the budget for the whole call, spent across the selection
+in order.
 
 :VERIFIED is true only when at least one property was selected and every one
 of them passed.  A selection of zero, a timeout, a generator failure and a
 skipped run are each reported as themselves: none of them is evidence that
 anything holds."
   (let ((environment (environment-data api api-status))
-        (argument-error (%target-argument-error property symbol)))
+        (argument-error (%target-argument-error property symbol function)))
     ;; Before the availability check, deliberately: an argument that is wrong
     ;; is wrong whatever cl-spec is doing, and reporting the load state first
     ;; would send the caller to fix the wrong thing.
@@ -1237,14 +1474,21 @@ anything holds."
               :verified nil
               :message +backend-missing-message+
               :environment environment)))
+    (when (and function (not (and (api-has-p api :check-function)
+                                  (api-has-p api :function-spec-data))))
+      (return-from check-report
+        (list :status :unsupported
+              :verified nil
+              :message +check-function-unsupported-message+
+              :environment environment)))
     (multiple-value-bind (profile-keyword profile-error) (%resolve-profile profile)
       (when profile-error
         (return-from check-report
           (list :status :invalid-arguments :verified nil
                 :message profile-error :environment environment)))
       (let ((registry (funcall (api-fn api :registry))))
-        (multiple-value-bind (names selection selection-error)
-            (%select-properties api property symbol package registry)
+        (multiple-value-bind (names selection selection-error kind)
+            (%select-properties api property symbol function package registry)
           (when selection-error
             (return-from check-report
               (append selection-error
@@ -1292,11 +1536,13 @@ anything holds."
                              (funcall (api-fn api :generator-backend))
                            (error () nil))))
             (dolist (name names)
-              (let* ((facts (%property-facts api name registry))
+              (let* ((facts (if (eq kind :contract)
+                                (%contract-facts api name registry)
+                                (%property-facts api name registry)))
                      (trials (%trials-budget api facts profile-keyword backend))
                      (digest (%digest-facts api name registry facts))
                      (remaining (- budget (%elapsed-since start)))
-                     (result (%run-one api name registry profile-keyword seed
+                     (result (%run-one api name registry kind profile-keyword seed
                                        trials digest expect-definition-digest
                                        remaining max-value-chars backend
                                        facts)))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -399,7 +399,7 @@ is registered about this symbol: ~A" failure)
 ;;; spec-describe
 ;;; ---------------------------------------------------------------------------
 
-(defun %describe-condition-status (api condition)
+(defun %describe-condition-status (api condition &optional contract-p)
   "Return the status DESCRIBE-REPORT should answer for CONDITION.
 
 CL:UNDEFINED-FUNCTION gets its own answer here for the reason %REGISTERED-P
@@ -408,7 +408,15 @@ been written, the contract IS registered, and reporting :INTERNAL-ERROR --
 documented as \"this adapter failed\" -- had the describe path and the run path
 disagreeing about one fact."
   (cond ((%unknown-registration-p api condition) :not-registered)
-        ((typep condition 'undefined-function) :undefined-function)
+        ;; Contracts only.  cl-spec raises CL:UNDEFINED-FUNCTION on purpose
+        ;; for a contract whose target has not been written; the same
+        ;; condition out of PROPERTY-DATA or SPEC-DATA is a revision that
+        ;; calls something this image lacks, and answering
+        ;; "the function it contracts is not defined" makes a claim about the
+        ;; caller's code out of an adapter fault -- which is the misdiagnosis
+        ;; this clause was added to stop, in the other direction.
+        ((and contract-p (typep condition 'undefined-function))
+         :undefined-function)
         (t :internal-error)))
 
 (defun %unknown-registration-p (api condition)
@@ -887,31 +895,37 @@ answers."
             (post (clause (getf data :postconditions))))
         (multiple-value-bind (source source-complete source-omitted)
             (%print-bounded-form (getf data :source-form) max-chars)
-          (list :status :ok
-                :kind "function-spec"
-                :name (symbol-data name)
-                :documentation (getf data :documentation)
-                :arguments (loop for argument in (getf data :arguments)
-                                 collect (list :variable
-                                               (symbol-data (getf argument :variable))
-                                               :spec (%spec-tree (getf argument :spec))))
-                :returns (%spec-tree (getf data :returns))
-                :preconditions (first pre)
-                ;; Only when there is a clause.  "complete: true" about a
-                ;; :PRE the contract does not have is a claim, and the
-                ;; response has %OPTIONAL-BOOL to carry an absent flag as
-                ;; null -- which is what this PR added it for.
-                :preconditions-complete (if pre (second pre) :not-applicable)
-                :preconditions-omitted-chars (third pre)
-                :postconditions (first post)
-                :postconditions-complete (if post (second post) :not-applicable)
-                :postconditions-omitted-chars (third post)
-                :source-form source
-                :source-form-complete source-complete
-                :source-form-omitted-chars source-omitted
-                :source-location (getf data :source-location)
-                :definition-digest (definition-digest api name registry
-                                                      :property data)))))))
+          ;; The pair, not the value alone.  A digest whose input hit the print
+          ;; limit is not one a caller may compare, and this was the third
+          ;; place offering one for expect_definition_digest without saying so.
+          (multiple-value-bind (digest complete)
+              (definition-digest api name registry :property data)
+            (list :status :ok
+                  :kind "function-spec"
+                  :name (symbol-data name)
+                  :documentation (getf data :documentation)
+                  :arguments (loop for argument in (getf data :arguments)
+                                   collect (list :variable
+                                                 (symbol-data (getf argument :variable))
+                                                 :spec (%spec-tree (getf argument :spec))))
+                  :returns (%spec-tree (getf data :returns))
+                  :preconditions (first pre)
+                  ;; Only when there is a clause.  "complete: true" about a
+                  ;; :PRE the contract does not have is a claim, and the
+                  ;; response has %OPTIONAL-BOOL to carry an absent flag as
+                  ;; null -- which is what this PR added it for.
+                  :preconditions-complete (if pre (second pre) :not-applicable)
+                  :preconditions-omitted-chars (third pre)
+                  :postconditions (first post)
+                  :postconditions-complete (if post (second post) :not-applicable)
+                  :postconditions-omitted-chars (third post)
+                  :source-form source
+                  :source-form-complete source-complete
+                  :source-form-omitted-chars source-omitted
+                  :source-location (getf data :source-location)
+                  :definition-digest digest
+                  :definition-digest-complete complete
+                  :definition-digest-covers :contract)))))))
 
 (defun %describe-property (api name registry max-chars)
   "Return the detail plist for property NAME."
@@ -1004,7 +1018,8 @@ function-spec; got ~S" kind)
           ;; failure -- a bad argument, a printer error, a malformed
           ;; :ARGUMENTS entry -- as the absence of a registration, which is
           ;; exactly the false negative this file exists to prevent.
-          (list :status (%describe-condition-status api condition)
+          (list :status (%describe-condition-status
+                         api condition (string= kind "function-spec"))
                 :kind kind
                 :name (symbol-data symbol)
                 :message (princ-to-string condition)
@@ -1171,7 +1186,13 @@ each call.  Same reason DEFINITION-DIGEST takes a :PROPERTY."
     ;; Answering not-registered here made the two paths disagree about one
     ;; fact, and told the caller to register something they already had.
     (undefined-function (condition)
-      (values nil (princ-to-string condition) nil :undefined-function))
+      (values nil (princ-to-string condition) nil
+              ;; Only a contract's reader raises this on purpose; out of
+              ;; PROPERTY-DATA it is a fault in the revision, not a fact about
+              ;; the caller's code.
+              (if (eq data-key :function-spec-data)
+                  :undefined-function
+                  :not-registered)))
     (error (condition)
       (values nil (princ-to-string condition) nil :not-registered))))
 
@@ -1259,6 +1280,13 @@ while listing the properties about this symbol: ~A" condition)))))))
                         ;; the channels added so the fact need not be read out
                         ;; of prose, and they were sending the caller to an
                         ;; operation CHECK-REPORT answers :unsupported.
+                        ;; The symbol's own property, as data.  The mirror
+                        ;; direction reports it in three channels; here it
+                        ;; lived only in a note several lines under a bare
+                        ;; verdict, which is the reading those channels exist
+                        ;; to stop.
+                        :own-property-not-run (let ((own (getf routing :property)))
+                                                (when own (symbol-data own)))
                         :contract-not-run (let ((contract
                                                   (getf routing :function-spec)))
                                             (when (and contract
@@ -1714,7 +1742,11 @@ cl-spec's structured account of a return value that missed its spec."
                   ;; it.
                   (%print-bounded-form explanation max-value-chars)
                   (values nil :not-applicable nil))
-            (list :rejected rejected
+            (list ;; Only when it is a number.  A reader that answered a
+                ;; keyword or a float published that value beside a status
+                ;; saying the count could not be read -- and handed yason
+                ;; something it may refuse to serialize.
+                :rejected (when (integerp rejected) rejected)
                   :rejection-status rejection-status
                   :rejected-measured (and rejected-read (integerp rejected) t)
                 :rejected-readable (and rejected-read t)

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -391,12 +391,17 @@ UNKNOWN-SPEC reports the failure as a failure."
         (is-a :unknown-property)
         (is-a :unknown-function-spec))))
 
-(defparameter +listing-unsupported-message+
-  (concatenate 'string
-               "this cl-spec revision does not export the listing functions "
-               "(list-specs, list-properties); nothing can be enumerated. "
-               "Every other spec tool still works on a name you already have.")
-  "Said when the loaded cl-spec cannot enumerate its registry.")
+(defun %listing-unsupported-message (missing)
+  "Return the message for a listing kind this cl-spec cannot enumerate.
+
+Names the handles the requested kind actually needs.  One sentence covering
+both list functions and claiming \"nothing can be enumerated\" was two false
+statements on a revision that exports one of them: the other kinds still
+enumerate, and contracts enumerate through readers neither of these names."
+  (format nil "this cl-spec revision does not export ~{~A~^ or ~}, so the ~
+requested kind cannot be enumerated. Another kind may still list, and every ~
+other spec tool still works on a name you already have."
+          missing))
 
 (defparameter +listing-coverage-note+
   (concatenate 'string
@@ -492,14 +497,18 @@ function-specs or both; got ~S" kind)
     ;; kind="function-specs", which reads neither of these two, and refused a
     ;; listing it could have produced -- while reporting
     ;; function_specs_listable true three keys later.
-    (let ((needed (cond ((string= kind "specs") '(:list-specs))
-                        ((string= kind "properties") '(:list-properties))
-                        ((string= kind "both") '(:list-specs :list-properties))
-                        (t '()))))
-      (unless (every (lambda (name) (api-has-p api name)) needed)
+    (let* ((needed (cond ((string= kind "specs") '(:list-specs))
+                         ((string= kind "properties") '(:list-properties))
+                         ((string= kind "both") '(:list-specs :list-properties))
+                         (t '())))
+           (missing (remove-if (lambda (key) (api-has-p api key)) needed)))
+      (when missing
         (return-from list-report
           (list :status :unsupported
-                :message +listing-unsupported-message+
+                :message (%listing-unsupported-message
+                          (mapcar (lambda (key)
+                                    (string-downcase (symbol-name key)))
+                                  missing))
                 :environment environment))))
     (multiple-value-bind (package-object package-error)
         (%listing-package-filter package)
@@ -669,9 +678,16 @@ answers."
              ;; NIL rather than the string "NIL" for an absent clause, so a
              ;; renderer can tell a contract with no :PRE from one whose :PRE
              ;; is the literal NIL.
+             ;; A single clause prints as the clause.  :PRECONDITIONS is a
+             ;; list of forms, so (:pre (<= low high)) arrives as
+             ;; ((<= low high)) and printing the list gave the reader a form
+             ;; they cannot paste back: a call to the list.
              (when forms
                (multiple-value-bind (text complete omitted)
-                   (%print-bounded-form forms max-chars)
+                   (%print-bounded-form (if (null (rest forms))
+                                            (first forms)
+                                            forms)
+                                        max-chars)
                  (list text complete omitted)))))
       (let ((pre (clause (getf data :preconditions)))
             (post (clause (getf data :postconditions))))
@@ -974,6 +990,16 @@ name in NAMES and to no other."
                                     :message message))
               (values (list name)
                       (list :mode mode
+                            ;; The keyword, beside the display string.  A
+                            ;; renderer that decides "contract or property"
+                            ;; by matching MODE's text is one typo from
+                            ;; calling a contract a property while every
+                            ;; other line still treats it as a contract --
+                            ;; which is how a fixture written with mode
+                            ;; "function" hid that branch from the suite.
+                            :kind (if (eq requested-key :function)
+                                      :contract
+                                      :property)
                             :requested (list requested-key (symbol-data name))
                             :selected (list (symbol-data name))
                             :count 1
@@ -1128,6 +1154,7 @@ truth is that nothing was read."
                       (funcall (api-fn api :property-data) name
                                :registry registry))))
         (list :argument-count (length (getf data :arguments))
+              :kind :property
               :shrink-enabled (and (getf (getf data :metadata) :shrink) t)
               :trials-table (getf data :trials)
               ;; Carried so the digest beside it does not fetch the same
@@ -1135,8 +1162,8 @@ truth is that nothing was read."
               :data data
               :known t))
     (error ()
-      (list :argument-count nil :shrink-enabled nil :trials-table nil
-            :data nil :known nil))))
+      (list :argument-count nil :kind :property :shrink-enabled nil
+            :trials-table nil :data nil :known nil))))
 
 (defun %contract-facts (api name registry &optional pre-read)
   "Return the facts about the contract for NAME a result needs.
@@ -1153,13 +1180,18 @@ here rather than things read off a definition."
                       (funcall (api-fn api :function-spec-data) name
                                :registry registry))))
         (list :argument-count (length (getf data :arguments))
+              :kind :contract
               :shrink-enabled t
               :trials-table nil
+              ;; :UNKNOWN in the error branch, not NIL.  A contract with no
+              ;; :PRE refuses nothing, and saying so is different from having
+              ;; failed to read whether it has one.
+              :precondition-p (and (getf data :preconditions) t)
               :data data
               :known t))
     (error ()
-      (list :argument-count nil :shrink-enabled t :trials-table nil
-            :data nil :known nil))))
+      (list :argument-count nil :kind :contract :shrink-enabled t
+            :trials-table nil :precondition-p :unknown :data nil :known nil))))
 
 (defun %digest-facts (api name registry facts)
   "Return (:value <string-or-nil> :complete <boolean>) for NAME's digest.
@@ -1169,9 +1201,18 @@ together everywhere: a digest whose input was truncated is not a digest a
 caller may compare, and separating them invites reporting the value without
 the caveat."
   (multiple-value-bind (value complete)
-      (if (getf facts :known)
-          (definition-digest api name registry :property (getf facts :data))
-          (definition-digest api name registry))
+      ;; The fallback reads the definition itself, so it has to ask the reader
+      ;; for the kind being run.  A symbol carrying both a property and a
+      ;; contract would otherwise have the property's digest stamped on the
+      ;; contract's result -- the one field whose job is to say the definition
+      ;; behind this run did not move.
+      (let ((data-key (if (eq :contract (getf facts :kind))
+                          :function-spec-data
+                          :property-data)))
+        (if (getf facts :known)
+            (definition-digest api name registry :property (getf facts :data)
+                                                 :data-key data-key)
+            (definition-digest api name registry :data-key data-key)))
     (list :value value :complete (and value complete t))))
 
 (defun %trials-budget (api facts profile backend &optional requested)
@@ -1270,7 +1311,8 @@ report text is a rendering, not the value."
                       :value (externalize-value value
                                                 :max-chars max-value-chars))))
 
-(defun %contract-plist (api result executed max-value-chars)
+(defun %contract-plist (api result executed max-value-chars
+                        &optional (precondition-p :unknown))
   "Return the contract-specific half of a CHECK-FUNCTION result, or NIL.
 
 REJECTED is what separates a run that checked the function from one that only
@@ -1305,6 +1347,10 @@ cl-spec's structured account of a return value that missed its spec."
               (values nil t nil))
         (list :rejected rejected
               :rejected-measured (and (integerp rejected) t)
+              ;; Carried so a renderer does not describe a refusal that
+              ;; cannot happen: "0 of them refused by :pre" told the reader a
+              ;; precondition exists, on a contract written without one.
+              :precondition-p precondition-p
               :rejected-overcounted (and overcounted t)
               ;; Absent, not floored, when the two cannot be subtracted: 0 is
               ;; itself a claim -- "the function was never called" -- about a
@@ -1347,7 +1393,8 @@ arguments, or that a failure was somehow argument-free."
     (list :property (symbol-data name)
           :kind kind
           :contract (when (eq kind :contract)
-                      (%contract-plist api result executed max-value-chars))
+                      (%contract-plist api result executed max-value-chars
+                                       (getf facts :precondition-p)))
           :status status
           :trials (list* :executed executed trials)
           ;; Text, not a number: a cl-spec seed reaches 2^62 and a JSON
@@ -1634,18 +1681,23 @@ anything holds."
         (append argument-error (list :verified nil :environment environment))))
     (unless (eq api-status :ok)
       (return-from check-report (unavailable-report api-status environment)))
-    (unless (api-backend-available-p api)
-      (return-from check-report
-        (list :status :backend-not-loaded
-              :verified nil
-              :message +backend-missing-message+
-              :environment environment)))
+    ;; Above the backend check, for the reason the argument check is above
+    ;; both: whether this revision exports the contract API is a fact about
+    ;; the image and does not change when a generator backend is installed.
+    ;; Ordered the other way, a caller was sent to load cl-spec/check-it and
+    ;; only then told that the cl-spec they have cannot run a contract at all.
     (when (and function (not (and (api-has-p api :check-function)
                                   (api-has-p api :function-spec-data))))
       (return-from check-report
         (list :status :unsupported
               :verified nil
               :message (%contract-unsupported-message api)
+              :environment environment)))
+    (unless (api-backend-available-p api)
+      (return-from check-report
+        (list :status :backend-not-loaded
+              :verified nil
+              :message +backend-missing-message+
               :environment environment)))
     (multiple-value-bind (profile-keyword profile-error) (%resolve-profile profile)
       (when profile-error

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -370,7 +370,7 @@ is registered about this symbol: ~A" failure)
                         (when (getf routing :property)
                           (list +symbol-is-a-property-note+))
                         (when (getf routing :function-spec)
-                          (list +symbol-has-a-contract-note+)))
+                          (list (%symbol-contract-note api))))
                 :environment environment)))))))
 
 ;;; ---------------------------------------------------------------------------
@@ -497,18 +497,37 @@ function-specs or both; got ~S" kind)
     ;; kind="function-specs", which reads neither of these two, and refused a
     ;; listing it could have produced -- while reporting
     ;; function_specs_listable true three keys later.
-    (let* ((needed (cond ((string= kind "specs") '(:list-specs))
-                         ((string= kind "properties") '(:list-properties))
-                         ((string= kind "both") '(:list-specs :list-properties))
-                         (t '())))
-           (missing (remove-if (lambda (key) (api-has-p api key)) needed)))
-      (when missing
+    ;; Refused only when NOTHING the kind asks for can be listed.  "both" is
+    ;; the default kind, and failing it outright on a revision that can still
+    ;; enumerate contracts reproduced the "nothing can be enumerated" answer
+    ;; this gate was narrowed to stop giving.  A half it cannot list is
+    ;; reported as its own null count, the way FUNCTION-SPECS-LISTABLE already
+    ;; reports the third half.
+    (let ((wanted (cond ((string= kind "specs") '("list-specs"))
+                        ((string= kind "properties") '("list-properties"))
+                        ((string= kind "function-specs")
+                         '("list-function-specs with function-spec-data"))
+                        (t '("list-specs" "list-properties"
+                             "list-function-specs with function-spec-data"))))
+          (reachable
+             (remove nil
+                     (list (when (and (member kind '("specs" "both")
+                                              :test #'string=)
+                                      (api-has-p api :list-specs))
+                             t)
+                           (when (and (member kind '("properties" "both")
+                                              :test #'string=)
+                                      (api-has-p api :list-properties))
+                             t)
+                           (when (and (member kind '("function-specs" "both")
+                                              :test #'string=)
+                                      (api-has-p api :list-function-specs)
+                                      (api-has-p api :function-spec-data))
+                             t)))))
+      (unless reachable
         (return-from list-report
           (list :status :unsupported
-                :message (%listing-unsupported-message
-                          (mapcar (lambda (key)
-                                    (string-downcase (symbol-name key)))
-                                  missing))
+                :message (%listing-unsupported-message wanted)
                 :environment environment))))
     (multiple-value-bind (package-object package-error)
         (%listing-package-filter package)
@@ -533,12 +552,19 @@ function-specs or both; got ~S" kind)
                  (remove-if-not
                   (lambda (name) (%in-package-p name package-object))
                   (funcall (api-fn api :list-function-specs) registry))))
+             ;; Each half asks only for the reader it uses.  A revision
+             ;; missing one of them still lists the others, and the half it
+             ;; could not look at comes back as a null count beside a false
+             ;; listable flag -- never as an empty list, which would say the
+             ;; registry holds none.
+             (specs-listable (api-has-p api :list-specs))
+             (properties-listable (api-has-p api :list-properties))
              (spec-names
-               (when want-specs
+               (when (and want-specs specs-listable)
                  (remove-if-not (lambda (name) (%in-package-p name package-object))
                                 (funcall (api-fn api :list-specs) registry))))
              (property-names
-               (when want-properties
+               (when (and want-properties properties-listable)
                  (remove-if-not
                   (lambda (name) (%in-package-p name package-object))
                   (cond
@@ -556,14 +582,18 @@ function-specs or both; got ~S" kind)
               :function-specs (loop for name in (%take function-spec-names limit)
                                     collect (%function-spec-listing api name registry))
               :function-specs-listable (and function-specs-listable t)
+              :specs-listable (and specs-listable t)
+              :properties-listable (and properties-listable t)
               ;; NIL, not 0, for a kind that was not asked for.  The count
               ;; is a fact about the registry and the list is what this
               ;; response carries; not looking leaves the first unknown, and
               ;; reporting it as zero says the registry holds none -- the
               ;; same conflation the tag and no-properties answers go out of
               ;; their way to avoid.
-              :counts (list :specs (when want-specs (length spec-names))
-                            :properties (when want-properties
+              :counts (list :specs (when (and want-specs specs-listable)
+                                     (length spec-names))
+                            :properties (when (and want-properties
+                                                   properties-listable)
                                           (length property-names))
                             :function-specs (when (and want-function-specs
                                                        function-specs-listable)
@@ -618,6 +648,39 @@ contract cannot be executed.~@[ ~A~]"
                            "Its text can still be read with spec-describe "
                            "kind=function-spec.")))))
 
+(defun %symbol-contract-note (api)
+  "Return spec-symbol's note about a registered contract, matched to the API.
+
+Every message this module prints is meant to be a true statement about the
+loaded revision, and an instruction is a statement too: sending a caller to
+spec-describe kind=function-spec on a cl-spec with no FUNCTION-SPEC-DATA, or
+to spec-check function= with no CHECK-FUNCTION, is a dead end issued by the
+one place that can see it is a dead end."
+  (let ((readable (api-has-p api :function-spec-data))
+        (runnable (api-has-p api :check-function)))
+    (cond
+      ((and readable runnable) +symbol-has-a-contract-note+)
+      (readable
+       (concatenate 'string
+                    "a function spec is registered for this symbol: read it "
+                    "with spec-describe kind=function-spec. The loaded "
+                    "cl-spec cannot run it -- it exports no check-function."))
+      (t
+       (concatenate 'string
+                    "a function spec is registered for this symbol. The "
+                    "loaded cl-spec exports no function-spec-data, so this "
+                    "adapter can neither project nor run it.")))))
+
+(defun %contract-not-selected-note (api)
+  "Return spec-check's note about the contract an :ABOUT selection left alone."
+  (if (and (api-has-p api :function-spec-data) (api-has-p api :check-function))
+      +contract-not-selected-note+
+      (concatenate 'string
+                   "a function spec is registered for this symbol and was NOT "
+                   "run: an :about selection covers properties only. The "
+                   "loaded cl-spec cannot run it either, so there is nothing "
+                   "to re-run it with.")))
+
 (defun %spec-tree (spec-plist)
   "Return SPEC-PLIST with its symbols externalized, or NIL when there is none.
 
@@ -642,22 +705,30 @@ to the caller as one that exists."
                     (when values (printed-for-display values)))
           :base-type (let ((base (getf spec-plist :base-type)))
                        (when base (printed-for-display base)))
-          :min (%range-bound (getf spec-plist :min))
-          :max (%range-bound (getf spec-plist :max))
+          :min (%range-bound (getf spec-plist :min) (getf spec-plist :kind))
+          :max (%range-bound (getf spec-plist :max) (getf spec-plist :kind))
           :class-name (let ((name (getf spec-plist :class-name)))
                         (when name (symbol-data name)))
           :source-form (printed-for-display (getf spec-plist :source-form))
           :source-location (getf spec-plist :source-location)
           :children (mapcar #'%spec-tree (getf spec-plist :children)))))
 
-(defun %range-bound (value)
-  "Return a range end as text, or NIL when the node has none.
+(defun %range-bound (value kind)
+  "Return a range end as text, or NIL when the node has no such end.
 
 cl-spec spells an open end :UNBOUNDED.  Mapped back to the * the author wrote,
 here rather than in a renderer, so the text and the JSON agree and neither has
-to know the IR's word for it."
-  (when value
-    (if (eq :unbounded value) "*" (printed-for-display value))))
+to know the IR's word for it.
+
+On a RANGE node an absent end is an open end, so NIL maps to * as well.  A
+revision that spells one that way -- and this adapter exists to tolerate
+revisions -- would otherwise give (range integer 0 *) one printable bound, and
+a renderer showing only the pair it could complete would drop the 0 with it:
+a wider input domain than the author wrote, silently.  On any other node there
+is no end to report and NIL stays NIL."
+  (cond ((eq :unbounded value) "*")
+        (value (printed-for-display value))
+        ((eq :range kind) "*")))
 
 (defun %describe-function-spec (api name registry max-chars)
   "Return the detail plist for the contract registered for NAME.
@@ -1029,6 +1100,11 @@ while listing the properties about this symbol: ~A" condition)))))))
                (about (getf routing :properties-about)))
           (values about
                   (list :mode "about"
+                        ;; The keyword every consumer of this plist reads --
+                        ;; %SELECTION-NOUN among them, which would otherwise
+                        ;; reach the property branch by falling through rather
+                        ;; than by being told.
+                        :kind :property
                         :requested (list :symbol (symbol-data name))
                         :selected (mapcar #'symbol-data about)
                         :count (length about)
@@ -1044,7 +1120,7 @@ while listing the properties about this symbol: ~A" condition)))))))
                                 (when (getf routing :property)
                                   (list +symbol-is-a-property-not-selected-note+))
                                 (when (getf routing :function-spec)
-                                  (list +contract-not-selected-note+))))
+                                  (list (%contract-not-selected-note api)))))
                   nil)))))
 
 (defparameter +trials-needs-a-contract-message+
@@ -1496,9 +1572,16 @@ budget computed from one backend and the trials run under another."
                (progv names settings
                  (%result-plist api
                                 (if (eq kind :contract)
-                                    (funcall (api-fn api :check-function) name
-                                             :trials (getf trials :budget)
-                                             :seed seed :registry registry)
+                                    ;; The keyword only when there is a
+                                    ;; number.  :TRIALS NIL is not "use your
+                                    ;; default", it is an override that
+                                    ;; suppresses it -- and the budget is NIL
+                                    ;; whenever BACKEND-DEFAULT-TRIALS could
+                                    ;; not be read.
+                                    (apply (api-fn api :check-function) name
+                                           :seed seed :registry registry
+                                           (let ((budget (getf trials :budget)))
+                                             (when budget (list :trials budget))))
                                     (funcall (api-fn api :run-property) name
                                              :profile profile :seed seed
                                              :registry registry))
@@ -1617,10 +1700,14 @@ nothing reports which parts of the input domain were reached, so a caller must
 not read a trial count as that (cl-spec specification 72.1).
 
 Rejection counts are listed whenever they were not measured, which is every
-property run -- a property has no precondition, so there is no refused-input
-count to have and nothing here can say how much of the generated input the
-body actually exercised.  A contract check measures it, and claiming the gap
-where the number is right there would train a reader to ignore the list.
+property run and no contract run.  The asymmetry is not an oversight: a
+property's inputs are refused inside the generator, where check-it retries a
+guard without reporting how often, so how much of the generated domain the
+body actually saw is unknown.  A contract's are refused by the checker, which
+counts them -- so the gap is listed where the number is missing and left off
+where it is present, including on a contract with no :PRE, where the honest
+count is zero.  Claiming a gap whose answer is right there trains a reader to
+ignore the list.
 
 SELECTION is read for what did not run at all.  A contract an :ABOUT selection
 left alone is a coverage shortfall like any other, and until it was listed

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -621,26 +621,39 @@ cl-spec's answer to give, not this adapter's to assemble.
 projected: a function cannot be read, and whether they hold is what spec-check
 answers."
   (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
-    (multiple-value-bind (source source-complete source-omitted)
-        (%print-bounded-form (getf data :source-form) max-chars)
-      (list :status :ok
-            :kind "function-spec"
-            :name (symbol-data name)
-            :documentation (getf data :documentation)
-            :arguments (loop for argument in (getf data :arguments)
-                             collect (list :variable
-                                           (symbol-data (getf argument :variable))
-                                           :spec (%spec-tree (getf argument :spec))))
-            :returns (%spec-tree (getf data :returns))
-            :preconditions (let ((forms (getf data :preconditions)))
-                             (when forms (printed-for-display forms)))
-            :postconditions (let ((forms (getf data :postconditions)))
-                              (when forms (printed-for-display forms)))
-            :source-form source
-            :source-form-complete source-complete
-            :source-form-omitted-chars source-omitted
-            :source-location (getf data :source-location)
-            :definition-digest (definition-digest api name registry :property data)))))
+    (flet ((clause (forms)
+             ;; Bounded like the body a property describe carries.  A :PRE or
+             ;; :POST form is short in practice, but "in practice" is not a
+             ;; budget, and every other form this module prints is cut at one.
+             ;; NIL rather than the string "NIL" for an absent clause, so a
+             ;; renderer can tell a contract with no :PRE from one whose :PRE
+             ;; is the literal NIL.
+             (when forms
+               (multiple-value-bind (text complete) (%print-bounded-form forms max-chars)
+                 (list text complete)))))
+      (let ((pre (clause (getf data :preconditions)))
+            (post (clause (getf data :postconditions))))
+        (multiple-value-bind (source source-complete source-omitted)
+            (%print-bounded-form (getf data :source-form) max-chars)
+          (list :status :ok
+                :kind "function-spec"
+                :name (symbol-data name)
+                :documentation (getf data :documentation)
+                :arguments (loop for argument in (getf data :arguments)
+                                 collect (list :variable
+                                               (symbol-data (getf argument :variable))
+                                               :spec (%spec-tree (getf argument :spec))))
+                :returns (%spec-tree (getf data :returns))
+                :preconditions (first pre)
+                :preconditions-complete (if pre (second pre) t)
+                :postconditions (first post)
+                :postconditions-complete (if post (second post) t)
+                :source-form source
+                :source-form-complete source-complete
+                :source-form-omitted-chars source-omitted
+                :source-location (getf data :source-location)
+                :definition-digest (definition-digest api name registry
+                                                      :property data)))))))
 
 (defun %describe-property (api name registry max-chars)
   "Return the detail plist for property NAME."

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -147,6 +147,15 @@ trailing spaces into every message and every JSON field carrying one.")
                "about the same symbol are NOT included and were not run.")
   "The limit of what an explicit contract selection covers.")
 
+(defparameter +own-property-not-run-note+
+  (concatenate 'string
+               "this symbol is itself a registered property and was NOT run: "
+               "a contract run covers the contract only. Run it with "
+               "spec-check property=<this symbol> -- symbol= will not select "
+               "it, because an :about selection leaves the symbol's own "
+               "property out.")
+  "Said by a contract run about a property registered under the same name.")
+
 (defparameter +about-source+
   (concatenate 'string
                "cl-spec:semantic-data -> :properties-about "
@@ -364,6 +373,18 @@ is registered about this symbol: ~A" failure)
 ;;; spec-describe
 ;;; ---------------------------------------------------------------------------
 
+(defun %describe-condition-status (api condition)
+  "Return the status DESCRIBE-REPORT should answer for CONDITION.
+
+CL:UNDEFINED-FUNCTION gets its own answer here for the reason %REGISTERED-P
+gives it one: cl-spec raises it on purpose for a contract whose target has not
+been written, the contract IS registered, and reporting :INTERNAL-ERROR --
+documented as \"this adapter failed\" -- had the describe path and the run path
+disagreeing about one fact."
+  (cond ((%unknown-registration-p api condition) :not-registered)
+        ((typep condition 'undefined-function) :undefined-function)
+        (t :internal-error)))
+
 (defun %unknown-registration-p (api condition)
   "Return true when CONDITION is cl-spec saying a name is not registered.
 
@@ -442,6 +463,11 @@ return\" at all.  The specs themselves stay in spec-describe: a listing is for
 finding a name, not for reading a contract."
   (handler-case
       (let ((data (funcall (api-fn api :function-spec-data) name :registry registry)))
+        ;; NIL is not a contract with no parameters and no :returns.  The
+        ;; describe and run paths both refuse to read it as one; only the
+        ;; signalling case was marked here, so a reader that answered nothing
+        ;; came out as a positive claim about the contract's shape.
+        (unless data (error 'unreadable-projection))
         (list :name (symbol-data name)
               :parameters (mapcar (lambda (argument)
                                     (symbol-data (getf argument :variable)))
@@ -522,13 +548,18 @@ function-specs or both; got ~S" kind)
                 ;; Built here rather than above: it is used only on this
                 ;; branch, and formatting a message for every successful
                 ;; listing is work inside the caller's introspection deadline.
+                ;; Only the handles that are absent.  Naming every handle
+                ;; the kind reads told a caller their cl-spec does not export
+                ;; a function it does export -- the statement
+                ;; %CONTRACT-UNSUPPORTED-MESSAGE was rewritten to stop making.
                 :message (%listing-unsupported-message
-                          (mapcar
+                          (mapcan
                            (lambda (row)
-                             (format nil "~{~A~^ with ~}"
-                                     (mapcar (lambda (key)
-                                               (string-downcase (symbol-name key)))
-                                             (fourth row))))
+                             (mapcar (lambda (key)
+                                       (string-downcase (symbol-name key)))
+                                     (remove-if (lambda (key)
+                                                  (api-has-p api key))
+                                                (fourth row))))
                            (set-difference asked reachable :test #'eq)))
                 :environment environment)))
       (multiple-value-bind (package-object package-error)
@@ -931,9 +962,7 @@ function-spec; got ~S" kind)
           ;; failure -- a bad argument, a printer error, a malformed
           ;; :ARGUMENTS entry -- as the absence of a registration, which is
           ;; exactly the false negative this file exists to prevent.
-          (list :status (if (%unknown-registration-p api condition)
-                            :not-registered
-                            :internal-error)
+          (list :status (%describe-condition-status api condition)
                 :kind kind
                 :name (symbol-data symbol)
                 :message (princ-to-string condition)
@@ -1253,16 +1282,21 @@ prose, and the argument for naming one is the argument for naming the other."
         ;; path reports that direction explicitly -- dropping it here let a
         ;; contract run answer "nothing else was left unrun" about a property
         ;; of the same name, off a routing table already in hand.
-        (values (append (let ((own (getf routing :property)))
-                          (when own (list (symbol-data own))))
-                        (mapcar #'symbol-data (getf routing :properties-about)))
-                t))
+        ;; Three values: the :ABOUT registrations, and separately the
+        ;; property registered under the symbol's own name.  Folded together
+        ;; they were counted as :ABOUT ones and the note sent the caller to
+        ;; spec-check symbol=, the selection that deliberately excludes the
+        ;; symbol's own property -- an instruction that returns nothing.
+        (values (mapcar #'symbol-data (getf routing :properties-about))
+                t
+                (let ((own (getf routing :property)))
+                  (when own (symbol-data own)))))
     ;; (values NIL NIL) rather than NIL: an empty list here says the symbol has
     ;; no properties registered about it, and a read that failed has no
     ;; evidence for that.  Reported as its own fact, the way every sibling in
     ;; this module is -- FUNCTION-SPECS-LISTABLE, REJECTED-MEASURED,
     ;; FAILURE-REASON-READABLE, HAS-PRECONDITION.
-    (error () (values nil nil))))
+    (error () (values nil nil nil))))
 
 (defun %select-properties (api property symbol function package registry)
   "Return (values NAMES SELECTION ERROR KIND DATA) for the requested selection.
@@ -1290,18 +1324,23 @@ learns it exists rather than being left to assume the run covered it."
                         :coverage +contract-coverage-note+)
        (values names
                (if names
-                   (multiple-value-bind (about read)
+                   (multiple-value-bind (about read own)
                        (%properties-about api (first names) registry)
                      (append selection
                              (list :properties-not-run about
+                                   :own-property-not-run own
                                    :properties-not-run-read (and read t))
                              (cond
-                               (about
+                               ((or about own)
                                 (list :notes
-                                      (list (format nil "~D propert~:@P ~
+                                      (append
+                                       (when about
+                                         (list (format nil "~D propert~:@P ~
 registered (:about this symbol) ~:*~[~;is~:;are~] NOT covered by a contract ~
 run: run them with spec-check symbol=<this symbol>."
-                                                    (length about)))))
+                                                       (length about))))
+                                       (when own
+                                         (list +own-property-not-run-note+)))))
                                ((not read)
                                 (list :notes
                                       (list (concatenate 'string
@@ -1563,7 +1602,11 @@ cl-spec's structured account of a return value that missed its spec."
     (multiple-value-bind (reason reason-read) (read-slot :check-failure-reason)
       (multiple-value-bind (explanation explanation-read)
           (read-slot :check-explanation)
-        (let* ((rejected (read-slot :check-rejected))
+        (multiple-value-bind (rejected rejected-read) (read-slot :check-rejected)
+      (let* (;; REJECTED-READ, not (integerp rejected).  "no reader" and "the
+             ;; reader signalled" are different facts about the loaded
+             ;; revision, and the description promises the first.
+             (rejected rejected)
                (countable (and (integerp executed) (integerp rejected)))
                (overcounted (and countable (> rejected executed)))
                ;; A refusal reported against a contract whose projection says it
@@ -1608,7 +1651,8 @@ cl-spec's structured account of a return value that missed its spec."
                   (values nil :not-applicable nil))
             (list :rejected rejected
                   :rejection-status rejection-status
-                  :rejected-measured (and (integerp rejected) t)
+                  :rejected-measured (and rejected-read (integerp rejected) t)
+                :rejected-readable (and rejected-read t)
                   ;; Carried so a renderer does not describe a refusal that
                   ;; cannot happen: "0 of them refused by :pre" told the reader
                   ;; a precondition exists, on a contract written without one.
@@ -1636,7 +1680,19 @@ cl-spec's structured account of a return value that missed its spec."
                   :explanation explanation-text
                   :explanation-readable (and explanation-read t)
                   :explanation-complete explanation-complete
-                  :explanation-omitted-chars explanation-omitted)))))))
+                  :explanation-omitted-chars explanation-omitted))))))))
+
+(defun %recorded-budget (api result)
+  "Return the trial budget cl-spec recorded on RESULT, or NIL.
+
+A contract result carries the budget the run was given.  Preferred over the
+figure %TRIALS-BUDGET derives, which is the adapter's reconstruction and says
+so: when the recorded one is there, the derivation note is not the truth about
+that run.  NIL for a property result, which records no budget, and for a
+cl-spec that does not export the reader."
+  (when (api-has-p api :check-budget)
+    (handler-case (funcall (api-fn api :check-budget) result)
+      (error () nil))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
@@ -1663,7 +1719,18 @@ arguments, or that a failure was somehow argument-free."
                       (%contract-plist api result executed max-value-chars
                                        (getf facts :precondition-p)))
           :status status
-          :trials (list* :executed executed trials)
+          ;; The recorded budget wins over the derived one, and takes the
+          ;; derivation note off with it: the note says cl-spec does not
+          ;; expose the resolved budget, which is false of a contract result
+          ;; that carries it.
+          :trials (let ((recorded (and (eq kind :contract)
+                                       (%recorded-budget api result))))
+                    (list* :executed executed
+                           (if recorded
+                               (list :budget recorded
+                                     :budget-source "cl-spec result"
+                                     :budget-derivation nil)
+                               trials)))
           ;; Text, not a number: a cl-spec seed reaches 2^62 and a JSON
           ;; consumer holding it as a number would round it, which turns a
           ;; reproducible failure into one that cannot be reproduced.
@@ -1933,7 +2000,10 @@ here the only place that said so was the headline: a consumer branching on
 VERIFIED and this list -- the documented pair for what a run could not
 establish -- read full coverage for a function whose contract never ran."
   (let ((gaps '())
-        (rejections-measured t))
+        ;; Zero results measured nothing.  Initialised true and only cleared
+        ;; inside the loop, a call that selected nothing came back asserting
+        ;; the refusal counts were measured -- by a run that did not happen.
+        (rejections-measured (and results t)))
     (dolist (result results)
       ;; Keyed on REJECTED-USABLE, the one flag that answers "may this
       ;; response subtract with the refusal count".  Keyed on the reader
@@ -1969,7 +2039,8 @@ establish -- read full coverage for a function whose contract never ran."
           (t (pushnew status gaps)))))
     (append (nreverse gaps)
             (when (getf selection :contract-not-run) (list :contract-not-run))
-            (when (getf selection :properties-not-run)
+            (when (or (getf selection :properties-not-run)
+                      (getf selection :own-property-not-run))
               (list :properties-not-run))
             (when (and (getf selection :kind)
                        (eq :contract (getf selection :kind))
@@ -2105,6 +2176,9 @@ anything holds."
                      (budget-plist (%trials-budget api facts profile-keyword
                                                    backend trials))
                      (digest (append (%digest-facts api name registry facts)
+                                     ;; On every branch, not only the one that
+                                     ;; ran: a timeout publishes the digest too
+                                     ;; and would print it bare.
                                      (list :covers (if (eq kind :contract)
                                                        :contract
                                                        :property))))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -599,15 +599,22 @@ to the caller as one that exists."
                     (when values (printed-for-display values)))
           :base-type (let ((base (getf spec-plist :base-type)))
                        (when base (printed-for-display base)))
-          :min (let ((minimum (getf spec-plist :min)))
-                 (when minimum (printed-for-display minimum)))
-          :max (let ((maximum (getf spec-plist :max)))
-                 (when maximum (printed-for-display maximum)))
+          :min (%range-bound (getf spec-plist :min))
+          :max (%range-bound (getf spec-plist :max))
           :class-name (let ((name (getf spec-plist :class-name)))
                         (when name (symbol-data name)))
           :source-form (printed-for-display (getf spec-plist :source-form))
           :source-location (getf spec-plist :source-location)
           :children (mapcar #'%spec-tree (getf spec-plist :children)))))
+
+(defun %range-bound (value)
+  "Return a range end as text, or NIL when the node has none.
+
+cl-spec spells an open end :UNBOUNDED.  Mapped back to the * the author wrote,
+here rather than in a renderer, so the text and the JSON agree and neither has
+to know the IR's word for it."
+  (when value
+    (if (eq :unbounded value) "*" (printed-for-display value))))
 
 (defun %describe-function-spec (api name registry max-chars)
   "Return the detail plist for the contract registered for NAME.

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -476,11 +476,19 @@ different answers."
               :message (format nil "kind must be one of specs, properties, ~
 function-specs or both; got ~S" kind)
               :environment environment)))
-    (unless (and (api-has-p api :list-specs) (api-has-p api :list-properties))
-      (return-from list-report
-        (list :status :unsupported
-              :message +listing-unsupported-message+
-              :environment environment)))
+    ;; Gated on what THIS kind needs.  The blanket check predates
+    ;; kind="function-specs", which reads neither of these two, and refused a
+    ;; listing it could have produced -- while reporting
+    ;; function_specs_listable true three keys later.
+    (let ((needed (cond ((string= kind "specs") '(:list-specs))
+                        ((string= kind "properties") '(:list-properties))
+                        ((string= kind "both") '(:list-specs :list-properties))
+                        (t '()))))
+      (unless (every (lambda (name) (api-has-p api name)) needed)
+        (return-from list-report
+          (list :status :unsupported
+                :message +listing-unsupported-message+
+                :environment environment))))
     (multiple-value-bind (package-object package-error)
         (%listing-package-filter package)
       (when package-error
@@ -636,8 +644,9 @@ answers."
              ;; renderer can tell a contract with no :PRE from one whose :PRE
              ;; is the literal NIL.
              (when forms
-               (multiple-value-bind (text complete) (%print-bounded-form forms max-chars)
-                 (list text complete)))))
+               (multiple-value-bind (text complete omitted)
+                   (%print-bounded-form forms max-chars)
+                 (list text complete omitted)))))
       (let ((pre (clause (getf data :preconditions)))
             (post (clause (getf data :postconditions))))
         (multiple-value-bind (source source-complete source-omitted)
@@ -653,8 +662,10 @@ answers."
                 :returns (%spec-tree (getf data :returns))
                 :preconditions (first pre)
                 :preconditions-complete (if pre (second pre) t)
+                :preconditions-omitted-chars (third pre)
                 :postconditions (first post)
                 :postconditions-complete (if post (second post) t)
+                :postconditions-omitted-chars (third post)
                 :source-form source
                 :source-form-complete source-complete
                 :source-form-omitted-chars source-omitted
@@ -896,33 +907,44 @@ no registered property can select a trial count for it. Use a profile that ~
 appears in the property's trials table (see spec-describe)."
                         profile)))))
 
-(defun %registered-property-p (api name registry)
-  "Return (values FOUND-P MESSAGE) for property NAME in REGISTRY."
+(defun %registered-p (api data-key name registry)
+  "Return (values FOUND-P MESSAGE) for NAME under the API reader DATA-KEY.
+
+DATA-KEY is :PROPERTY-DATA or :FUNCTION-SPEC-DATA.  Every error is read as
+\"not registered\", which is true of cl-spec's unknown-name conditions and an
+approximation for anything else it might signal; the message is carried so the
+approximation is at least visible."
   (handler-case
-      (progn (funcall (api-fn api :property-data) name :registry registry)
+      (progn (funcall (api-fn api data-key) name :registry registry)
              (values t nil))
     (error (condition) (values nil (princ-to-string condition)))))
 
-(defun %select-explicit (api property package registry)
-  "Return (values NAMES SELECTION ERROR) for an explicit property request."
+(defun %select-named (api designator package registry
+                      &key data-key mode requested-key source coverage)
+  "Return (values NAMES SELECTION ERROR) for one explicitly named definition.
+
+Serves both explicit selections -- a property by name and a contract by name.
+They resolve, check and describe identically, and differ only in the reader
+they ask and the five literals they put in the selection plist; kept apart,
+each fix to one had to be remembered for the other."
   (multiple-value-bind (name reason)
-      (resolve-symbol-designator property :package package)
+      (resolve-symbol-designator designator :package package)
     (if (null name)
         (values nil nil (list :status :unresolved-symbol :reason reason
-                              :input property))
+                              :input designator))
         (multiple-value-bind (found-p message)
-            (%registered-property-p api name registry)
+            (%registered-p api data-key name registry)
           (if (not found-p)
               (values nil nil (list :status :not-registered
                                     :name (symbol-data name)
                                     :message message))
               (values (list name)
-                      (list :mode "explicit"
-                            :requested (list :property (symbol-data name))
+                      (list :mode mode
+                            :requested (list requested-key (symbol-data name))
                             :selected (list (symbol-data name))
                             :count 1
-                            :source "explicit property argument"
-                            :coverage +explicit-coverage-note+)
+                            :source source
+                            :coverage coverage)
                       nil))))))
 
 (defun %select-about (api symbol package registry)
@@ -1011,35 +1033,6 @@ refused only for a profile that was actually asked for."
        (list :status :invalid-arguments
              :message +profile-needs-a-property-message+)))))
 
-(defun %registered-contract-p (api name registry)
-  "Return (values FOUND-P MESSAGE) for the contract registered for NAME."
-  (handler-case
-      (progn (funcall (api-fn api :function-spec-data) name :registry registry)
-             (values t nil))
-    (error (condition) (values nil (princ-to-string condition)))))
-
-(defun %select-contract (api function package registry)
-  "Return (values NAMES SELECTION ERROR) for an explicit contract request."
-  (multiple-value-bind (name reason)
-      (resolve-symbol-designator function :package package)
-    (if (null name)
-        (values nil nil (list :status :unresolved-symbol :reason reason
-                              :input function))
-        (multiple-value-bind (found-p message)
-            (%registered-contract-p api name registry)
-          (if (not found-p)
-              (values nil nil (list :status :not-registered
-                                    :name (symbol-data name)
-                                    :message message))
-              (values (list name)
-                      (list :mode "contract"
-                            :requested (list :function (symbol-data name))
-                            :selected (list (symbol-data name))
-                            :count 1
-                            :source "explicit function argument"
-                            :coverage +contract-coverage-note+)
-                      nil))))))
-
 (defun %select-properties (api property symbol function package registry)
   "Return (values NAMES SELECTION ERROR KIND) for the requested selection.
 
@@ -1055,11 +1048,21 @@ learns it exists rather than being left to assume the run covered it."
   (cond
     (function
      (multiple-value-bind (names selection error)
-         (%select-contract api function package registry)
+         (%select-named api function package registry
+                        :data-key :function-spec-data
+                        :mode "contract"
+                        :requested-key :function
+                        :source "explicit function argument"
+                        :coverage +contract-coverage-note+)
        (values names selection error :contract)))
     (property
      (multiple-value-bind (names selection error)
-         (%select-explicit api property package registry)
+         (%select-named api property package registry
+                        :data-key :property-data
+                        :mode "explicit"
+                        :requested-key :property
+                        :source "explicit property argument"
+                        :coverage +explicit-coverage-note+)
        (values names selection error :property)))
     (t
      (multiple-value-bind (names selection error)
@@ -1213,30 +1216,46 @@ admit, and a trial count that includes them overstates the work.  It is
 reported with REJECTED-MEASURED beside it, because a cl-spec whose readers this
 adapter could not resolve gives NIL, which must not read as zero rejections.
 
+REJECTED can exceed EXECUTED, so the difference is floored at zero and the
+overshoot reported rather than published as a negative count.  cl-spec stops
+counting refusals at the first failure it recognizes, but a target that
+SIGNALS unwinds past that point with the counter still running, and shrinking
+then re-runs the predicate over candidates its :PRE refuses.  Measured at 3
+runs in 8 against a contract whose function signals inside its :PRE region,
+one of them reporting 1 trial and 2 rejections.
+
 FAILURE-REASON names which half of the contract broke; EXPLANATION carries
 cl-spec's structured account of a return value that missed its spec."
   (flet ((read-slot (key)
            (when (api-has-p api key)
              (handler-case (funcall (api-fn api key) result)
                (error () nil)))))
-    (let ((rejected (read-slot :check-rejected))
-          (reason (read-slot :check-failure-reason))
-          (explanation (read-slot :check-explanation)))
-      (list :rejected rejected
-            :rejected-measured (and (integerp rejected) t)
-            :effective-trials (when (and (integerp executed) (integerp rejected))
-                                (- executed rejected))
-            :failure-reason reason
-            ;; Whether the reader resolved, not whether it returned something.
-            ;; NIL is a legitimate answer from cl-spec -- a passing run, or a
-            ;; failing one whose counterexample did not reproduce -- so it
-            ;; cannot double as "this adapter could not ask".  Reported for
-            ;; the same reason REJECTED-MEASURED is: without it a renderer
-            ;; tells the caller their function is non-deterministic on the
-            ;; evidence of a name this image could not find.
-            :failure-reason-readable (and (api-has-p api :check-failure-reason) t)
-            :explanation (when explanation
-                           (print-form-bounded explanation max-value-chars))))))
+    (let* ((rejected (read-slot :check-rejected))
+           (reason (read-slot :check-failure-reason))
+           (explanation (read-slot :check-explanation))
+           (countable (and (integerp executed) (integerp rejected)))
+           (overcounted (and countable (> rejected executed))))
+      (multiple-value-bind (explanation-text explanation-complete
+                            explanation-omitted)
+          (if explanation
+              (print-form-bounded explanation max-value-chars)
+              (values nil t nil))
+        (list :rejected rejected
+              :rejected-measured (and (integerp rejected) t)
+              :rejected-overcounted (and overcounted t)
+              :effective-trials (when countable (max 0 (- executed rejected)))
+              :failure-reason reason
+              ;; Whether the reader resolved, not whether it returned something.
+              ;; NIL is a legitimate answer from cl-spec -- a passing run, or a
+              ;; failing one whose counterexample did not reproduce -- so it
+              ;; cannot double as "this adapter could not ask".  Reported for
+              ;; the same reason REJECTED-MEASURED is: without it a renderer
+              ;; tells the caller their function is non-deterministic on the
+              ;; evidence of a name this image could not find.
+              :failure-reason-readable (and (api-has-p api :check-failure-reason) t)
+              :explanation explanation-text
+              :explanation-complete explanation-complete
+              :explanation-omitted-chars explanation-omitted)))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -973,13 +973,29 @@ while listing the properties about this symbol: ~A" condition)))))))
                "use.")
   "Said when trials is given for a property selection.")
 
-(defun %target-argument-error (property symbol function)
+(defparameter +profile-needs-a-property-message+
+  (concatenate 'string
+               "profile applies to a property run only. A contract has no "
+               ":trials table for a profile to select from, and cl-spec's "
+               "check-function takes no profile, so honouring it here would "
+               "report a profile the run did not use -- the mirror of why "
+               "trials is refused with property=. Size a contract run with "
+               "trials= instead.")
+  "Said when profile is given for a contract selection.")
+
+(defun %target-argument-error (property symbol function trials profile)
   "Return the plist for a bad target selection, or NIL when it is fine.
 
 Checked before cl-spec is consulted.  Naming more than one or none of them is
 a mistake in the call itself, and answering \"cl-spec is not loaded\" would
 send the caller to fix the wrong thing -- the same reason SPEC-ENTRY validates
-the seed before it resolves the API."
+the seed before it resolves the API.
+
+TRIALS and PROFILE sit here for that same reason, and as a pair: each sizes
+one kind of run and neither reaches the other, so accepting either against the
+wrong target would publish a budget or a profile the run never used.  PROFILE
+is the caller's own word, NIL when none was given, so a contract run is
+refused only for a profile that was actually asked for."
   (let ((given (count-if-not #'null (list property symbol function))))
     (cond
       ((> given 1)
@@ -987,7 +1003,13 @@ the seed before it resolves the API."
              :message "give exactly one of property, symbol or function"))
       ((zerop given)
        (list :status :invalid-arguments
-             :message "give one of property, symbol or function")))))
+             :message "give one of property, symbol or function"))
+      ((and trials (not function))
+       (list :status :invalid-arguments
+             :message +trials-needs-a-contract-message+))
+      ((and profile function)
+       (list :status :invalid-arguments
+             :message +profile-needs-a-property-message+)))))
 
 (defun %registered-contract-p (api name registry)
   "Return (values FOUND-P MESSAGE) for the contract registered for NAME."
@@ -1205,6 +1227,14 @@ cl-spec's structured account of a return value that missed its spec."
             :effective-trials (when (and (integerp executed) (integerp rejected))
                                 (- executed rejected))
             :failure-reason reason
+            ;; Whether the reader resolved, not whether it returned something.
+            ;; NIL is a legitimate answer from cl-spec -- a passing run, or a
+            ;; failing one whose counterexample did not reproduce -- so it
+            ;; cannot double as "this adapter could not ask".  Reported for
+            ;; the same reason REJECTED-MEASURED is: without it a renderer
+            ;; tells the caller their function is non-deterministic on the
+            ;; evidence of a name this image could not find.
+            :failure-reason-readable (and (api-has-p api :check-failure-reason) t)
             :explanation (when explanation
                            (print-form-bounded explanation max-value-chars))))))
 
@@ -1387,7 +1417,7 @@ could answer with eleven -- and the description is the only documentation a
 model ever sees.")
 
 (defparameter +call-statuses+
-  '(:no-properties :completed :incomplete
+  '(:no-properties :completed :incomplete :unsupported
     :cl-spec-not-loaded :cl-spec-incomplete :backend-not-loaded
     :unresolved-symbol :not-registered :invalid-arguments :internal-error)
   "Every status a whole spec-check call can carry.")
@@ -1500,7 +1530,8 @@ of them passed.  A selection of zero, a timeout, a generator failure and a
 skipped run are each reported as themselves: none of them is evidence that
 anything holds."
   (let ((environment (environment-data api api-status))
-        (argument-error (%target-argument-error property symbol function)))
+        (argument-error (%target-argument-error property symbol function
+                                                trials profile)))
     ;; Before the availability check, deliberately: an argument that is wrong
     ;; is wrong whatever cl-spec is doing, and reporting the load state first
     ;; would send the caller to fix the wrong thing.
@@ -1514,12 +1545,6 @@ anything holds."
         (list :status :backend-not-loaded
               :verified nil
               :message +backend-missing-message+
-              :environment environment)))
-    (when (and trials (not function))
-      (return-from check-report
-        (list :status :invalid-arguments
-              :verified nil
-              :message +trials-needs-a-contract-message+
               :environment environment)))
     (when (and function (not (and (api-has-p api :check-function)
                                   (api-has-p api :function-spec-data))))

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -488,12 +488,20 @@ function-specs or both; got ~S" kind)
     ;; reported as its own null count, the way FUNCTION-SPECS-LISTABLE already
     ;; reports the third half.
     (let ((wanted (remove nil
-                          (list (unless (api-has-p api :list-specs)
+                          (list (when (and (member kind '("specs" "both")
+                                                   :test #'string=)
+                                           (not (api-has-p api :list-specs)))
                                   "list-specs")
-                                (unless (api-has-p api :list-properties)
+                                (when (and (member kind '("properties" "both")
+                                                   :test #'string=)
+                                           (not (api-has-p api :list-properties)))
                                   "list-properties")
-                                (unless (and (api-has-p api :list-function-specs)
-                                             (api-has-p api :function-spec-data))
+                                (when (and (member kind '("function-specs" "both")
+                                                   :test #'string=)
+                                           (not (and (api-has-p
+                                                      api :list-function-specs)
+                                                     (api-has-p
+                                                      api :function-spec-data))))
                                   "list-function-specs with function-spec-data"))))
           (reachable
              (remove nil
@@ -766,10 +774,14 @@ answers."
                                                :spec (%spec-tree (getf argument :spec))))
                 :returns (%spec-tree (getf data :returns))
                 :preconditions (first pre)
-                :preconditions-complete (if pre (second pre) t)
+                ;; Only when there is a clause.  "complete: true" about a
+                ;; :PRE the contract does not have is a claim, and the
+                ;; response has %OPTIONAL-BOOL to carry an absent flag as
+                ;; null -- which is what this PR added it for.
+                :preconditions-complete (if pre (second pre) :not-applicable)
                 :preconditions-omitted-chars (third pre)
                 :postconditions (first post)
-                :postconditions-complete (if post (second post) t)
+                :postconditions-complete (if post (second post) :not-applicable)
                 :postconditions-omitted-chars (third post)
                 :source-form source
                 :source-form-complete source-complete
@@ -1170,10 +1182,17 @@ alone.  The mirror of what an :ABOUT selection reports about the contract it
 did not run: both are coverage a caller would otherwise have to infer from
 prose, and the argument for naming one is the argument for naming the other."
   (handler-case
-      (mapcar #'symbol-data
-              (getf (funcall (api-fn api :semantic-data) name :registry registry)
-                    :properties-about))
-    (error () nil)))
+      (values (mapcar #'symbol-data
+                      (getf (funcall (api-fn api :semantic-data) name
+                                     :registry registry)
+                            :properties-about))
+              t)
+    ;; (values NIL NIL) rather than NIL: an empty list here says the symbol has
+    ;; no properties registered about it, and a read that failed has no
+    ;; evidence for that.  Reported as its own fact, the way every sibling in
+    ;; this module is -- FUNCTION-SPECS-LISTABLE, REJECTED-MEASURED,
+    ;; FAILURE-REASON-READABLE, HAS-PRECONDITION.
+    (error () (values nil nil))))
 
 (defun %select-properties (api property symbol function package registry)
   "Return (values NAMES SELECTION ERROR KIND DATA) for the requested selection.
@@ -1201,15 +1220,28 @@ learns it exists rather than being left to assume the run covered it."
                         :coverage +contract-coverage-note+)
        (values names
                (if names
-                   (let ((about (%properties-about api (first names) registry)))
+                   (multiple-value-bind (about read)
+                       (%properties-about api (first names) registry)
                      (append selection
-                             (list :properties-not-run about)
-                             (when about
-                               (list :notes
-                                     (list (format nil "~D propert~:@P ~
+                             (list :properties-not-run about
+                                   :properties-not-run-read (and read t))
+                             (cond
+                               (about
+                                (list :notes
+                                      (list (format nil "~D propert~:@P ~
 registered (:about this symbol) ~:*~[~;is~:;are~] NOT covered by a contract ~
 run: run them with spec-check symbol=<this symbol>."
-                                                   (length about)))))))
+                                                    (length about)))))
+                               ((not read)
+                                (list :notes
+                                      (list (concatenate 'string
+                                                         "whether any property "
+                                                         "is registered about "
+                                                         "this symbol could "
+                                                         "not be read, so "
+                                                         "this run's coverage "
+                                                         "is unknown beyond "
+                                                         "the contract")))))))
                    selection)
                error :contract data)))
     (property
@@ -1425,11 +1457,18 @@ one of them reporting 1 trial and 2 rejections.
 FAILURE-REASON names which half of the contract broke; EXPLANATION carries
 cl-spec's structured account of a return value that missed its spec."
   (flet ((read-slot (key)
-           (when (api-has-p api key)
-             (handler-case (funcall (api-fn api key) result)
-               (error () nil)))))
+           ;; (values VALUE OK-P).  Resolving the symbol is not the same as
+           ;; calling it: a reader that signals -- a result type that drifted,
+           ;; an argument count that moved -- also gives NIL, and a flag
+           ;; recording only that the name existed then told the caller their
+           ;; function was non-deterministic on the strength of an adapter
+           ;; read that failed.
+           (if (api-has-p api key)
+               (handler-case (values (funcall (api-fn api key) result) t)
+                 (error () (values nil nil)))
+               (values nil nil))))
+    (multiple-value-bind (reason reason-read) (read-slot :check-failure-reason)
     (let* ((rejected (read-slot :check-rejected))
-           (reason (read-slot :check-failure-reason))
            (explanation (read-slot :check-explanation))
            (countable (and (integerp executed) (integerp rejected)))
            (overcounted (and countable (> rejected executed))))
@@ -1462,10 +1501,10 @@ cl-spec's structured account of a return value that missed its spec."
               ;; the same reason REJECTED-MEASURED is: without it a renderer
               ;; tells the caller their function is non-deterministic on the
               ;; evidence of a name this image could not find.
-              :failure-reason-readable (and (api-has-p api :check-failure-reason) t)
+              :failure-reason-readable (and reason-read t)
               :explanation explanation-text
               :explanation-complete explanation-complete
-              :explanation-omitted-chars explanation-omitted)))))
+              :explanation-omitted-chars explanation-omitted))))))
 
 (defun %result-plist (api result name kind trials digest expected-digest
                       max-value-chars facts)
@@ -1702,22 +1741,20 @@ cl-spec reports :PASSED for a property whose profile resolves to a budget of
 zero -- the trial loop simply never runs -- and a passing status with nothing
 behind it is precisely the shape of a verification that did not happen.
 
-For a contract the number that counts is the one with the rejected inputs taken
-out.  A generated argument list its :PRE refused was never passed to the
-function, so counting it here would let a contract nothing exercised report
-itself evaluated."
+For a contract the effective count is the only count that answers this, and
+there is no falling back to the raw one when it is missing.  The raw count is
+what the effective count exists to correct: it includes every argument list
+the :PRE refused, so a contract whose precondition admitted nothing at all
+reads as a hundred evaluated trials.  Missing means unknown, and unknown is
+not evidence -- whether it went missing because this cl-spec exports no
+refused-input reader, because that reader signalled, or because cl-spec
+counted more refusals than trials."
   (let* ((contract (getf result :contract))
          (effective (getf contract :effective-trials))
          (executed (getf (getf result :trials) :executed)))
-    (cond
-      ;; The raw trial count is not a fallback here.  It is the number the
-      ;; rejection count was supposed to correct, and a run whose correction
-      ;; could not be computed has no usable count at all -- falling back to
-      ;; the uncorrected one let VERIFIED read true for a run whose own text
-      ;; says how often the function was called cannot be derived.
-      ((getf contract :rejected-overcounted) nil)
-      ((integerp effective) (plusp effective))
-      (t (and (integerp executed) (plusp executed))))))
+    (if contract
+        (and (integerp effective) (plusp effective))
+        (and (integerp executed) (plusp executed)))))
 
 (defun %verification-gaps (results &optional selection)
   "Return the reasons RESULTS fall short of a complete verification.
@@ -1754,13 +1791,30 @@ establish -- read full coverage for a function whose contract never ran."
           (setf rejections-measured nil)))
       (let ((status (getf result :status)))
         (case status
-          (:passed (unless (%evaluated-p result) (pushnew :zero-trials gaps)))
+          (:passed
+           (unless (%evaluated-p result)
+             ;; Two different shortfalls.  ZERO-TRIALS is documented as a
+             ;; budget that resolved to nothing; a contract whose effective
+             ;; count could not be derived did run trials, and saying its
+             ;; budget was zero sends the reader to raise a number that was
+             ;; never the problem.
+             (pushnew (if (and (getf result :contract)
+                               (not (integerp
+                                     (getf (getf result :contract)
+                                           :effective-trials))))
+                          :effective-trials-unknown
+                          :zero-trials)
+                      gaps)))
           ((:failed :error) nil)
           (t (pushnew status gaps)))))
     (append (nreverse gaps)
             (when (getf selection :contract-not-run) (list :contract-not-run))
             (when (getf selection :properties-not-run)
               (list :properties-not-run))
+            (when (and (getf selection :kind)
+                       (eq :contract (getf selection :kind))
+                       (not (getf selection :properties-not-run-read)))
+              (list :related-properties-unknown))
             (unless rejections-measured (list :rejection-counts-unmeasured))
             (list :input-coverage-unmeasured))))
 

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -514,18 +514,22 @@ function-specs or both; got ~S" kind)
            (reachable (remove-if-not
                        (lambda (row)
                          (every (lambda (key) (api-has-p api key)) (fourth row)))
-                       asked))
-           (wanted (mapcar (lambda (row)
+                       asked)))
+      (unless reachable
+        (return-from list-report
+          (list :status :unsupported
+                ;; Built here rather than above: it is used only on this
+                ;; branch, and formatting a message for every successful
+                ;; listing is work inside the caller's introspection deadline.
+                :message (%listing-unsupported-message
+                          (mapcar
+                           (lambda (row)
                              (format nil "~{~A~^ with ~}"
                                      (mapcar (lambda (key)
                                                (string-downcase (symbol-name key)))
                                              (fourth row))))
-                           (set-difference asked reachable :test #'eq))))
-      (unless reachable
-        (return-from list-report
-          (list :status :unsupported
-                :message (%listing-unsupported-message wanted)
-                :environment environment))))
+                           (set-difference asked reachable :test #'eq)))
+                :environment environment)))
     (multiple-value-bind (package-object package-error)
         (%listing-package-filter package)
       (when package-error
@@ -533,24 +537,19 @@ function-specs or both; got ~S" kind)
           (append package-error (list :environment environment))))
       (let* ((registry (funcall (api-fn api :registry)))
              (tag-keyword (and tag (find-keyword tag)))
-             (want-specs (listing-kind-wanted-p (assoc "specs" +listing-kinds+
-                                                       :test #'string=)
-                                                kind))
-             (want-properties (listing-kind-wanted-p
-                               (assoc "properties" +listing-kinds+
-                                      :test #'string=)
-                               kind))
-             (want-function-specs (listing-kind-wanted-p
-                                   (assoc "function-specs" +listing-kinds+
-                                          :test #'string=)
-                                   kind))
+             (want-specs (assoc "specs" asked :test #'string=))
+             (want-properties (assoc "properties" asked :test #'string=))
+             (want-function-specs (assoc "function-specs" asked :test #'string=))
              ;; Listed only when cl-spec can enumerate them.  Absence is
              ;; reported as its own answer below rather than as an empty
              ;; list: "this revision cannot enumerate contracts" and "there
              ;; are none" are different, and only one of them is a fact
              ;; about the project.
-             (function-specs-listable (and (api-has-p api :list-function-specs)
-                                           (api-has-p api :function-spec-data)))
+             ;; Off REACHABLE, which the gate above already computed from
+             ;; the same rows and the same handles.  Re-running API-HAS-P here
+             ;; was the fourth copy of the mapping the table exists to hold.
+             (function-specs-listable (assoc "function-specs" reachable
+                                             :test #'string=))
              (function-spec-names
                (when (and want-function-specs function-specs-listable)
                  (remove-if-not
@@ -561,8 +560,8 @@ function-specs or both; got ~S" kind)
              ;; could not look at comes back as a null count beside a false
              ;; listable flag -- never as an empty list, which would say the
              ;; registry holds none.
-             (specs-listable (api-has-p api :list-specs))
-             (properties-listable (api-has-p api :list-properties))
+             (specs-listable (assoc "specs" reachable :test #'string=))
+             (properties-listable (assoc "properties" reachable :test #'string=))
              (spec-names
                (when (and want-specs specs-listable)
                  (remove-if-not (lambda (name) (%in-package-p name package-object))
@@ -626,7 +625,7 @@ function-specs or both; got ~S" kind)
                                                  (tag-keyword t)
                                                  (t nil)))
               :coverage +listing-coverage-note+
-              :environment environment)))))
+              :environment environment))))))
 
 (defparameter +function-spec-unsupported-message+
   (concatenate 'string
@@ -767,15 +766,17 @@ answers."
              ;; NIL rather than the string "NIL" for an absent clause, so a
              ;; renderer can tell a contract with no :PRE from one whose :PRE
              ;; is the literal NIL.
-             ;; A single clause prints as the clause.  :PRECONDITIONS is a
-             ;; list of forms, so (:pre (<= low high)) arrives as
-             ;; ((<= low high)) and printing the list gave the reader a form
-             ;; they cannot paste back: a call to the list.
+             ;; What cl-spec evaluates, not the list it stores.
+             ;; :PRECONDITIONS is a list of forms -- (:pre (<= low high))
+             ;; arrives as ((<= low high)) -- and DEFSPEC-FUNCTION compiles
+             ;; them as (and ,@pre), so one clause prints as the clause and
+             ;; several print as that AND.  Printing the bare list gave the
+             ;; reader a form they cannot paste back: a call to the list.
              (when forms
                (multiple-value-bind (text complete omitted)
                    (%print-bounded-form (if (null (rest forms))
                                             (first forms)
-                                            forms)
+                                            (cons 'and forms))
                                         max-chars)
                  (list text complete omitted)))))
       (let ((pre (clause (getf data :preconditions)))
@@ -1504,7 +1505,16 @@ cl-spec's structured account of a return value that missed its spec."
              (contradicted (and countable
                                 (null precondition-p)
                                 (plusp rejected)))
-             (usable (and countable (not overcounted) (not contradicted))))
+             (usable (and countable
+                          (not overcounted)
+                          (not contradicted)
+                          ;; :UNKNOWN too.  The text already says a refusal
+                          ;; count cannot be interpreted without knowing
+                          ;; whether there is a :pre to have produced it;
+                          ;; leaving the subtraction in the payload let the
+                          ;; same response publish the figure and verify off
+                          ;; it while saying that.
+                          (not (eq :unknown precondition-p)))))
         (multiple-value-bind (explanation-text explanation-complete
                               explanation-omitted)
             (if explanation

--- a/src/tools/spec-entry.lisp
+++ b/src/tools/spec-entry.lisp
@@ -74,6 +74,28 @@ not registered\"."
       (t (values nil (format nil "~A must be a positive integer, got ~S"
                              name value))))))
 
+(defvar *maximum-trials* 1000000
+  "Largest trial count spec-check will pass to a contract run.
+
+An upper bound because the run happens on a deadline thread that cannot always
+be stopped: a budget of a hundred million outlives its timeout, keeps calling
+the target, and does it inside the worker this session's repl-eval and
+load-system share.  The deadline bounds how long the caller waits; only this
+bounds what the worker is left doing afterwards.  PROFILE never offered a
+caller-supplied number, so TRIALS is the first argument on this path that
+needed one.")
+
+(defun %bounded-integer-arg (params name maximum)
+  "Return (values N NIL) for a positive integer at most MAXIMUM, else an error."
+  (multiple-value-bind (value message) (%positive-integer-arg params name nil)
+    (cond
+      (message (values nil message))
+      ((and value (> value maximum))
+       (values nil (format nil "~A must be at most ~:D; a larger budget can ~
+outlive its timeout and go on calling the function in this worker"
+                           name maximum)))
+      (t (values value nil)))))
+
 (defun %argument-error-response (message builder)
   "Return BUILDER's response for an argument MESSAGE, before cl-spec is asked."
   (funcall builder
@@ -206,7 +228,7 @@ without complaint -- zero trials, reported as \"-5 executed of -5 budget\"."
       ;; comes from the property's own table or the backend, which is what
       ;; CHECK-REPORT expects to see.
       (multiple-value-bind (trials trials-error)
-          (%positive-integer-arg params "trials" nil)
+          (%bounded-integer-arg params "trials" *maximum-trials*)
         (let ((message (or seed-error chars-error trials-error)))
           (if message
               (%argument-error-response message #'build-spec-check-response)

--- a/src/tools/spec-entry.lisp
+++ b/src/tools/spec-entry.lisp
@@ -189,7 +189,10 @@ cl-mcp: ~A" value)
   "Return the spec-check response hash-table for PARAMS.
 
 An unusable seed is answered here rather than passed on: a run started with a
-seed the caller did not mean is a run whose result means nothing."
+seed the caller did not mean is a run whose result means nothing.  TRIALS is
+checked in the same place and for the same reason: the tool schema's :INTEGER
+admits 0 and negative numbers, and cl-spec runs (loop for trial from 1 to -5)
+without complaint -- zero trials, reported as \"-5 executed of -5 budget\"."
   ;; The raw value, not %STRING-ARG's: that filter turned a JSON number or an
   ;; empty string into NIL, and NIL means "no seed given" -- so the run went
   ;; ahead with a fresh random seed and reported it as though it were the
@@ -199,20 +202,25 @@ seed the caller did not mean is a run whose result means nothing."
       (parse-seed-string (and params (gethash "seed" params)))
     (multiple-value-bind (max-value-chars chars-error)
         (%positive-integer-arg params "max_value_chars" 2000)
-      (let ((message (or seed-error chars-error)))
-        (if message
-            (%argument-error-response message #'build-spec-check-response)
-            (multiple-value-bind (api status) (resolve-cl-spec-api)
-              (build-spec-check-response
-               (check-report api status
-                             :property (%string-arg params "property")
-                             :symbol (%string-arg params "symbol")
-                             :function (%string-arg params "function")
-                             :trials (gethash "trials" params)
-                             :package (%string-arg params "package")
-                             :profile (%string-arg params "profile")
-                             :seed seed
-                             :expect-definition-digest
-                             (%string-arg params "expect_definition_digest")
-                             :timeout-seconds (gethash "timeout_seconds" params)
-                             :max-value-chars max-value-chars))))))))
+      ;; A default of NIL, so an absent trials stays absent: the budget then
+      ;; comes from the property's own table or the backend, which is what
+      ;; CHECK-REPORT expects to see.
+      (multiple-value-bind (trials trials-error)
+          (%positive-integer-arg params "trials" nil)
+        (let ((message (or seed-error chars-error trials-error)))
+          (if message
+              (%argument-error-response message #'build-spec-check-response)
+              (multiple-value-bind (api status) (resolve-cl-spec-api)
+                (build-spec-check-response
+                 (check-report api status
+                               :property (%string-arg params "property")
+                               :symbol (%string-arg params "symbol")
+                               :function (%string-arg params "function")
+                               :trials trials
+                               :package (%string-arg params "package")
+                               :profile (%string-arg params "profile")
+                               :seed seed
+                               :expect-definition-digest
+                               (%string-arg params "expect_definition_digest")
+                               :timeout-seconds (gethash "timeout_seconds" params)
+                               :max-value-chars max-value-chars)))))))))

--- a/src/tools/spec-entry.lisp
+++ b/src/tools/spec-entry.lisp
@@ -77,13 +77,16 @@ not registered\"."
 (defvar *maximum-trials* 1000000
   "Largest trial count spec-check will pass to a contract run.
 
-An upper bound because the run happens on a deadline thread that cannot always
-be stopped: a budget of a hundred million outlives its timeout, keeps calling
-the target, and does it inside the worker this session's repl-eval and
-load-system share.  The deadline bounds how long the caller waits; only this
-bounds what the worker is left doing afterwards.  PROFILE never offered a
-caller-supplied number, so TRIALS is the first argument on this path that
-needed one.")
+A ceiling, not a bound on the work.  The run happens on a deadline thread that
+cannot always be stopped, so a budget outliving its timeout keeps calling the
+target inside the worker this session's repl-eval and load-system share; this
+caps how many calls that can be, and a million calls of an arbitrary function
+is still unbounded wall-clock time.  What would actually bound it is a
+cooperative deadline the run checks, or retiring a worker on a leaked thread
+-- which WORKER-REUSE already reports and nothing acts on -- and both are at a
+layer below this argument.  Recorded rather than implied, because a number
+that lets the bad case through is worth having only if nobody reads it as a
+guarantee.")
 
 (defun %bounded-integer-arg (params name maximum)
   "Return (values N NIL) for a positive integer at most MAXIMUM, else an error."

--- a/src/tools/spec-entry.lisp
+++ b/src/tools/spec-entry.lisp
@@ -208,6 +208,7 @@ seed the caller did not mean is a run whose result means nothing."
                              :property (%string-arg params "property")
                              :symbol (%string-arg params "symbol")
                              :function (%string-arg params "function")
+                             :trials (gethash "trials" params)
                              :package (%string-arg params "package")
                              :profile (%string-arg params "profile")
                              :seed seed

--- a/src/tools/spec-entry.lisp
+++ b/src/tools/spec-entry.lisp
@@ -207,6 +207,7 @@ seed the caller did not mean is a run whose result means nothing."
                (check-report api status
                              :property (%string-arg params "property")
                              :symbol (%string-arg params "symbol")
+                             :function (%string-arg params "function")
                              :package (%string-arg params "package")
                              :profile (%string-arg params "profile")
                              :seed seed

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -450,6 +450,18 @@ to see the rest; the text above is a preview, not a form that can be read back."
          (format stream "~&~%defined at a REPL, in package ~A"
                  (getf location :package)))))))
 
+(defun %optional-bool (report key)
+  "Return KEY's value as a JSON boolean, or NIL when REPORT does not carry KEY.
+
+JSON-BOOL renders an absent key as false, and false is a claim.  A contract
+describe carries no :SHRINK-ENABLED and no :BODY, so it published
+shrink_enabled false -- shrinking is off for this contract, which contradicts
+what spec-check function= then does -- and body_complete false, the body was
+cut, about a definition that has none.  A property describe did the same to
+preconditions_complete.  Absent has to reach the consumer as null."
+  (when (get-properties report (list key))
+    (json-bool (getf report key))))
+
 (defun build-spec-describe-response (report)
   "Return the MCP response for a DESCRIBE-REPORT plist."
   (case (getf report :status)
@@ -467,7 +479,7 @@ to see the rest; the text above is a preview, not a form that can be read back."
               "targets" (%symbol-hts (getf report :targets))
               "documentation" (sanitize-for-json (getf report :documentation))
               "trials_table" (sanitize-for-json (getf report :trials-table))
-              "shrink_enabled" (json-bool (getf report :shrink-enabled))
+              "shrink_enabled" (%optional-bool report :shrink-enabled)
               "arguments"
               (coerce (mapcar (lambda (argument)
                                 (make-ht "variable"
@@ -479,18 +491,18 @@ to see the rest; the text above is a preview, not a form that can be read back."
               "spec" (%spec-tree-ht (getf report :spec))
               "returns" (%spec-tree-ht (getf report :returns))
               "preconditions" (sanitize-for-json (getf report :preconditions))
-              "preconditions_complete" (json-bool (getf report :preconditions-complete))
+              "preconditions_complete" (%optional-bool report :preconditions-complete)
               "preconditions_omitted_chars" (getf report
                                                   :preconditions-omitted-chars)
               "postconditions" (sanitize-for-json (getf report :postconditions))
-              "postconditions_complete" (json-bool (getf report :postconditions-complete))
+              "postconditions_complete" (%optional-bool report :postconditions-complete)
               "postconditions_omitted_chars" (getf report
                                                    :postconditions-omitted-chars)
               "body" (sanitize-for-json (getf report :body))
-              "body_complete" (json-bool (getf report :body-complete))
+              "body_complete" (%optional-bool report :body-complete)
               "body_omitted_chars" (getf report :body-omitted-chars)
               "source_form" (sanitize-for-json (getf report :source-form))
-              "source_form_complete" (json-bool (getf report :source-form-complete))
+              "source_form_complete" (%optional-bool report :source-form-complete)
               "source_form_omitted_chars" (getf report :source-form-omitted-chars)
               "source_location" (%source-location-ht (getf report :source-location))
               "definition_digest" (getf report :definition-digest)
@@ -1008,13 +1020,24 @@ it came out."
       (when (getf filters :tag)
         ;; Named as narrowing properties, because that is all it narrows.
         ;; "4 function specs  tagged critical" read as four tagged contracts,
-        ;; and LIST-REPORT never offers TAG to the contract listing at all.
-        (format stream "  tagged ~A~:[ (properties only)~;~]"
-                (getf filters :tag)
-                (equal "properties" (getf report :kind)))
-        (unless (eq t (getf filters :tag-resolved))
-          (format stream " (NO SUCH TAG exists in this image, so nothing can ~
-carry it -- this is not the same as no property having it)")))
+        ;; and LIST-REPORT never offers TAG to the contract listing at all --
+        ;; on a kind that lists no properties it narrowed nothing whatever,
+        ;; which the caller has to be told rather than left to infer from a
+        ;; header that says the filter ran.
+        (let ((narrowed (member (getf report :kind) '("properties" "both")
+                                :test #'equal)))
+          (cond
+            ((not narrowed)
+             (format stream "  tag ~A was NOT applied: it narrows properties, ~
+and this kind lists none"
+                     (getf filters :tag)))
+            (t
+             (format stream "  tagged ~A~:[~; (properties only)~]"
+                     (getf filters :tag)
+                     (equal "both" (getf report :kind)))
+             (unless (eq t (getf filters :tag-resolved))
+               (format stream " (NO SUCH TAG exists in this image, so nothing ~
+can carry it -- this is not the same as no property having it)"))))))
       (when (getf report :truncated)
         (format stream "~&Showing at most ~D of each; raise limit for more."
                 (getf report :limit)))
@@ -1061,13 +1084,17 @@ project it here"
                       (or (getf contract :postcondition-count) 0)))
             (when (getf contract :documentation)
               (format stream "~&      ~A" (getf contract :documentation))))))
-      (when (and (getf report :kind)
-                 (member (getf report :kind) '("function-specs" "both")
-                         :test #'string=)
-                 (not (getf report :function-specs-listable)))
-        (format stream "~&~%function specs: the loaded cl-spec cannot ~
-enumerate them, so none are listed here. This is not evidence that none are ~
-registered."))
+      (dolist (half '(("specs" :specs-listable ("specs" "both"))
+                      ("properties" :properties-listable
+                       ("properties" "both"))
+                      ("function specs" :function-specs-listable
+                       ("function-specs" "both"))))
+        (destructuring-bind (label flag kinds) half
+          (when (and (member (getf report :kind) kinds :test #'equal)
+                     (not (getf report flag)))
+            (format stream "~&~%~A: the loaded cl-spec cannot enumerate them, ~
+so none are listed here. This is not evidence that none are registered."
+                    label))))
       ;; Only when every requested kind was in fact looked at.  Printed
       ;; after "the loaded cl-spec cannot enumerate them", it turned "cannot
       ;; look" back into "none here" -- the distinction function_specs_listable
@@ -1075,9 +1102,15 @@ registered."))
       (when (and (null (getf report :specs))
                  (null (getf report :properties))
                  (null (getf report :function-specs))
-                 (or (not (member (getf report :kind) '("function-specs" "both")
-                                  :test #'equal))
-                     (getf report :function-specs-listable)))
+                 (every (lambda (half)
+                          (destructuring-bind (flag kinds) half
+                            (or (not (member (getf report :kind) kinds
+                                             :test #'equal))
+                                (getf report flag))))
+                        '((:specs-listable ("specs" "both"))
+                          (:properties-listable ("properties" "both"))
+                          (:function-specs-listable
+                           ("function-specs" "both")))))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
 not evidence that this project has no contracts: a definition whose system ~
 has not been loaded into this worker is not here."))
@@ -1104,6 +1137,9 @@ has not been loaded into this worker is not here."))
                 "function_specs" (coerce (mapcar #'%function-spec-entry-ht
                                                  (getf report :function-specs))
                                          'vector)
+                "specs_listable" (json-bool (getf report :specs-listable))
+                "properties_listable" (json-bool
+                                       (getf report :properties-listable))
                 "function_specs_listable"
                 (json-bool (getf report :function-specs-listable))
                 ;; NIL for a kind that was not requested, which yason

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -386,7 +386,7 @@ max_chars -- which is to say, by luck."
               (getf report :shrink-enabled)))))
 
 (defun %report-cut (stream report complete-key omitted-key
-                    &key (budget "max_chars") extra)
+                    &key (budget "max_chars") extra (indent 0))
   "Write REPORT's truncation notice for one field, or nothing when it is whole.
 
 Four copies of this line had drifted into three wordings and one that forgot
@@ -394,9 +394,9 @@ to name the budget at all -- and two of the four were added in the same change
 that added the fields.  EXTRA carries what a particular field has to add."
   (unless (eq t (getf report complete-key))
     (unless (eq :not-applicable (getf report complete-key))
-      (format stream "~&... truncated, ~D more character~:P. Raise ~A to see ~
-the rest.~@[ ~A~]"
-              (getf report omitted-key) budget extra))))
+      (format stream "~&~vT... truncated, ~D more character~:P. Raise ~A to ~
+see the rest.~@[ ~A~]"
+              indent (getf report omitted-key) budget extra))))
 
 (defun %format-describe-text (report)
   "Render the spec-describe report as text."
@@ -487,7 +487,8 @@ preconditions_complete.  Absent has to reach the consumer as null."
   (case (getf report :status)
     ((:cl-spec-not-loaded :cl-spec-incomplete) (%unavailable-response report))
     (:unresolved-symbol (%unresolved-response report))
-    ((:not-registered :unsupported :invalid-arguments :internal-error :timeout)
+    ((:not-registered :undefined-function :unsupported :invalid-arguments
+      :internal-error :timeout)
      (%simple-status-response report))
     (t
      (make-ht "schema_version" +schema-version+
@@ -764,10 +765,9 @@ a finding about the function"))))
       (let ((explanation (getf contract :explanation)))
         (when explanation
           (format stream "~&    return value: ~A" explanation)
-          (unless (getf contract :explanation-complete)
-            (format stream "~&    ... truncated, ~D more character~:P. Raise ~
-max_value_chars to see the rest."
-                    (getf contract :explanation-omitted-chars))))))))
+          (%report-cut stream contract :explanation-complete
+                       :explanation-omitted-chars
+                       :budget "max_value_chars" :indent 4))))))
 
 (defun %format-one-result (stream result index)
   "Write one per-property result to STREAM."

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -591,6 +591,8 @@ not be read."
              "failure_reason_readable" (json-bool
                                         (getf contract :failure-reason-readable))
              "explanation" (sanitize-for-json (getf contract :explanation))
+             "explanation_readable" (json-bool
+                                     (getf contract :explanation-readable))
              "rejected_contradicted" (json-bool
                                       (getf contract :rejected-contradicted))
              "rejected_usable" (json-bool (getf contract :rejected-usable))
@@ -698,44 +700,31 @@ The effective trial count is the one a reader should act on: a contract whose
 count suggests, and that shortfall is invisible in every other line."
   (let ((contract (getf result :contract)))
     (when contract
-      (cond
-        ;; The two uncertainty branches first.  "no :pre, so every generated
-        ;; input was passed to the function" is an affirmative claim that the
-        ;; effective count equals the executed one, and it must not be made
-        ;; over a refusal count that is missing or unusable -- whichever of
-        ;; the two the response is carrying.
-        ((getf contract :rejected-overcounted)
-         ;; More refusals than trials, so the difference says nothing.  Left
-         ;; as its own line rather than folded into the one below: printing
-         ;; "the function was called 0 times" for a run that did call it is a
-         ;; different wrong answer, not a smaller one.
+      (case (getf contract :rejection-status)
+        ;; One CASE on the keyword the report decided, rather than five
+        ;; booleans re-tested in an order that must not change.
+        (:overcounted
          (format stream "~&    contract: ~A inputs refused by :pre against ~
 ~A trials -- cl-spec counted more refusals than trials, so how often the ~
 function was actually called cannot be derived here"
                  (getf contract :rejected)
                  (or (getf (getf result :trials) :executed)
                      "an unknown number of")))
-        ((not (getf contract :rejected-measured))
+        (:unmeasured
          (format stream "~&    contract: the refused-input count could not be ~
 read, so the trial count above is an upper bound on what was checked"))
-        ((getf contract :rejected-contradicted)
+        (:contradicted
          (format stream "~&    contract: ~A input~:P refused although this ~
 contract has no :pre -- the two do not agree, so how often the function was ~
 called cannot be read off them"
                  (getf contract :rejected)))
-        ((null (getf contract :precondition-p))
-         ;; No :PRE, so nothing could be refused and there is no shortfall to
-         ;; report.  The refusal line named a clause the author never wrote.
-         (format stream "~&    contract: no :pre, so every generated input ~
-was passed to the function"))
-        ((eq :unknown (getf contract :precondition-p))
-         ;; Neither "it has one" nor "it has none".  Folded into the branch
-         ;; below, the text asserted a :pre while has_precondition beside it
-         ;; came back null -- the two halves of one response disagreeing on
-         ;; whether the clause exists.
+        (:precondition-unknown
          (format stream "~&    contract: whether it has a :pre could not be ~
 read, so ~A refused input~:P is a count this response cannot interpret"
                  (or (getf contract :rejected) "an unknown number of")))
+        (:no-precondition
+         (format stream "~&    contract: no :pre, so every generated input ~
+was passed to the function"))
         (t
          (format stream "~&    contract: ~A of them refused by :pre, ~
 so the function was called ~A time~:P"
@@ -906,6 +895,14 @@ it came out."
        (format nil "~A (contract only -- ~D propert~:@P about this symbol ~
 ~:*~[~;was~:;were~] NOT run)"
                verdict (length properties)))
+      ;; And the case where coverage is least known needs it most: the
+      ;; lookup that would have said what else is registered failed, so the
+      ;; bare verdict would be the only line that did not admit it.
+      ((and (eq :contract (getf (getf report :selection) :kind))
+            (not (getf (getf report :selection) :properties-not-run-read)))
+       (format nil "~A (contract only -- what else is registered about this ~
+symbol could not be read)"
+               verdict))
       (t verdict))))
 
 (defun %format-check-text (report)
@@ -949,8 +946,8 @@ it came out."
     ;; of a run renders "Selected NIL properties via NIL" while the one thing
     ;; the caller needs -- why cl-spec could not run the contract -- never
     ;; reaches content[].text.
-    ((:not-registered :unsupported :invalid-arguments :backend-not-loaded
-      :internal-error :timeout)
+    ((:not-registered :undefined-function :unsupported :invalid-arguments
+      :backend-not-loaded :internal-error :timeout)
      (let ((response (%simple-status-response report)))
        (setf (gethash "verified" response) (json-bool nil))
        response))
@@ -1222,7 +1219,10 @@ has not been loaded into this worker is not here."))
                                    "tag" (getf filters :tag)
                                    "tag_resolved"
                                    (%tag-resolved-string
-                                    (getf filters :tag-resolved)))
+                                    (getf filters :tag-resolved))
+                                   "tag_applied"
+                                   (when (getf filters :tag)
+                                     (json-bool (getf filters :tag-applied))))
                 "coverage" (getf report :coverage)
                 "environment" (%environment-ht (getf report :environment))
                 "content" (text-content (%format-list-text report)))))))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -1082,8 +1082,22 @@ it came out."
         ;; header that says the filter ran.
         (let ((narrowed (and (member (getf report :kind) '("properties" "both")
                                      :test #'equal)
-                             (getf report :properties-listable))))
+                             (getf report :properties-listable)
+                             ;; The flag that answers whether the filter ran.
+                             ;; Keyed on PROPERTIES-LISTABLE, a revision with
+                             ;; no PROPERTIES-WITH-TAG printed "tagged
+                             ;; critical" over a listing the tag never
+                             ;; touched -- the "no property carries this tag"
+                             ;; reading the flags exist to prevent.
+                             (getf report :tag-filterable))))
           (cond
+            ((and (not narrowed)
+                  (member (getf report :kind) '("properties" "both")
+                          :test #'equal)
+                  (getf report :properties-listable))
+             (format stream "  tag ~A was NOT applied: the loaded cl-spec ~
+exports no properties-with-tag, so nothing here was filtered by it"
+                     (getf filters :tag)))
             ((not narrowed)
              (format stream "  tag ~A was NOT applied: it narrows properties, ~
 and this kind lists none"
@@ -1143,8 +1157,8 @@ project it here"
               (format stream "~&      ~A" (getf contract :documentation))))))
       (dolist (half +listing-kinds+)
         (destructuring-bind (name label flag keys) half
-          (declare (ignore keys))
-          (when (and (listing-kind-wanted-p (list name) (getf report :kind))
+          (declare (ignore name keys))
+          (when (and (listing-kind-wanted-p half (getf report :kind))
                      (not (getf report flag)))
             (format stream "~&~%~A: the loaded cl-spec cannot enumerate them, ~
 so none are listed here. This is not evidence that none are registered."
@@ -1158,9 +1172,9 @@ so none are listed here. This is not evidence that none are registered."
                  (null (getf report :function-specs))
                  (every (lambda (half)
                           (destructuring-bind (name label flag keys) half
-                            (declare (ignore label keys))
+                            (declare (ignore name label keys))
                             (or (not (listing-kind-wanted-p
-                                      (list name) (getf report :kind)))
+                                      half (getf report :kind)))
                                 (getf report flag))))
                         +listing-kinds+))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
@@ -1192,6 +1206,7 @@ has not been loaded into this worker is not here."))
                 "specs_listable" (json-bool (getf report :specs-listable))
                 "properties_listable" (json-bool
                                        (getf report :properties-listable))
+                "tag_filterable" (json-bool (getf report :tag-filterable))
                 "function_specs_listable"
                 (json-bool (getf report :function-specs-listable))
                 ;; NIL for a kind that was not requested, which yason

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -15,6 +15,9 @@
                 #:make-ht #:text-content #:json-bool)
   (:import-from #:cl-mcp/src/utils/sanitize
                 #:sanitize-for-json)
+  (:import-from #:cl-mcp/src/spec-adapter-report
+                #:+listing-kinds+
+                #:listing-kind-wanted-p)
   (:export #:build-spec-list-response
            #:build-spec-symbol-response
            #:build-spec-describe-response
@@ -588,8 +591,11 @@ not be read."
              "failure_reason_readable" (json-bool
                                         (getf contract :failure-reason-readable))
              "explanation" (sanitize-for-json (getf contract :explanation))
-             "explanation_complete" (json-bool
-                                     (getf contract :explanation-complete))
+             "rejected_contradicted" (json-bool
+                                      (getf contract :rejected-contradicted))
+             "rejected_usable" (json-bool (getf contract :rejected-usable))
+             "explanation_complete" (%optional-bool contract
+                                                   :explanation-complete)
              "explanation_omitted_chars" (getf contract
                                                :explanation-omitted-chars))))
 
@@ -712,19 +718,16 @@ function was actually called cannot be derived here"
         ((not (getf contract :rejected-measured))
          (format stream "~&    contract: the refused-input count could not be ~
 read, so the trial count above is an upper bound on what was checked"))
+        ((getf contract :rejected-contradicted)
+         (format stream "~&    contract: ~A input~:P refused although this ~
+contract has no :pre -- the two do not agree, so how often the function was ~
+called cannot be read off them"
+                 (getf contract :rejected)))
         ((null (getf contract :precondition-p))
          ;; No :PRE, so nothing could be refused and there is no shortfall to
          ;; report.  The refusal line named a clause the author never wrote.
-         (if (eql 0 (getf contract :rejected))
-             (format stream "~&    contract: no :pre, so every generated ~
-input was passed to the function")
-             ;; A refusal against a contract with nothing to refuse with.  The
-             ;; two facts came from different readers and they disagree; the
-             ;; affirmative claim is the one that has to go.
-             (format stream "~&    contract: ~A input~:P refused although ~
-this contract has no :pre -- the two do not agree, so how often the function ~
-was called cannot be read off them"
-                     (getf contract :rejected))))
+         (format stream "~&    contract: no :pre, so every generated input ~
+was passed to the function"))
         ((eq :unknown (getf contract :precondition-p))
          ;; Neither "it has one" nor "it has none".  Folded into the branch
          ;; below, the text asserted a :pre while has_precondition beside it
@@ -971,8 +974,14 @@ it came out."
                          "coverage" (getf selection :coverage)
                          "contract_not_run" (%symbol-ht
                                              (getf selection :contract-not-run))
+                         ;; NIL, not [], for a selection that never looks:
+                         ;; an empty array is the claim that nothing was left
+                         ;; unrun, and property= and symbol= leave three
+                         ;; properties and a contract unrun without ever
+                         ;; populating this key.
                          "properties_not_run"
-                         (%symbol-hts (getf selection :properties-not-run))
+                         (when (getf selection :properties-not-run-read)
+                           (%symbol-hts (getf selection :properties-not-run)))
                          "properties_not_run_read"
                          (%optional-bool selection :properties-not-run-read)
                          "notes" (%strings (getf selection :notes)))
@@ -1042,18 +1051,6 @@ it came out."
     ((nil) "no-such-keyword")
     (:not-requested "not-requested")
     (t "resolved")))
-
-(defparameter +listing-halves+
-  '(("specs" :specs-listable ("specs" "both"))
-    ("properties" :properties-listable ("properties" "both"))
-    ("function specs" :function-specs-listable ("function-specs" "both")))
-  "Each listing half: its label, its listable flag, and the kinds that ask for it.
-
-One table rather than two.  The notes saying a half could not be enumerated
-and the gate on \"Nothing registered matches\" read the same three facts, and
-written twice they could disagree -- printing the empty claim about a half the
-listing never looked at, which is the conflation the second one exists to
-prevent.")
 
 (defun %format-list-text (report)
   "Render the spec-list report as the text an MCP client will show."
@@ -1144,9 +1141,10 @@ project it here"
                       (or (getf contract :postcondition-count) 0)))
             (when (getf contract :documentation)
               (format stream "~&      ~A" (getf contract :documentation))))))
-      (dolist (half +listing-halves+)
-        (destructuring-bind (label flag kinds) half
-          (when (and (member (getf report :kind) kinds :test #'equal)
+      (dolist (half +listing-kinds+)
+        (destructuring-bind (name label flag keys) half
+          (declare (ignore keys))
+          (when (and (listing-kind-wanted-p (list name) (getf report :kind))
                      (not (getf report flag)))
             (format stream "~&~%~A: the loaded cl-spec cannot enumerate them, ~
 so none are listed here. This is not evidence that none are registered."
@@ -1159,12 +1157,12 @@ so none are listed here. This is not evidence that none are registered."
                  (null (getf report :properties))
                  (null (getf report :function-specs))
                  (every (lambda (half)
-                          (destructuring-bind (label flag kinds) half
-                            (declare (ignore label))
-                            (or (not (member (getf report :kind) kinds
-                                             :test #'equal))
+                          (destructuring-bind (name label flag keys) half
+                            (declare (ignore label keys))
+                            (or (not (listing-kind-wanted-p
+                                      (list name) (getf report :kind)))
                                 (getf report flag))))
-                        +listing-halves+))
+                        +listing-kinds+))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
 not evidence that this project has no contracts: a definition whose system ~
 has not been loaded into this worker is not here."))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -333,14 +333,20 @@ renders only content[].text is the same as not reaching it at all."
                 (getf node :predicate)
                 (getf node :class-name))
             (getf (getf node :target) :qualified))
-    (let ((minimum (getf node :min))
-          (maximum (getf node :max))
-          (values* (getf node :values))
-          (base (getf node :base-type)))
-      (when (or minimum maximum)
-        (format stream " [~A, ~A]" (or minimum "*") (or maximum "*")))
-      (when base (format stream "  base: ~A" base))
-      (when values* (format stream "  values: ~A" values*)))
+    (flet ((bound (value)
+             ;; cl-spec spells an open end :UNBOUNDED. Printing the keyword
+             ;; puts an IR detail in front of a reader who wrote "*" and will
+             ;; read "*" back; and a bound of 0 is a bound, so OR is not the
+             ;; test for whether one is there.
+             (if (or (null value) (eq :unbounded value)) "*" value)))
+      (let ((minimum (getf node :min))
+            (maximum (getf node :max))
+            (values* (getf node :values))
+            (base (getf node :base-type)))
+        (when (or minimum maximum)
+          (format stream " [~A, ~A]" (bound minimum) (bound maximum)))
+        (when base (format stream "  base: ~A" base))
+        (when values* (format stream "  values: ~A" values*))))
     ;; MAP NIL rather than LOOP ACROSS: this helper walks the report plist,
     ;; where :CHILDREN is a list, while the payload carries a vector.  ACROSS
     ;; signalled a type error on the list, and the deadline wrapper above

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -385,6 +385,19 @@ max_chars -- which is to say, by luck."
       (format stream "~&shrinking: ~:[disabled (:shrink nil)~;enabled~]"
               (getf report :shrink-enabled)))))
 
+(defun %report-cut (stream report complete-key omitted-key
+                    &key (budget "max_chars") extra)
+  "Write REPORT's truncation notice for one field, or nothing when it is whole.
+
+Four copies of this line had drifted into three wordings and one that forgot
+to name the budget at all -- and two of the four were added in the same change
+that added the fields.  EXTRA carries what a particular field has to add."
+  (unless (eq t (getf report complete-key))
+    (unless (eq :not-applicable (getf report complete-key))
+      (format stream "~&... truncated, ~D more character~:P. Raise ~A to see ~
+the rest.~@[ ~A~]"
+              (getf report omitted-key) budget extra))))
+
 (defun %format-describe-text (report)
   "Render the spec-describe report as text."
   (with-output-to-string (stream)
@@ -416,20 +429,14 @@ max_chars -- which is to say, by luck."
     ;; whole condition and concludes the contract admits inputs it refuses.
     (when (getf report :preconditions)
       (format stream "~&~%:pre  ~A" (getf report :preconditions))
-      (unless (getf report :preconditions-complete)
-        (format stream "~&... truncated, ~D more character~:P. Raise max_chars ~
-to see the rest."
-                (getf report :preconditions-omitted-chars))))
+      (%report-cut stream report :preconditions-complete :preconditions-omitted-chars))
     (let ((returns (getf report :returns)))
       (when returns
         (format stream "~&~%returns:")
         (%format-spec-node stream returns 0)))
     (when (getf report :postconditions)
       (format stream "~&~%:post ~A" (getf report :postconditions))
-      (unless (getf report :postconditions-complete)
-        (format stream "~&... truncated, ~D more character~:P. Raise max_chars ~
-to see the rest."
-                (getf report :postconditions-omitted-chars))))
+      (%report-cut stream report :postconditions-complete :postconditions-omitted-chars))
     (let ((tree (getf report :spec)))
       (when tree
         (format stream "~&~%normalized IR tree:")
@@ -438,15 +445,14 @@ to see the rest."
       (format stream "~&~%definition_digest: ~A" (getf report :definition-digest)))
     (when (getf report :body)
       (format stream "~&~%body:~%~A" (getf report :body))
-      (unless (getf report :body-complete)
-        (format stream "~&... truncated, ~D more character~:P. Raise max_chars ~
-to see the rest; the text above is a preview, not a form that can be read back."
-                (getf report :body-omitted-chars))))
+      (%report-cut stream report :body-complete :body-omitted-chars
+                   :extra (concatenate 'string
+                                       "The text above is a preview, not a "
+                                       "form that can be read back.")))
     (when (getf report :source-form)
       (format stream "~&~%source form:~%~A" (getf report :source-form))
-      (unless (getf report :source-form-complete)
-        (format stream "~&... truncated, ~D more character~:P."
-                (getf report :source-form-omitted-chars))))
+      (%report-cut stream report :source-form-complete
+                   :source-form-omitted-chars))
     ;; Guarded on the file, not on the plist: a REPL definition has a
     ;; location whose :FILE is NIL, and printing that gave "defined in NIL".
     (let ((location (getf report :source-location)))
@@ -578,7 +584,9 @@ REJECTED_MEASURED travels beside REJECTED because a null rejected count is not
 a count of zero: one says nothing was refused, the other says the number could
 not be read."
   (when contract
-    (make-ht "has_precondition" (let ((value (getf contract :precondition-p)))
+    (make-ht "rejection_status" (%keyword-string
+                                (getf contract :rejection-status))
+             "has_precondition" (let ((value (getf contract :precondition-p)))
                                   (if (eq :unknown value)
                                       nil
                                       (json-bool value)))
@@ -630,6 +638,8 @@ not be read."
            "timeout_seconds" (getf result :timeout-seconds)
            "thread_leaked" (json-bool (getf result :thread-leaked))
            "definition_digest" (getf result :definition-digest)
+           "definition_digest_covers" (%keyword-string
+                                       (getf result :definition-digest-covers))
            "definition_digest_complete" (json-bool
                                          (getf result :definition-digest-complete))
            "definition_match" (%match-string (getf result :definition-match))
@@ -704,12 +714,14 @@ count suggests, and that shortfall is invisible in every other line."
         ;; One CASE on the keyword the report decided, rather than five
         ;; booleans re-tested in an order that must not change.
         (:overcounted
-         (format stream "~&    contract: ~A inputs refused by :pre against ~
-~A trials -- cl-spec counted more refusals than trials, so how often the ~
-function was actually called cannot be derived here"
+         (format stream "~&    contract: ~A input~:P refused against ~A ~
+trial~:P -- cl-spec counted more refusals than trials, so how often the ~
+function was actually called cannot be derived here~@[. This contract has ~
+no :pre, so it should have refused none~]"
                  (getf contract :rejected)
                  (or (getf (getf result :trials) :executed)
-                     "an unknown number of")))
+                     "an unknown number of")
+                 (null (getf contract :precondition-p))))
         (:unmeasured
          (format stream "~&    contract: the refused-input count could not be ~
 read, so the trial count above is an upper bound on what was checked"))
@@ -782,8 +794,11 @@ max_value_chars to see the rest."
             (getf result :seed)
             (%keyword-string (getf result :profile))))
   (when (getf result :definition-digest)
-    (format stream "~&    definition_digest: ~A~@[  (~A)~]"
+    (format stream "~&    definition_digest: ~A~@[ (covers the ~A, not the ~
+function body)~]~@[  (~A)~]"
             (getf result :definition-digest)
+            (when (eq :contract (getf result :definition-digest-covers))
+              "contract")
             (unless (eq :not-checked (getf result :definition-match))
               (%match-string (getf result :definition-match)))))
   (when (getf result :message)
@@ -1077,27 +1092,23 @@ symbol could not be read)"
         ;; on a kind that lists no properties it narrowed nothing whatever,
         ;; which the caller has to be told rather than left to infer from a
         ;; header that says the filter ran.
-        (let ((narrowed (and (member (getf report :kind) '("properties" "both")
-                                     :test #'equal)
-                             (getf report :properties-listable)
-                             ;; The flag that answers whether the filter ran.
-                             ;; Keyed on PROPERTIES-LISTABLE, a revision with
-                             ;; no PROPERTIES-WITH-TAG printed "tagged
-                             ;; critical" over a listing the tag never
-                             ;; touched -- the "no property carries this tag"
-                             ;; reading the flags exist to prevent.
-                             (getf report :tag-filterable))))
+        ;; Three states, tested once each.  The conjunction and the first
+        ;; clause used to re-derive two of the same three facts, so "this
+        ;; kind lists no properties" and "this cl-spec cannot filter by tag"
+        ;; were one edit away from being reported as each other.
+        (let ((lists-properties (and (member (getf report :kind)
+                                             '("properties" "both")
+                                             :test #'equal)
+                                     (getf report :properties-listable)
+                                     t)))
           (cond
-            ((and (not narrowed)
-                  (member (getf report :kind) '("properties" "both")
-                          :test #'equal)
-                  (getf report :properties-listable))
-             (format stream "  tag ~A was NOT applied: the loaded cl-spec ~
-exports no properties-with-tag, so nothing here was filtered by it"
-                     (getf filters :tag)))
-            ((not narrowed)
+            ((not lists-properties)
              (format stream "  tag ~A was NOT applied: it narrows properties, ~
 and this kind lists none"
+                     (getf filters :tag)))
+            ((not (getf report :tag-filterable))
+             (format stream "  tag ~A was NOT applied: the loaded cl-spec ~
+exports no properties-with-tag, so nothing here was filtered by it"
                      (getf filters :tag)))
             (t
              (format stream "  tagged ~A~:[~; (properties only)~]"
@@ -1167,6 +1178,11 @@ so none are listed here. This is not evidence that none are registered."
       (when (and (null (getf report :specs))
                  (null (getf report :properties))
                  (null (getf report :function-specs))
+                 ;; The tag counts as a half that was not looked at: a
+                 ;; listing whose filter never ran has no evidence the
+                 ;; registry is empty, which is the whole point of the flags.
+                 (or (null (getf (getf report :filters) :tag))
+                     (getf (getf report :filters) :tag-applied))
                  (every (lambda (half)
                           (destructuring-bind (name label flag keys) half
                             (declare (ignore name label keys))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -345,12 +345,13 @@ the :RETURNS spec four lines below showed all three."
           (maximum (getf node :max))
           (values* (getf node :values))
           (base (getf node :base-type)))
-      ;; Both ends or neither: cl-spec gives a range node an :UNBOUNDED
-      ;; initform on each side, which %RANGE-BOUND has already spelled "*", so
-      ;; there is no half-open node to render and nothing here has to invent
-      ;; a bound or repeat the IR's word for an open one.
-      (when (and minimum maximum)
-        (format stream " [~A, ~A]" minimum maximum))
+      ;; Whatever is there is printed.  %RANGE-BOUND spells an absent end on
+      ;; a RANGE node as "*", and on any other node an absent end is an absent
+      ;; bound, which reads the same way -- so a node carrying one bound keeps
+      ;; it instead of losing the pair.  Requiring both ends dropped a present
+      ;; bound and showed a wider domain than the author wrote.
+      (when (or minimum maximum)
+        (format stream " [~A, ~A]" (or minimum "*") (or maximum "*")))
       (when base (format stream "  base: ~A" base))
       (when values* (format stream "  values: ~A" values*)))
     ;; MAP NIL rather than LOOP ACROSS: this helper walks the report plist,
@@ -687,6 +688,14 @@ count suggests, and that shortfall is invisible in every other line."
          ;; report.  The refusal line named a clause the author never wrote.
          (format stream "~&    contract: no :pre, so every generated input ~
 was passed to the function"))
+        ((eq :unknown (getf contract :precondition-p))
+         ;; Neither "it has one" nor "it has none".  Folded into the branch
+         ;; below, the text asserted a :pre while has_precondition beside it
+         ;; came back null -- the two halves of one response disagreeing on
+         ;; whether the clause exists.
+         (format stream "~&    contract: whether it has a :pre could not be ~
+read, so ~A refused input~:P is a count this response cannot interpret"
+                 (or (getf contract :rejected) "an unknown number of")))
         ((getf contract :rejected-overcounted)
          ;; More refusals than trials, so the difference says nothing.  Left
          ;; as its own line rather than folded into the one below: printing
@@ -856,11 +865,20 @@ it came out."
   (let ((verdict (cond ((getf report :verified) "✓ VERIFIED")
                        ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
                        (t "⚠ NOT VERIFIED")))
-        (contract (getf (getf report :selection) :contract-not-run)))
-    (if contract
-        (format nil "~A (properties only -- the function spec for ~A was NOT run)"
-                verdict (getf contract :qualified))
-        verdict)))
+        (contract (getf (getf report :selection) :contract-not-run))
+        (properties (getf (getf report :selection) :properties-not-run)))
+    (cond
+      (contract
+       (format nil "~A (properties only -- the function spec for ~A was NOT run)"
+               verdict (getf contract :qualified)))
+      ;; The mirror, and it needs saying for the same reason: a contract that
+      ;; holds is not a clean bill for a function whose properties were never
+      ;; run, and the headline is where a reader stops.
+      (properties
+       (format nil "~A (contract only -- ~D propert~:@P about this symbol ~
+~:*~[~;was~:;were~] NOT run)"
+               verdict (length properties)))
+      (t verdict))))
 
 (defun %format-check-text (report)
   "Render the spec-check report as the text an MCP client will show."
@@ -928,6 +946,8 @@ it came out."
                          "coverage" (getf selection :coverage)
                          "contract_not_run" (%symbol-ht
                                              (getf selection :contract-not-run))
+                         "properties_not_run"
+                         (%symbol-hts (getf selection :properties-not-run))
                          "notes" (%strings (getf selection :notes)))
                 "results" (coerce (mapcar #'%result-ht (getf report :results))
                                   'vector)
@@ -996,6 +1016,18 @@ it came out."
     (:not-requested "not-requested")
     (t "resolved")))
 
+(defparameter +listing-halves+
+  '(("specs" :specs-listable ("specs" "both"))
+    ("properties" :properties-listable ("properties" "both"))
+    ("function specs" :function-specs-listable ("function-specs" "both")))
+  "Each listing half: its label, its listable flag, and the kinds that ask for it.
+
+One table rather than two.  The notes saying a half could not be enumerated
+and the gate on \"Nothing registered matches\" read the same three facts, and
+written twice they could disagree -- printing the empty claim about a half the
+listing never looked at, which is the conflation the second one exists to
+prevent.")
+
 (defun %format-list-text (report)
   "Render the spec-list report as the text an MCP client will show."
   (with-output-to-string (stream)
@@ -1024,8 +1056,9 @@ it came out."
         ;; on a kind that lists no properties it narrowed nothing whatever,
         ;; which the caller has to be told rather than left to infer from a
         ;; header that says the filter ran.
-        (let ((narrowed (member (getf report :kind) '("properties" "both")
-                                :test #'equal)))
+        (let ((narrowed (and (member (getf report :kind) '("properties" "both")
+                                     :test #'equal)
+                             (getf report :properties-listable))))
           (cond
             ((not narrowed)
              (format stream "  tag ~A was NOT applied: it narrows properties, ~
@@ -1084,11 +1117,7 @@ project it here"
                       (or (getf contract :postcondition-count) 0)))
             (when (getf contract :documentation)
               (format stream "~&      ~A" (getf contract :documentation))))))
-      (dolist (half '(("specs" :specs-listable ("specs" "both"))
-                      ("properties" :properties-listable
-                       ("properties" "both"))
-                      ("function specs" :function-specs-listable
-                       ("function-specs" "both"))))
+      (dolist (half +listing-halves+)
         (destructuring-bind (label flag kinds) half
           (when (and (member (getf report :kind) kinds :test #'equal)
                      (not (getf report flag)))
@@ -1103,14 +1132,12 @@ so none are listed here. This is not evidence that none are registered."
                  (null (getf report :properties))
                  (null (getf report :function-specs))
                  (every (lambda (half)
-                          (destructuring-bind (flag kinds) half
+                          (destructuring-bind (label flag kinds) half
+                            (declare (ignore label))
                             (or (not (member (getf report :kind) kinds
                                              :test #'equal))
                                 (getf report flag))))
-                        '((:specs-listable ("specs" "both"))
-                          (:properties-listable ("properties" "both"))
-                          (:function-specs-listable
-                           ("function-specs" "both")))))
+                        +listing-halves+))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
 not evidence that this project has no contracts: a definition whose system ~
 has not been loaded into this worker is not here."))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -459,7 +459,9 @@ to see the rest; the text above is a preview, not a form that can be read back."
               "spec" (%spec-tree-ht (getf report :spec))
               "returns" (%spec-tree-ht (getf report :returns))
               "preconditions" (sanitize-for-json (getf report :preconditions))
+              "preconditions_complete" (json-bool (getf report :preconditions-complete))
               "postconditions" (sanitize-for-json (getf report :postconditions))
+              "postconditions_complete" (json-bool (getf report :postconditions-complete))
               "body" (sanitize-for-json (getf report :body))
               "body_complete" (json-bool (getf report :body-complete))
               "body_omitted_chars" (getf report :body-omitted-chars)
@@ -710,12 +712,24 @@ deterministic"))
       (format stream "~&reproduction: ~A"
               (%faithful-string (getf report :reproduction-faithful))))
     (when (and first-result (getf first-result :seed))
-      (format stream "~&~%Replay: spec-check property=~A seed=~A profile=~A~
+      ;; The argument the run was actually selected by, and for a contract the
+      ;; budget as well.  Printed as property= a contract's replay line asks
+      ;; for a property that does not exist, and without trials= a failure
+      ;; found at a raised budget need not reappear at the backend default --
+      ;; a replay instruction that does not replay is worse than none.
+      (if (eq :contract (getf first-result :kind))
+          (format stream "~&~%Replay: spec-check function=~A seed=~A~
+~@[ trials=~A~]~@[ expect_definition_digest=~A~]"
+                  (getf (getf first-result :property) :qualified)
+                  (getf first-result :seed)
+                  (getf (getf first-result :trials) :budget)
+                  (getf first-result :definition-digest))
+          (format stream "~&~%Replay: spec-check property=~A seed=~A profile=~A~
 ~@[ expect_definition_digest=~A~]"
-              (getf (getf first-result :property) :qualified)
-              (getf first-result :seed)
-              (%keyword-string (getf first-result :profile))
-              (getf first-result :definition-digest)))
+                  (getf (getf first-result :property) :qualified)
+                  (getf first-result :seed)
+                  (%keyword-string (getf first-result :profile))
+                  (getf first-result :definition-digest))))
     ;; Gated on there being a seed to reproduce from.  A run where nothing
     ;; executed has nothing to say about reproduction, and printing the
     ;; caveat there is noise the caller has to read past every time.
@@ -723,6 +737,20 @@ deterministic"))
                first-result
                (getf first-result :seed))
       (format stream "~&~A" (getf report :reproduce-scope)))))
+
+(defun %selection-noun (selection)
+  "Return the word for what SELECTION selected, singular or plural.
+
+A contract run selects a contract, not a property.  The two are different
+instruments -- one is the function's own :args/:returns, the other a relation
+someone asserted about it -- and a line that calls both \"property\" hides
+which one just ran."
+  (let ((contractp (equal "contract" (getf selection :mode)))
+        (one (eql 1 (getf selection :count))))
+    (cond ((and contractp one) "contract")
+          (contractp "contracts")
+          (one "property")
+          (t "properties"))))
 
 (defun %check-headline (report)
   "Return the first line of a spec-check text, in this project's house style.
@@ -740,16 +768,24 @@ was learned either way."
   (with-output-to-string (stream)
     (let ((selection (getf report :selection)))
       (if (eq :no-properties (getf report :status))
-          (format stream "⚠ NO PROPERTIES  ~A~&Selected 0 properties via ~A.~&~%~A~
-~&verified: false"
-                  (or (getf (getf (getf selection :requested) :symbol) :qualified)
-                      "")
-                  (getf selection :source)
-                  (getf report :message))
+          (progn
+            (format stream "⚠ NO PROPERTIES  ~A~&Selected 0 properties via ~A.~&~%~A"
+                    (or (getf (getf (getf selection :requested) :symbol) :qualified)
+                        "")
+                    (getf selection :source)
+                    (getf report :message))
+            ;; The notes belong here most of all.  A caller who asked about a
+            ;; symbol and was told nothing ran has no reason to look further,
+            ;; and the note is what says a contract is registered for it.
+            (dolist (note (getf selection :notes))
+              (format stream "~&~%note: ~A" note))
+            (format stream "~&verified: false"))
           (progn
             (format stream "~A" (%check-headline report))
-            (format stream "~&Selected ~D propert~:@P via ~A."
-                    (getf selection :count) (getf selection :source))
+            (format stream "~&Selected ~D ~A via ~A."
+                    (getf selection :count)
+                    (%selection-noun selection)
+                    (getf selection :source))
             (format stream "~&  ~A" (getf selection :coverage))
             (dolist (note (getf selection :notes))
               (format stream "~&  note: ~A" note))
@@ -779,7 +815,8 @@ was learned either way."
                          "requested"
                          (let ((requested (getf selection :requested)))
                            (make-ht "property" (%symbol-ht (getf requested :property))
-                                    "symbol" (%symbol-ht (getf requested :symbol))))
+                                    "symbol" (%symbol-ht (getf requested :symbol))
+                                    "function" (%symbol-ht (getf requested :function))))
                          "selected" (%symbol-hts (getf selection :selected))
                          "count" (getf selection :count)
                          "source" (getf selection :source)

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -715,8 +715,11 @@ max_value_chars to see the rest."
     (when condition
       (format stream "~&    condition: [~A] ~A"
               (getf condition :type) (getf condition :message))))
+  ;; Profile only when there was one.  A contract run has none, and printing
+  ;; the :NORMAL that leaks off cl-spec's synthetic property named a setting
+  ;; the run did not use -- which is why profile= is refused there.
   (when (getf result :seed)
-    (format stream "~&    seed: ~A   profile: ~A"
+    (format stream "~&    seed: ~A~@[   profile: ~A~]"
             (getf result :seed)
             (%keyword-string (getf result :profile))))
   (when (getf result :definition-digest)
@@ -935,8 +938,14 @@ it came out."
 (defun %function-spec-entry-ht (data)
   "Return one function spec listing entry as a hash-table."
   (make-ht "name" (%symbol-ht (getf data :name))
-           "parameters" (%symbol-hts (getf data :parameters))
-           "returns_specified" (json-bool (getf data :returns-specified))
+           ;; NIL rather than [] and false when the projection failed: an
+           ;; empty list and an unset flag are answers about the contract,
+           ;; and nothing was read to support either.
+           "read_failed" (json-bool (getf data :read-failed))
+           "parameters" (unless (getf data :read-failed)
+                          (%symbol-hts (getf data :parameters)))
+           "returns_specified" (unless (getf data :read-failed)
+                                 (json-bool (getf data :returns-specified)))
            "precondition_count" (getf data :precondition-count)
            "postcondition_count" (getf data :postcondition-count)
            "documentation" (sanitize-for-json (getf data :documentation))))
@@ -986,11 +995,17 @@ carry it -- this is not the same as no property having it)")))
         (when contracts
           (format stream "~&~%function specs:")
           (dolist (contract contracts)
-            (format stream "~&  ~A (~{~A~^ ~})~:[~;  -> :returns~]"
-                    (getf (getf contract :name) :qualified)
-                    (mapcar (lambda (parameter) (getf parameter :name))
-                            (getf contract :parameters))
-                    (getf contract :returns-specified))
+            (if (getf contract :read-failed)
+                ;; Never as "()": an empty parameter list is a claim about
+                ;; the contract, and this entry has no evidence for one.
+                (format stream "~&  ~A  -- registered, but cl-spec could not ~
+project it here"
+                        (getf (getf contract :name) :qualified))
+                (format stream "~&  ~A (~{~A~^ ~})~:[~;  -> :returns~]"
+                        (getf (getf contract :name) :qualified)
+                        (mapcar (lambda (parameter) (getf parameter :name))
+                                (getf contract :parameters))
+                        (getf contract :returns-specified)))
             (when (or (plusp (or (getf contract :precondition-count) 0))
                       (plusp (or (getf contract :postcondition-count) 0)))
               (format stream "~&      :pre ~D, :post ~D"

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -755,10 +755,22 @@ which one just ran."
 Three outcomes rather than two.  A property that was falsified and a run that
 could not finish are different news: collapsing them under one word would let
 a timeout read as a counterexample, and it is the timeout that means nothing
-was learned either way."
-  (cond ((getf report :verified) "✓ VERIFIED")
-        ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
-        (t "⚠ NOT VERIFIED")))
+was learned either way.
+
+A verdict is also a claim about coverage.  An :about selection over a symbol
+that has a function spec ran the properties and not the contract, and the bare
+word would be read as a clean bill for the function -- which is exactly what a
+run over a broken function whose properties happen to hold produces.  The
+qualifier goes on all three verdicts: what was covered does not depend on how
+it came out."
+  (let ((verdict (cond ((getf report :verified) "✓ VERIFIED")
+                       ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
+                       (t "⚠ NOT VERIFIED")))
+        (contract (getf (getf report :selection) :contract-not-run)))
+    (if contract
+        (format nil "~A (properties only -- the function spec for ~A was NOT run)"
+                verdict (getf contract :qualified))
+        verdict)))
 
 (defun %format-check-text (report)
   "Render the spec-check report as the text an MCP client will show."
@@ -818,6 +830,8 @@ was learned either way."
                          "count" (getf selection :count)
                          "source" (getf selection :source)
                          "coverage" (getf selection :coverage)
+                         "contract_not_run" (%symbol-ht
+                                             (getf selection :contract-not-run))
                          "notes" (%strings (getf selection :notes)))
                 "results" (coerce (mapcar #'%result-ht (getf report :results))
                                   'vector)

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -315,35 +315,44 @@ system defining them may simply not be loaded.")
              "children" (coerce (mapcar #'%spec-tree-ht (getf data :children))
                                 'vector))))
 
-(defun %format-spec-node (stream node depth)
+(defun %format-spec-node (stream node depth &optional label)
   "Write one spec-data node and its children to STREAM, indented by DEPTH.
 
 spec-describe's own description promises \"the spec's normalized IR tree\", and
 the tree was reaching the payload but not the text -- which for a client that
-renders only content[].text is the same as not reaching it at all."
+renders only content[].text is the same as not reaching it at all.
+
+LABEL is printed before the node, for the caller that has a name to put on it:
+an argument renders as its variable followed by its own spec.  It is a
+parameter rather than a second renderer because the argument list used to have
+one, printing the node's kind and then recursing into the node's CHILDREN --
+so an argument's own bounds, member values and base type were dropped while
+the :RETURNS spec four lines below showed all three."
   (when node
     ;; The kind is lower-cased like every other keyword this file renders
     ;; (statuses, property kinds, argument spec kinds); an upper-case AND in
     ;; the middle of lower-case prose reads as a different vocabulary.
-    (format stream "~&~vT~A~@[ ~A~]~@[ -> ~A~]"
+    (format stream "~&~vT~@[~A : ~]~A~@[ ~A~]~@[ -> ~A~]"
             (+ 2 (* 2 depth))
+            label
             (or (%keyword-string (getf node :kind)) "node")
             (or (getf (getf node :name) :qualified)
                 (getf node :type)
                 (getf node :predicate)
                 (getf node :class-name))
             (getf (getf node :target) :qualified))
-    ;; A bound of 0 is a bound, so OR is not the test for whether one is
-    ;; there.  An open end arrives already spelled "*"; see %RANGE-BOUND.
-    (flet ((bound (value) (or value "*")))
-      (let ((minimum (getf node :min))
-            (maximum (getf node :max))
-            (values* (getf node :values))
-            (base (getf node :base-type)))
-        (when (or minimum maximum)
-          (format stream " [~A, ~A]" (bound minimum) (bound maximum)))
-        (when base (format stream "  base: ~A" base))
-        (when values* (format stream "  values: ~A" values*))))
+    (let ((minimum (getf node :min))
+          (maximum (getf node :max))
+          (values* (getf node :values))
+          (base (getf node :base-type)))
+      ;; Both ends or neither: cl-spec gives a range node an :UNBOUNDED
+      ;; initform on each side, which %RANGE-BOUND has already spelled "*", so
+      ;; there is no half-open node to render and nothing here has to invent
+      ;; a bound or repeat the IR's word for an open one.
+      (when (and minimum maximum)
+        (format stream " [~A, ~A]" minimum maximum))
+      (when base (format stream "  base: ~A" base))
+      (when values* (format stream "  values: ~A" values*)))
     ;; MAP NIL rather than LOOP ACROSS: this helper walks the report plist,
     ;; where :CHILDREN is a list, while the payload carries a vector.  ACROSS
     ;; signalled a type error on the list, and the deadline wrapper above
@@ -385,12 +394,15 @@ max_chars -- which is to say, by luck."
     (when (getf report :arguments)
       (format stream "~&~%arguments:")
       (dolist (argument (getf report :arguments))
-        (format stream "~&  ~A : ~A~@[ -> ~A~]"
-                (getf (getf argument :variable) :name)
-                (%keyword-string (getf (getf argument :spec) :kind))
-                (getf (getf (getf argument :spec) :target) :qualified))
-        (map nil (lambda (child) (%format-spec-node stream child 1))
-             (or (getf (getf argument :spec) :children) '()))))
+        (let ((spec (getf argument :spec))
+              (name (getf (getf argument :variable) :name)))
+          (if spec
+              ;; The node itself, not its children: the bounds, member values
+              ;; and base type live on the argument's own spec, and rendering
+              ;; only the children dropped exactly the half of a contract the
+              ;; tool promises -- which inputs it accepts.
+              (%format-spec-node stream spec 0 name)
+              (format stream "~&  ~A" name)))))
     ;; Cut and reported, like the body and the source form below.  A silently
     ;; truncated :PRE is worse than either: a reader takes a clause for the
     ;; whole condition and concludes the contract admits inputs it refuses.
@@ -540,7 +552,11 @@ REJECTED_MEASURED travels beside REJECTED because a null rejected count is not
 a count of zero: one says nothing was refused, the other says the number could
 not be read."
   (when contract
-    (make-ht "rejected" (getf contract :rejected)
+    (make-ht "has_precondition" (let ((value (getf contract :precondition-p)))
+                                  (if (eq :unknown value)
+                                      nil
+                                      (json-bool value)))
+             "rejected" (getf contract :rejected)
              "rejected_measured" (json-bool (getf contract :rejected-measured))
              "rejected_overcounted" (json-bool
                                      (getf contract :rejected-overcounted))
@@ -654,6 +670,11 @@ count suggests, and that shortfall is invisible in every other line."
   (let ((contract (getf result :contract)))
     (when contract
       (cond
+        ((null (getf contract :precondition-p))
+         ;; No :PRE, so nothing could be refused and there is no shortfall to
+         ;; report.  The refusal line named a clause the author never wrote.
+         (format stream "~&    contract: no :pre, so every generated input ~
+was passed to the function"))
         ((getf contract :rejected-overcounted)
          ;; More refusals than trials, so the difference says nothing.  Left
          ;; as its own line rather than folded into the one below: printing
@@ -793,8 +814,13 @@ max_value_chars to see the rest."
 A contract run selects a contract, not a property.  The two are different
 instruments -- one is the function's own :args/:returns, the other a relation
 someone asserted about it -- and a line that calls both \"property\" hides
-which one just ran."
-  (let ((contractp (equal "contract" (getf selection :mode)))
+which one just ran.
+
+Keyed on :KIND rather than on the :MODE text.  MODE is a display string and
+matching it made two spellings decide the same fact: a fixture written with
+mode \"function\" rendered every contract as a property while the replay line,
+the kind field and the profile suppression all still behaved as a contract."
+  (let ((contractp (eq :contract (getf selection :kind)))
         (one (eql 1 (getf selection :count))))
     (cond ((and contractp one) "contract")
           (contractp "contracts")
@@ -878,6 +904,7 @@ it came out."
                 "verified" (json-bool (getf report :verified))
                 "selection"
                 (make-ht "mode" (getf selection :mode)
+                         "kind" (%keyword-string (getf selection :kind))
                          "requested"
                          (let ((requested (getf selection :requested)))
                            (make-ht "property" (%symbol-ht (getf requested :property))
@@ -979,7 +1006,12 @@ it came out."
       (when (getf filters :package)
         (format stream "  in package ~A" (getf filters :package)))
       (when (getf filters :tag)
-        (format stream "  tagged ~A" (getf filters :tag))
+        ;; Named as narrowing properties, because that is all it narrows.
+        ;; "4 function specs  tagged critical" read as four tagged contracts,
+        ;; and LIST-REPORT never offers TAG to the contract listing at all.
+        (format stream "  tagged ~A~:[ (properties only)~;~]"
+                (getf filters :tag)
+                (equal "properties" (getf report :kind)))
         (unless (eq t (getf filters :tag-resolved))
           (format stream " (NO SUCH TAG exists in this image, so nothing can ~
 carry it -- this is not the same as no property having it)")))
@@ -991,6 +1023,22 @@ carry it -- this is not the same as no property having it)")))
           (format stream "~&~%specs:")
           (dolist (spec specs)
             (format stream "~&  ~A" (getf spec :qualified)))))
+      (let ((properties (getf report :properties)))
+        (when properties
+          (format stream "~&~%properties:")
+          (dolist (property properties)
+            (format stream "~&  ~A~@[  [~A]~]"
+                    (getf (getf property :name) :qualified)
+                    (%keyword-string (getf property :kind)))
+            (when (getf property :targets)
+              (format stream "~&      about: ~{~A~^, ~}"
+                      (mapcar (lambda (target) (getf target :qualified))
+                              (getf property :targets))))
+            (when (getf property :tags)
+              (format stream "~&      tags: ~{~A~^, ~}"
+                      (mapcar #'%keyword-string (getf property :tags))))
+            (when (getf property :documentation)
+              (format stream "~&      ~A" (getf property :documentation))))))
       (let ((contracts (getf report :function-specs)))
         (when contracts
           (format stream "~&~%function specs:")
@@ -1020,25 +1068,16 @@ project it here"
         (format stream "~&~%function specs: the loaded cl-spec cannot ~
 enumerate them, so none are listed here. This is not evidence that none are ~
 registered."))
-      (let ((properties (getf report :properties)))
-        (when properties
-          (format stream "~&~%properties:")
-          (dolist (property properties)
-            (format stream "~&  ~A~@[  [~A]~]"
-                    (getf (getf property :name) :qualified)
-                    (%keyword-string (getf property :kind)))
-            (when (getf property :targets)
-              (format stream "~&      about: ~{~A~^, ~}"
-                      (mapcar (lambda (target) (getf target :qualified))
-                              (getf property :targets))))
-            (when (getf property :tags)
-              (format stream "~&      tags: ~{~A~^, ~}"
-                      (mapcar #'%keyword-string (getf property :tags))))
-            (when (getf property :documentation)
-              (format stream "~&      ~A" (getf property :documentation))))))
+      ;; Only when every requested kind was in fact looked at.  Printed
+      ;; after "the loaded cl-spec cannot enumerate them", it turned "cannot
+      ;; look" back into "none here" -- the distinction function_specs_listable
+      ;; exists to keep.
       (when (and (null (getf report :specs))
                  (null (getf report :properties))
-                 (null (getf report :function-specs)))
+                 (null (getf report :function-specs))
+                 (or (not (member (getf report :kind) '("function-specs" "both")
+                                  :test #'equal))
+                     (getf report :function-specs-listable)))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
 not evidence that this project has no contracts: a definition whose system ~
 has not been loaded into this worker is not here."))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -388,6 +388,14 @@ max_chars -- which is to say, by luck."
                 (getf (getf (getf argument :spec) :target) :qualified))
         (map nil (lambda (child) (%format-spec-node stream child 1))
              (or (getf (getf argument :spec) :children) '()))))
+    (when (getf report :preconditions)
+      (format stream "~&~%:pre  ~A" (getf report :preconditions)))
+    (let ((returns (getf report :returns)))
+      (when returns
+        (format stream "~&~%returns:")
+        (%format-spec-node stream returns 0)))
+    (when (getf report :postconditions)
+      (format stream "~&~%:post ~A" (getf report :postconditions)))
     (let ((tree (getf report :spec)))
       (when tree
         (format stream "~&~%normalized IR tree:")
@@ -443,6 +451,9 @@ to see the rest; the text above is a preview, not a form that can be read back."
                               (getf report :arguments))
                       'vector)
               "spec" (%spec-tree-ht (getf report :spec))
+              "returns" (%spec-tree-ht (getf report :returns))
+              "preconditions" (sanitize-for-json (getf report :preconditions))
+              "postconditions" (sanitize-for-json (getf report :postconditions))
               "body" (sanitize-for-json (getf report :body))
               "body_complete" (json-bool (getf report :body-complete))
               "body_omitted_chars" (getf report :body-omitted-chars)
@@ -502,9 +513,24 @@ real disagreement.  CHECK-REPORT now says :FALSE for the disagreement."
            "backend_default" (getf trials :backend-default)
            "budget_derivation" (getf trials :budget-derivation)))
 
+(defun %contract-ht (contract)
+  "Return the contract half of a check result as a hash-table, or NIL.
+
+REJECTED_MEASURED travels beside REJECTED because a null rejected count is not
+a count of zero: one says nothing was refused, the other says the number could
+not be read."
+  (when contract
+    (make-ht "rejected" (getf contract :rejected)
+             "rejected_measured" (json-bool (getf contract :rejected-measured))
+             "effective_trials" (getf contract :effective-trials)
+             "failure_reason" (%keyword-string (getf contract :failure-reason))
+             "explanation" (sanitize-for-json (getf contract :explanation)))))
+
 (defun %result-ht (result)
   "Return one per-property result as a hash-table."
   (make-ht "property" (%symbol-ht (getf result :property))
+           "kind" (%keyword-string (getf result :kind))
+           "contract" (%contract-ht (getf result :contract))
            "status" (%keyword-string (getf result :status))
            "reason" (%keyword-string (getf result :reason))
            "trials" (%trials-ht (getf result :trials))
@@ -591,6 +617,33 @@ returned no smaller input"))
 not reach a verdict"))
       (t nil))))
 
+(defun %format-contract (stream result)
+  "Write a contract check's rejected count and failure reason to STREAM.
+
+The effective trial count is the one a reader should act on: a contract whose
+:PRE refused most of what was generated was checked far less than its trial
+count suggests, and that shortfall is invisible in every other line."
+  (let ((contract (getf result :contract)))
+    (when contract
+      (if (getf contract :rejected-measured)
+          (format stream "~&    contract: ~A of them refused by :pre, ~
+so the function was called ~A time~:P"
+                  (getf contract :rejected)
+                  (or (getf contract :effective-trials) "an unknown number of"))
+          (format stream "~&    contract: the refused-input count could not be ~
+read, so the trial count above is an upper bound on what was checked"))
+      (let ((reason (getf contract :failure-reason)))
+        (when reason
+          (format stream "~&    broken half: ~A" (%keyword-string reason))))
+      (when (and (member (getf result :status) '(:failed :error))
+                 (null (getf contract :failure-reason)))
+        (format stream "~&    broken half: not determined -- re-running the ~
+reported counterexample did not fail again, so the function is not ~
+deterministic"))
+      (let ((explanation (getf contract :explanation)))
+        (when explanation
+          (format stream "~&    return value: ~A" explanation))))))
+
 (defun %format-one-result (stream result index)
   "Write one per-property result to STREAM."
   (format stream "~&~%[~D] ~A  ~A"
@@ -602,6 +655,7 @@ not reach a verdict"))
             (or (getf trials :executed) "none")
             (or (getf trials :budget) "unknown")
             (or (getf trials :budget-source) "unknown")))
+  (%format-contract stream result)
   (%format-counterexample stream result)
   (let ((condition (getf result :condition)))
     (when condition
@@ -770,6 +824,15 @@ was learned either way."
            "targets" (%symbol-hts (getf data :targets))
            "documentation" (sanitize-for-json (getf data :documentation))))
 
+(defun %function-spec-entry-ht (data)
+  "Return one function spec listing entry as a hash-table."
+  (make-ht "name" (%symbol-ht (getf data :name))
+           "parameters" (%symbol-hts (getf data :parameters))
+           "returns_specified" (json-bool (getf data :returns-specified))
+           "precondition_count" (getf data :precondition-count)
+           "postcondition_count" (getf data :postcondition-count)
+           "documentation" (sanitize-for-json (getf data :documentation))))
+
 (defun %tag-resolved-string (value)
   "Return the tag-resolution answer as the word the tool documents."
   (case value
@@ -791,7 +854,10 @@ was learned either way."
                                   (format nil "~D spec~:P" (getf counts :specs)))
                                 (when (getf counts :properties)
                                   (format nil "~D propert~:@P"
-                                          (getf counts :properties)))))
+                                          (getf counts :properties)))
+                                (when (getf counts :function-specs)
+                                  (format nil "~D function spec~:P"
+                                          (getf counts :function-specs)))))
                   (list "nothing counted")))
       (when (getf filters :package)
         (format stream "  in package ~A" (getf filters :package)))
@@ -808,6 +874,29 @@ carry it -- this is not the same as no property having it)")))
           (format stream "~&~%specs:")
           (dolist (spec specs)
             (format stream "~&  ~A" (getf spec :qualified)))))
+      (let ((contracts (getf report :function-specs)))
+        (when contracts
+          (format stream "~&~%function specs:")
+          (dolist (contract contracts)
+            (format stream "~&  ~A (~{~A~^ ~})~:[~;  -> :returns~]"
+                    (getf (getf contract :name) :qualified)
+                    (mapcar (lambda (parameter) (getf parameter :name))
+                            (getf contract :parameters))
+                    (getf contract :returns-specified))
+            (when (or (plusp (or (getf contract :precondition-count) 0))
+                      (plusp (or (getf contract :postcondition-count) 0)))
+              (format stream "~&      :pre ~D, :post ~D"
+                      (or (getf contract :precondition-count) 0)
+                      (or (getf contract :postcondition-count) 0)))
+            (when (getf contract :documentation)
+              (format stream "~&      ~A" (getf contract :documentation))))))
+      (when (and (getf report :kind)
+                 (member (getf report :kind) '("function-specs" "both")
+                         :test #'string=)
+                 (not (getf report :function-specs-listable)))
+        (format stream "~&~%function specs: the loaded cl-spec cannot ~
+enumerate them, so none are listed here. This is not evidence that none are ~
+registered."))
       (let ((properties (getf report :properties)))
         (when properties
           (format stream "~&~%properties:")
@@ -824,7 +913,9 @@ carry it -- this is not the same as no property having it)")))
                       (mapcar #'%keyword-string (getf property :tags))))
             (when (getf property :documentation)
               (format stream "~&      ~A" (getf property :documentation))))))
-      (when (and (null (getf report :specs)) (null (getf report :properties)))
+      (when (and (null (getf report :specs))
+                 (null (getf report :properties))
+                 (null (getf report :function-specs)))
         (format stream "~&~%Nothing registered matches. An empty listing is ~
 not evidence that this project has no contracts: a definition whose system ~
 has not been loaded into this worker is not here."))
@@ -848,11 +939,18 @@ has not been loaded into this worker is not here."))
                 "properties" (coerce (mapcar #'%listing-entry-ht
                                              (getf report :properties))
                                      'vector)
+                "function_specs" (coerce (mapcar #'%function-spec-entry-ht
+                                                 (getf report :function-specs))
+                                         'vector)
+                "function_specs_listable"
+                (json-bool (getf report :function-specs-listable))
                 ;; NIL for a kind that was not requested, which yason
                 ;; encodes as null: a consumer reading counts.specs as 0
                 ;; would take it for evidence that none are registered.
                 "counts" (make-ht "specs" (getf counts :specs)
-                                  "properties" (getf counts :properties))
+                                  "properties" (getf counts :properties)
+                                  "function_specs"
+                                  (getf counts :function-specs))
                 "truncated" (json-bool (getf report :truncated))
                 "limit" (getf report :limit)
                 "filters" (make-ht "package" (getf filters :package)

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -333,12 +333,9 @@ renders only content[].text is the same as not reaching it at all."
                 (getf node :predicate)
                 (getf node :class-name))
             (getf (getf node :target) :qualified))
-    (flet ((bound (value)
-             ;; cl-spec spells an open end :UNBOUNDED. Printing the keyword
-             ;; puts an IR detail in front of a reader who wrote "*" and will
-             ;; read "*" back; and a bound of 0 is a bound, so OR is not the
-             ;; test for whether one is there.
-             (if (or (null value) (eq :unbounded value)) "*" value)))
+    ;; A bound of 0 is a bound, so OR is not the test for whether one is
+    ;; there.  An open end arrives already spelled "*"; see %RANGE-BOUND.
+    (flet ((bound (value) (or value "*")))
       (let ((minimum (getf node :min))
             (maximum (getf node :max))
             (values* (getf node :values))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -593,6 +593,7 @@ not be read."
                                       (json-bool value)))
              "rejected" (getf contract :rejected)
              "rejected_measured" (json-bool (getf contract :rejected-measured))
+             "rejected_readable" (json-bool (getf contract :rejected-readable))
              "rejected_overcounted" (json-bool
                                      (getf contract :rejected-overcounted))
              "effective_trials" (getf contract :effective-trials)
@@ -719,9 +720,10 @@ count suggests, and that shortfall is invisible in every other line."
 trial~:P -- cl-spec counted more refusals than trials, so how often the ~
 function was actually called cannot be derived here~@[. This contract has ~
 no :pre, so it should have refused none~]"
+                 ;; EXECUTED is an integer here: :OVERCOUNTED is chosen only
+                 ;; after the countability guard, which requires one.
                  (getf contract :rejected)
-                 (or (getf (getf result :trials) :executed)
-                     "an unknown number of")
+                 (getf (getf result :trials) :executed)
                  (null (getf contract :precondition-p))))
         (:unmeasured
          (format stream "~&    contract: the refused-input count could not be ~
@@ -898,7 +900,10 @@ it came out."
                        ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
                        (t "⚠ NOT VERIFIED")))
         (contract (getf (getf report :selection) :contract-not-run))
-        (properties (getf (getf report :selection) :properties-not-run)))
+        (properties (append (getf (getf report :selection) :properties-not-run)
+                            (let ((own (getf (getf report :selection)
+                                             :own-property-not-run)))
+                              (when own (list own))))))
     (cond
       (contract
        (format nil "~A (properties only -- the function spec for ~A was NOT run)"
@@ -996,6 +1001,8 @@ symbol could not be read)"
                            (%symbol-hts (getf selection :properties-not-run)))
                          "properties_not_run_read"
                          (%optional-bool selection :properties-not-run-read)
+                         "own_property_not_run"
+                         (%symbol-ht (getf selection :own-property-not-run))
                          "notes" (%strings (getf selection :notes)))
                 "results" (coerce (mapcar #'%result-ht (getf report :results))
                                   'vector)
@@ -1096,15 +1103,22 @@ symbol could not be read)"
         ;; clause used to re-derive two of the same three facts, so "this
         ;; kind lists no properties" and "this cl-spec cannot filter by tag"
         ;; were one edit away from being reported as each other.
-        (let ((lists-properties (and (member (getf report :kind)
-                                             '("properties" "both")
-                                             :test #'equal)
-                                     (getf report :properties-listable)
-                                     t)))
+        ;; Three reasons, each named as itself.  Folding "this cl-spec cannot
+        ;; enumerate properties" into the kind test gave kind=both the answer
+        ;; "this kind lists none" two lines above a block saying the revision
+        ;; cannot enumerate them -- one response, two reasons, one fact.
+        (let ((kind-lists-properties (and (member (getf report :kind)
+                                                  '("properties" "both")
+                                                  :test #'equal)
+                                          t)))
           (cond
-            ((not lists-properties)
+            ((not kind-lists-properties)
              (format stream "  tag ~A was NOT applied: it narrows properties, ~
 and this kind lists none"
+                     (getf filters :tag)))
+            ((not (getf report :properties-listable))
+             (format stream "  tag ~A was NOT applied: the loaded cl-spec ~
+cannot enumerate properties, so there was nothing for it to narrow"
                      (getf filters :tag)))
             ((not (getf report :tag-filterable))
              (format stream "  tag ~A was NOT applied: the loaded cl-spec ~

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -339,7 +339,11 @@ the :RETURNS spec four lines below showed all three."
             (or (getf (getf node :name) :qualified)
                 (getf node :type)
                 (getf node :predicate)
-                (getf node :class-name))
+                ;; Read like :NAME and :TARGET two lines up.  %SPEC-TREE
+                ;; stores a class as SYMBOL-DATA's plist, and printing it raw
+                ;; put "(PACKAGE MY-APP NAME ACCOUNT ...)" into the text --
+                ;; unreachable until argument specs began rendering here.
+                (getf (getf node :class-name) :qualified))
             (getf (getf node :target) :qualified))
     (let ((minimum (getf node :min))
           (maximum (getf node :max))
@@ -460,8 +464,14 @@ shrink_enabled false -- shrinking is off for this contract, which contradicts
 what spec-check function= then does -- and body_complete false, the body was
 cut, about a definition that has none.  A property describe did the same to
 preconditions_complete.  Absent has to reach the consumer as null."
-  (when (get-properties report (list key))
-    (json-bool (getf report key))))
+  (let ((found (get-properties report (list key))))
+    (when found
+      ;; :NOT-APPLICABLE is the third answer a plist built positionally cannot
+      ;; give by leaving the key out: "this definition has no such clause", as
+      ;; distinct from "the clause is there and was cut".  NIL is the second
+      ;; of those and has to stay false.
+      (unless (eq :not-applicable (getf report key))
+        (json-bool (getf report key))))))
 
 (defun build-spec-describe-response (report)
   "Return the MCP response for a DESCRIBE-REPORT plist."
@@ -683,19 +693,11 @@ count suggests, and that shortfall is invisible in every other line."
   (let ((contract (getf result :contract)))
     (when contract
       (cond
-        ((null (getf contract :precondition-p))
-         ;; No :PRE, so nothing could be refused and there is no shortfall to
-         ;; report.  The refusal line named a clause the author never wrote.
-         (format stream "~&    contract: no :pre, so every generated input ~
-was passed to the function"))
-        ((eq :unknown (getf contract :precondition-p))
-         ;; Neither "it has one" nor "it has none".  Folded into the branch
-         ;; below, the text asserted a :pre while has_precondition beside it
-         ;; came back null -- the two halves of one response disagreeing on
-         ;; whether the clause exists.
-         (format stream "~&    contract: whether it has a :pre could not be ~
-read, so ~A refused input~:P is a count this response cannot interpret"
-                 (or (getf contract :rejected) "an unknown number of")))
+        ;; The two uncertainty branches first.  "no :pre, so every generated
+        ;; input was passed to the function" is an affirmative claim that the
+        ;; effective count equals the executed one, and it must not be made
+        ;; over a refusal count that is missing or unusable -- whichever of
+        ;; the two the response is carrying.
         ((getf contract :rejected-overcounted)
          ;; More refusals than trials, so the difference says nothing.  Left
          ;; as its own line rather than folded into the one below: printing
@@ -705,15 +707,38 @@ read, so ~A refused input~:P is a count this response cannot interpret"
 ~A trials -- cl-spec counted more refusals than trials, so how often the ~
 function was actually called cannot be derived here"
                  (getf contract :rejected)
-                 (or (getf (getf result :trials) :executed) "an unknown number of")))
-        ((getf contract :rejected-measured)
+                 (or (getf (getf result :trials) :executed)
+                     "an unknown number of")))
+        ((not (getf contract :rejected-measured))
+         (format stream "~&    contract: the refused-input count could not be ~
+read, so the trial count above is an upper bound on what was checked"))
+        ((null (getf contract :precondition-p))
+         ;; No :PRE, so nothing could be refused and there is no shortfall to
+         ;; report.  The refusal line named a clause the author never wrote.
+         (if (eql 0 (getf contract :rejected))
+             (format stream "~&    contract: no :pre, so every generated ~
+input was passed to the function")
+             ;; A refusal against a contract with nothing to refuse with.  The
+             ;; two facts came from different readers and they disagree; the
+             ;; affirmative claim is the one that has to go.
+             (format stream "~&    contract: ~A input~:P refused although ~
+this contract has no :pre -- the two do not agree, so how often the function ~
+was called cannot be read off them"
+                     (getf contract :rejected))))
+        ((eq :unknown (getf contract :precondition-p))
+         ;; Neither "it has one" nor "it has none".  Folded into the branch
+         ;; below, the text asserted a :pre while has_precondition beside it
+         ;; came back null -- the two halves of one response disagreeing on
+         ;; whether the clause exists.
+         (format stream "~&    contract: whether it has a :pre could not be ~
+read, so ~A refused input~:P is a count this response cannot interpret"
+                 (or (getf contract :rejected) "an unknown number of")))
+        (t
          (format stream "~&    contract: ~A of them refused by :pre, ~
 so the function was called ~A time~:P"
                  (getf contract :rejected)
-                 (or (getf contract :effective-trials) "an unknown number of")))
-        (t
-         (format stream "~&    contract: the refused-input count could not be ~
-read, so the trial count above is an upper bound on what was checked")))
+                 (or (getf contract :effective-trials)
+                     "an unknown number of"))))
       ;; An absent reason has two causes and they are opposite accusations:
       ;; cl-spec saying the counterexample would not reproduce, and this
       ;; adapter never having had a reader to ask.  Printing the first for
@@ -948,6 +973,8 @@ it came out."
                                              (getf selection :contract-not-run))
                          "properties_not_run"
                          (%symbol-hts (getf selection :properties-not-run))
+                         "properties_not_run_read"
+                         (%optional-bool selection :properties-not-run-read)
                          "notes" (%strings (getf selection :notes)))
                 "results" (coerce (mapcar #'%result-ht (getf report :results))
                                   'vector)

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -531,6 +531,10 @@ preconditions_complete.  Absent has to reach the consumer as null."
               "source_form_omitted_chars" (getf report :source-form-omitted-chars)
               "source_location" (%source-location-ht (getf report :source-location))
               "definition_digest" (getf report :definition-digest)
+              "definition_digest_complete" (%optional-bool
+                                            report :definition-digest-complete)
+              "definition_digest_covers" (%keyword-string
+                                          (getf report :definition-digest-covers))
               "environment" (%environment-ht (getf report :environment))
               "content" (text-content (%format-describe-text report))))))
 

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -391,14 +391,25 @@ max_chars -- which is to say, by luck."
                 (getf (getf (getf argument :spec) :target) :qualified))
         (map nil (lambda (child) (%format-spec-node stream child 1))
              (or (getf (getf argument :spec) :children) '()))))
+    ;; Cut and reported, like the body and the source form below.  A silently
+    ;; truncated :PRE is worse than either: a reader takes a clause for the
+    ;; whole condition and concludes the contract admits inputs it refuses.
     (when (getf report :preconditions)
-      (format stream "~&~%:pre  ~A" (getf report :preconditions)))
+      (format stream "~&~%:pre  ~A" (getf report :preconditions))
+      (unless (getf report :preconditions-complete)
+        (format stream "~&... truncated, ~D more character~:P. Raise max_chars ~
+to see the rest."
+                (getf report :preconditions-omitted-chars))))
     (let ((returns (getf report :returns)))
       (when returns
         (format stream "~&~%returns:")
         (%format-spec-node stream returns 0)))
     (when (getf report :postconditions)
-      (format stream "~&~%:post ~A" (getf report :postconditions)))
+      (format stream "~&~%:post ~A" (getf report :postconditions))
+      (unless (getf report :postconditions-complete)
+        (format stream "~&... truncated, ~D more character~:P. Raise max_chars ~
+to see the rest."
+                (getf report :postconditions-omitted-chars))))
     (let ((tree (getf report :spec)))
       (when tree
         (format stream "~&~%normalized IR tree:")
@@ -457,8 +468,12 @@ to see the rest; the text above is a preview, not a form that can be read back."
               "returns" (%spec-tree-ht (getf report :returns))
               "preconditions" (sanitize-for-json (getf report :preconditions))
               "preconditions_complete" (json-bool (getf report :preconditions-complete))
+              "preconditions_omitted_chars" (getf report
+                                                  :preconditions-omitted-chars)
               "postconditions" (sanitize-for-json (getf report :postconditions))
               "postconditions_complete" (json-bool (getf report :postconditions-complete))
+              "postconditions_omitted_chars" (getf report
+                                                   :postconditions-omitted-chars)
               "body" (sanitize-for-json (getf report :body))
               "body_complete" (json-bool (getf report :body-complete))
               "body_omitted_chars" (getf report :body-omitted-chars)
@@ -527,11 +542,17 @@ not be read."
   (when contract
     (make-ht "rejected" (getf contract :rejected)
              "rejected_measured" (json-bool (getf contract :rejected-measured))
+             "rejected_overcounted" (json-bool
+                                     (getf contract :rejected-overcounted))
              "effective_trials" (getf contract :effective-trials)
              "failure_reason" (%keyword-string (getf contract :failure-reason))
              "failure_reason_readable" (json-bool
                                         (getf contract :failure-reason-readable))
-             "explanation" (sanitize-for-json (getf contract :explanation)))))
+             "explanation" (sanitize-for-json (getf contract :explanation))
+             "explanation_complete" (json-bool
+                                     (getf contract :explanation-complete))
+             "explanation_omitted_chars" (getf contract
+                                               :explanation-omitted-chars))))
 
 (defun %result-ht (result)
   "Return one per-property result as a hash-table."
@@ -632,13 +653,25 @@ The effective trial count is the one a reader should act on: a contract whose
 count suggests, and that shortfall is invisible in every other line."
   (let ((contract (getf result :contract)))
     (when contract
-      (if (getf contract :rejected-measured)
-          (format stream "~&    contract: ~A of them refused by :pre, ~
+      (cond
+        ((getf contract :rejected-overcounted)
+         ;; More refusals than trials, so the difference says nothing.  Left
+         ;; as its own line rather than folded into the one below: printing
+         ;; "the function was called 0 times" for a run that did call it is a
+         ;; different wrong answer, not a smaller one.
+         (format stream "~&    contract: ~A inputs refused by :pre against ~
+~A trials -- cl-spec counted more refusals than trials, so how often the ~
+function was actually called cannot be derived here"
+                 (getf contract :rejected)
+                 (or (getf (getf result :trials) :executed) "an unknown number of")))
+        ((getf contract :rejected-measured)
+         (format stream "~&    contract: ~A of them refused by :pre, ~
 so the function was called ~A time~:P"
-                  (getf contract :rejected)
-                  (or (getf contract :effective-trials) "an unknown number of"))
-          (format stream "~&    contract: the refused-input count could not be ~
-read, so the trial count above is an upper bound on what was checked"))
+                 (getf contract :rejected)
+                 (or (getf contract :effective-trials) "an unknown number of")))
+        (t
+         (format stream "~&    contract: the refused-input count could not be ~
+read, so the trial count above is an upper bound on what was checked")))
       ;; An absent reason has two causes and they are opposite accusations:
       ;; cl-spec saying the counterexample would not reproduce, and this
       ;; adapter never having had a reader to ask.  Printing the first for
@@ -659,7 +692,11 @@ cl-spec does not export the reader. Which half broke is unknown; this is NOT ~
 a finding about the function"))))
       (let ((explanation (getf contract :explanation)))
         (when explanation
-          (format stream "~&    return value: ~A" explanation))))))
+          (format stream "~&    return value: ~A" explanation)
+          (unless (getf contract :explanation-complete)
+            (format stream "~&    ... truncated, ~D more character~:P. Raise ~
+max_value_chars to see the rest."
+                    (getf contract :explanation-omitted-chars))))))))
 
 (defun %format-one-result (stream result index)
   "Write one per-property result to STREAM."

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -529,6 +529,8 @@ not be read."
              "rejected_measured" (json-bool (getf contract :rejected-measured))
              "effective_trials" (getf contract :effective-trials)
              "failure_reason" (%keyword-string (getf contract :failure-reason))
+             "failure_reason_readable" (json-bool
+                                        (getf contract :failure-reason-readable))
              "explanation" (sanitize-for-json (getf contract :explanation)))))
 
 (defun %result-ht (result)
@@ -637,14 +639,24 @@ so the function was called ~A time~:P"
                   (or (getf contract :effective-trials) "an unknown number of"))
           (format stream "~&    contract: the refused-input count could not be ~
 read, so the trial count above is an upper bound on what was checked"))
+      ;; An absent reason has two causes and they are opposite accusations:
+      ;; cl-spec saying the counterexample would not reproduce, and this
+      ;; adapter never having had a reader to ask.  Printing the first for
+      ;; both tells the caller their function is non-deterministic on the
+      ;; evidence of a missing name.
       (let ((reason (getf contract :failure-reason)))
-        (when reason
-          (format stream "~&    broken half: ~A" (%keyword-string reason))))
-      (when (and (member (getf result :status) '(:failed :error))
-                 (null (getf contract :failure-reason)))
-        (format stream "~&    broken half: not determined -- re-running the ~
+        (cond
+          (reason
+           (format stream "~&    broken half: ~A" (%keyword-string reason)))
+          ((not (member (getf result :status) '(:failed :error))) nil)
+          ((getf contract :failure-reason-readable)
+           (format stream "~&    broken half: not determined -- re-running the ~
 reported counterexample did not fail again, so the function is not ~
 deterministic"))
+          (t
+           (format stream "~&    broken half: could not be read -- this ~
+cl-spec does not export the reader. Which half broke is unknown; this is NOT ~
+a finding about the function"))))
       (let ((explanation (getf contract :explanation)))
         (when explanation
           (format stream "~&    return value: ~A" explanation))))))
@@ -808,8 +820,13 @@ it came out."
   (case (getf report :status)
     ((:cl-spec-not-loaded :cl-spec-incomplete) (%unavailable-response report))
     (:unresolved-symbol (%unresolved-response report))
-    ((:not-registered :invalid-arguments :backend-not-loaded :internal-error
-      :timeout)
+    ;; :UNSUPPORTED belongs here and not in the branch below: like the other
+    ;; five it carries a message and no selection, and reading it as a report
+    ;; of a run renders "Selected NIL properties via NIL" while the one thing
+    ;; the caller needs -- why cl-spec could not run the contract -- never
+    ;; reaches content[].text.
+    ((:not-registered :unsupported :invalid-arguments :backend-not-loaded
+      :internal-error :timeout)
      (let ((response (%simple-status-response report)))
        (setf (gethash "verified" response) (json-bool nil))
        response))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -394,9 +394,13 @@ to name the budget at all -- and two of the four were added in the same change
 that added the fields.  EXTRA carries what a particular field has to add."
   (unless (eq t (getf report complete-key))
     (unless (eq :not-applicable (getf report complete-key))
-      (format stream "~&~vT... truncated, ~D more character~:P. Raise ~A to ~
-see the rest.~@[ ~A~]"
-              indent (getf report omitted-key) budget extra))))
+      ;; ~vT past its column advances to the next tab stop, so an indent of
+      ;; zero emitted one space -- every cut body and source form gained a
+      ;; leading space no other line in the block has.
+      (format stream "~&~@[~vT~]... truncated, ~D more character~:P. Raise ~A ~
+to see the rest.~@[ ~A~]"
+              (when (plusp indent) indent)
+              (getf report omitted-key) budget extra))))
 
 (defun %format-describe-text (report)
   "Render the spec-describe report as text."
@@ -728,6 +732,15 @@ no :pre, so it should have refused none~]"
         (:unmeasured
          (format stream "~&    contract: the refused-input count could not be ~
 read, so the trial count above is an upper bound on what was checked"))
+        (:trials-uncounted
+         (format stream "~&    contract: ~A input~:P refused, but cl-spec ~
+reported no trial count, so how often the function was called cannot be ~
+derived from them"
+                 (getf contract :rejected)))
+        (:negative
+         (format stream "~&    contract: cl-spec reported ~A refused inputs, ~
+which is not a count -- the figure is not one this response can subtract with"
+                 (getf contract :rejected)))
         (:contradicted
          (format stream "~&    contract: ~A input~:P refused although this ~
 contract has no :pre -- the two do not agree, so how often the function was ~
@@ -1107,11 +1120,23 @@ symbol could not be read)"
         ;; enumerate properties" into the kind test gave kind=both the answer
         ;; "this kind lists none" two lines above a block saying the revision
         ;; cannot enumerate them -- one response, two reasons, one fact.
+        ;; Whether the filter ran is FILTERS.TAG-APPLIED, which LIST-REPORT
+        ;; computed from these same three facts and this function reads again
+        ;; twenty lines down.  The flags below pick which reason to print; two
+        ;; implementations of one predicate in one function is how the header
+        ;; and the payload come to disagree.
         (let ((kind-lists-properties (and (member (getf report :kind)
                                                   '("properties" "both")
                                                   :test #'equal)
                                           t)))
           (cond
+            ((getf filters :tag-applied)
+             (format stream "  tagged ~A~:[~; (properties only)~]"
+                     (getf filters :tag)
+                     (equal "both" (getf report :kind)))
+             (unless (eq t (getf filters :tag-resolved))
+               (format stream " (NO SUCH TAG exists in this image, so nothing ~
+can carry it -- this is not the same as no property having it)")))
             ((not kind-lists-properties)
              (format stream "  tag ~A was NOT applied: it narrows properties, ~
 and this kind lists none"
@@ -1125,12 +1150,7 @@ cannot enumerate properties, so there was nothing for it to narrow"
 exports no properties-with-tag, so nothing here was filtered by it"
                      (getf filters :tag)))
             (t
-             (format stream "  tagged ~A~:[~; (properties only)~]"
-                     (getf filters :tag)
-                     (equal "both" (getf report :kind)))
-             (unless (eq t (getf filters :tag-resolved))
-               (format stream " (NO SUCH TAG exists in this image, so nothing ~
-can carry it -- this is not the same as no property having it)"))))))
+             (format stream "  tag ~A was NOT applied" (getf filters :tag))))))
       (when (getf report :truncated)
         (format stream "~&Showing at most ~D of each; raise limit for more."
                 (getf report :limit)))

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -236,6 +236,24 @@ For the whole call, status:
                   the call did not get as far as running anything. None of
                   these is evidence about the symbol or the property.
 
+verification_gaps names what the run could not establish. Values:
+  input-coverage-unmeasured   always present: nothing reports which parts of
+                              the input domain were reached.
+  zero-trials                 a passing run whose budget resolved to nothing.
+  effective-trials-unknown    a contract run whose real call count could not
+                              be derived. NOT the same as a budget of zero.
+  rejection-counts-unmeasured no usable refused-input count. Always present on
+                              a property run: its inputs are refused inside
+                              the generator, which does not report how often.
+  contract-not-run            a function spec is registered for the symbol and
+                              an :about selection did not run it.
+  properties-not-run          properties are registered about the symbol and a
+                              function= run did not run them.
+  related-properties-unknown  whether any property is registered about the
+                              symbol could not be read at all.
+  no-properties-selected      the selection was empty. Nothing ran.
+A non-verdict result status (timeout, not-run, *-error) appears here as itself.
+
 counts has a field for the five common statuses plus other, and by_status,
 which covers every status that occurred; selected always equals their sum. A
 status without a field of its own is in by_status, never dropped.

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -40,15 +40,22 @@
 (define-tool "spec-list"
   :group :cl-spec
   :description
-  "List the cl-spec specs and properties registered in this session's worker.
+  "List the cl-spec specs, function specs and properties registered in this
+session's worker.
 
 Use this when you do not yet know what is here. The other spec tools all take
 a name you already have; this is the one that answers \"what contracts does
 this project define?\".
 
-Returns names, and for each property its kind, tags, the symbols it is
-(:about ...), and its docstring. NOT bodies -- read one with 'spec-describe',
-run one with 'spec-check'.
+Returns names; for each property its kind, tags, the symbols it is
+(:about ...), and its docstring; for each function spec its parameter names and
+whether it carries a :returns. NOT bodies and NOT specs -- read one with
+'spec-describe', run one with 'spec-check'.
+
+A function spec is a contract on one function: which inputs it accepts and
+which output it must return. A property is a relation someone asserted about
+one or more functions. A project can have either without the other, so a
+listing with no function specs is not a listing with no contracts.
 
 An empty listing is NOT evidence that a project has no contracts: it shows
 what is registered in THIS worker, so a definition whose system has not been
@@ -61,11 +68,12 @@ and 'this tag does not exist here' are different answers.
 Examples:
   (no arguments) -- everything registered
   kind='properties', package='my-app'
+  kind='function-specs'
   tag='critical'"
   :args
   ((kind :type :string
-    :enum ("specs" "properties" "both")
-    :description "What to list (default: both)")
+    :enum ("specs" "properties" "function-specs" "both")
+    :description "What to list (default: both, which is all three)")
    (package :type :string
     :description "Only names whose home package is this one")
    (tag :type :string
@@ -145,15 +153,20 @@ that this relation is checked over that domain.
 
 kind='property'      the property's arguments, body, source form and digest
 kind='spec'          the spec's normalized IR tree
-kind='function-spec' NOT SUPPORTED by this cl-spec revision; the tool says so
-                     rather than inventing a projection
+kind='function-spec' the contract: the spec of each argument, the spec of the
+                     return value, and the :pre and :post forms. This is what
+                     answers \"which inputs does this accept and which output
+                     must it return\". A cl-spec revision that cannot project
+                     one says so rather than having a projection invented for
+                     it.
 
 Long bodies are cut at max_chars and the cut is reported. Truncated text is a
 preview for reading, NOT a form that can be read back.
 
 Examples:
   kind='property', name='my-app::transfer-preserves-total'
-  kind='spec', name='my-app::account'"
+  kind='spec', name='my-app::account'
+  kind='function-spec', name='my-app::transfer'"
   :args
   ((kind :type :string :required t
     :enum ("property" "spec" "function-spec")
@@ -180,8 +193,15 @@ Examples:
   :description
   "Run cl-spec properties and return structured results and counterexamples.
 
-Give EITHER property (one named property) OR symbol (every property registered
-with (:about <symbol>)).  Not both.
+Give EXACTLY ONE of property (one named property), symbol (every property
+registered with (:about <symbol>)) or function (one registered function spec,
+run with check-function).
+
+A function spec is the contract: which inputs the function accepts (:args,
+:pre) and which output it must return (:returns, :post).  It is NOT selected
+by symbol -- an :about selection covers properties only -- and the response
+says so when one exists.  Read it first with 'spec-describe'
+kind='function-spec'.
 
 WHAT A RESULT MEANS
 
@@ -203,6 +223,7 @@ Per property, results[].status:
 For the whole call, status:
   no-properties   ZERO properties were selected. This is NOT a successful
                   verification: nothing ran.
+  unsupported     the loaded cl-spec cannot run a contract. Nothing ran.
   completed       every selected property reached a verdict.
   incomplete      at least one timeout, not-run, or *-error.
   cl-spec-not-loaded / cl-spec-incomplete / backend-not-loaded /
@@ -218,8 +239,23 @@ verified is true ONLY when at least one property was selected, every one of
 them passed, AND every one evaluated at least one trial. A property whose
 profile resolves to a budget of zero passes without running anything, and that
 is not a verification. verification_gaps names what the run could not
-establish, and always includes the two things cl-spec never measures:
-precondition rejections and input-domain coverage.
+establish, and always includes input-domain coverage, which nothing measures.
+
+CONTRACT RUNS (function=...)
+A contract check generates arguments from :args, drops the ones :pre refuses,
+calls the function, then checks :returns and :post. results[].contract carries:
+  rejected         generated argument lists :pre refused
+  effective_trials trials minus rejected -- what the function was ACTUALLY
+                   called with. A passing run whose effective_trials is 0
+                   checked nothing; cl-spec reports that as skipped, not
+                   passed.
+  failure_reason   which half broke: return-spec, postcondition, precondition,
+                   condition -- or absent when the counterexample did not
+                   reproduce, which means the function is not deterministic.
+  explanation      cl-spec's structured account of a return value that missed
+                   its :returns spec.
+Because rejections are counted here, verification_gaps does not claim they are
+unmeasured for a contract run.
 
 REPRODUCING A RUN
 Every result carries seed (decimal TEXT, because a cl-spec seed can exceed
@@ -259,15 +295,22 @@ load-system call wrote to.
 
 Examples:
   symbol='my-app::transfer'
+  function='my-app::transfer'
   property='my-app::transfer-preserves-total'
   property='my-app::transfer-preserves-total', seed='3963993791726803706',
     profile='normal', expect_definition_digest='a41f9c2b7d0e5518'"
   :args
   ((property :type :string
-    :description "One registered property to run. Exclusive with symbol.")
+    :description
+    "One registered property to run. Exclusive with symbol and function.")
    (symbol :type :string
     :description
-    "Run every property registered (:about <symbol>). Exclusive with property.")
+    "Run every property registered (:about <symbol>). Does NOT include the
+symbol's function spec; the response names it when one exists.")
+   (function :type :string
+    :description
+    "One registered function spec to run against its function. Exclusive with
+property and symbol.")
    (package :type :string
     :description "Package for an unqualified name (default: COMMON-LISP-USER)")
    (profile :type :string
@@ -287,6 +330,7 @@ Examples:
   :body
   (let ((params (make-ht "property" property
                          "symbol" symbol
+                         "function" function
                          "package" package
                          "profile" profile
                          "seed" seed

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -319,9 +319,12 @@ calls the function, then checks :returns and :post. results[].contract carries:
                    null explanation then says nothing about the run.
                    explanation_complete and explanation_omitted_chars report a
                    cut, like every other bounded field.
-  rejection_status the keyword the five booleans above are derived from, and
-                   the one to branch on: usable, no-precondition, unmeasured,
-                   overcounted, contradicted, precondition-unknown.
+  rejection_status the keyword the booleans above are derived from, and the
+                   one to branch on: usable, no-precondition, unmeasured (the
+                   refusal count could not be read), trials-uncounted (it was,
+                   and the trial count was not), negative (cl-spec reported a
+                   count below zero), overcounted, contradicted,
+                   precondition-unknown.
   rejected_readable
                    false when the refused-input reader is absent or signalled,
                    as against rejected_measured, which is also false when it
@@ -412,7 +415,9 @@ Contract runs only -- a property takes its count from its own :trials table,
 selected by profile -- and given with property= or symbol= it is refused, not
 ignored. The ceiling is there because the run happens on a deadline thread
 that cannot always be stopped: a budget that outlives its timeout goes on
-calling your function inside this session's worker.")
+calling your function inside this session's worker. It caps the number of
+calls, not the time -- size the run with timeout_seconds as well, and check
+worker_reuse afterwards.")
    (package :type :string
     :description "Package for an unqualified name (default: COMMON-LISP-USER)")
    (profile :type :string

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -250,8 +250,11 @@ calls the function, then checks :returns and :post. results[].contract carries:
                    checked nothing; cl-spec reports that as skipped, not
                    passed.
   failure_reason   which half broke: return-spec, postcondition, precondition,
-                   condition -- or absent when the counterexample did not
-                   reproduce, which means the function is not deterministic.
+                   condition. Absent has two meanings, told apart by
+                   failure_reason_readable: true means cl-spec could not
+                   reproduce the counterexample, so the function is not
+                   deterministic; false means this cl-spec exports no reader
+                   for it, which says nothing about the function.
   explanation      cl-spec's structured account of a return value that missed
                    its :returns spec.
 Because rejections are counted here, verification_gaps does not claim they are
@@ -319,12 +322,17 @@ symbol's function spec; the response names it when one exists.")
 property and symbol.")
    (trials :type :integer
     :description
-    "Trial count for a contract run. Contract runs only: a property takes its
-count from its own :trials table, selected by profile.")
+    "Trial count for a contract run, a POSITIVE integer. Contract runs only: a
+property takes its count from its own :trials table, selected by profile.
+Given with property= or symbol= it is refused, not ignored.")
    (package :type :string
     :description "Package for an unqualified name (default: COMMON-LISP-USER)")
    (profile :type :string
-    :description "Trial-count profile, e.g. 'normal' or 'smoke' (default: normal)")
+    :description
+    "Trial-count profile, e.g. 'normal' or 'smoke' (default: normal). Property
+runs only -- a contract has no :trials table to select from and cl-spec's
+check-function takes no profile, so it is refused with function=, the mirror
+of how trials is refused with property=. Size a contract run with trials=.")
    (seed :type :string
     :description
     "Decimal digits AS A STRING. A JSON number would already have lost digits.")

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -314,6 +314,15 @@ calls the function, then checks :returns and :post. results[].contract carries:
                    false when this cl-spec exports no reader for cl-spec's
                    account of the return value, or that reader signalled. A
                    null explanation then says nothing about the run.
+                   explanation_complete and explanation_omitted_chars report a
+                   cut, like every other bounded field.
+  rejection_status the keyword the five booleans above are derived from, and
+                   the one to branch on: usable, no-precondition, unmeasured,
+                   overcounted, contradicted, precondition-unknown.
+  rejected_readable
+                   false when the refused-input reader is absent or signalled,
+                   as against rejected_measured, which is also false when it
+                   returned something that is not a count.
   failure_reason   which half broke: return-spec, postcondition, precondition,
                    condition. Absent has two meanings, told apart by
                    failure_reason_readable: true means cl-spec could not
@@ -395,9 +404,12 @@ symbol's function spec; the response names it when one exists.")
 property and symbol.")
    (trials :type :integer
     :description
-    "Trial count for a contract run, a POSITIVE integer. Contract runs only: a
-property takes its count from its own :trials table, selected by profile.
-Given with property= or symbol= it is refused, not ignored.")
+    "Trial count for a contract run: a positive integer, at most 1,000,000.
+Contract runs only -- a property takes its count from its own :trials table,
+selected by profile -- and given with property= or symbol= it is refused, not
+ignored. The ceiling is there because the run happens on a deadline thread
+that cannot always be stopped: a budget that outlives its timeout goes on
+calling your function inside this session's worker.")
    (package :type :string
     :description "Package for an unqualified name (default: COMMON-LISP-USER)")
    (profile :type :string

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -307,6 +307,10 @@ calls the function, then checks :returns and :post. results[].contract carries:
                    count may not be subtracted with, for any of the reasons
                    above. effective_trials is null exactly when this is false,
                    and verified is false with it.
+  explanation_readable
+                   false when this cl-spec exports no reader for cl-spec's
+                   account of the return value, or that reader signalled. A
+                   null explanation then says nothing about the run.
   failure_reason   which half broke: return-spec, postcondition, precondition,
                    condition. Absent has two meanings, told apart by
                    failure_reason_readable: true means cl-spec could not

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -239,6 +239,9 @@ For the whole call, status:
   unsupported     the loaded cl-spec cannot run a contract. Nothing ran.
   completed       every selected property reached a verdict.
   incomplete      at least one timeout, not-run, or *-error.
+  undefined-function
+                  the name is registered but the function it contracts is not
+                  defined in this image. Nothing ran. NOT an adapter fault.
   cl-spec-not-loaded / cl-spec-incomplete / backend-not-loaded /
   unresolved-symbol / not-registered / invalid-arguments / internal-error
                   the call did not get as far as running anything. None of

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -250,9 +250,12 @@ verification_gaps names what the run could not establish. Values:
   zero-trials                 a passing run whose budget resolved to nothing.
   effective-trials-unknown    a contract run whose real call count could not
                               be derived. NOT the same as a budget of zero.
-  rejection-counts-unmeasured no usable refused-input count. Always present on
-                              a property run: its inputs are refused inside
-                              the generator, which does not report how often.
+  rejection-counts-unmeasured no usable refused-input count. Always on a
+                              property run -- its inputs are refused inside
+                              the generator, which does not report how often
+                              -- and on a contract run whose count could not
+                              be read or never happened at all, a timeout or
+                              a budget-exhausted result included.
   contract-not-run            a function spec is registered for the symbol and
                               an :about selection did not run it.
   properties-not-run          properties are registered about the symbol and a
@@ -337,6 +340,11 @@ what JSON holds exactly as a number), profile, and definition_digest.  Re-run
 with the same property, seed and profile to regenerate the same trial
 sequence.  Pass expect_definition_digest to be told when the definitions moved
 underneath you.
+
+definition_digest_covers says what the digest is a digest OF: the property, or
+the contract. On a contract run it does NOT cover the function body -- nothing
+here reads one -- so editing the function and replaying from the same seed is
+reported faithful and is not a reproduction. Check the function yourself.
 
 definition_match is four-valued: match, mismatch, unknown (the digest could
 not be computed, or its input hit the print limit -- this is NOT a

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -264,7 +264,10 @@ A contract has no :trials table for profile to select from, so its budget is
 the backend default unless you pass trials. Raise it when effective_trials
 comes back small: a :pre that refuses most of what is generated leaves the
 interesting inputs unreached, and cl-spec does not yet reflect a precondition
-into the generator (its specification 19).
+into the generator (its specification 19). Raise timeout_seconds alongside it:
+that budget covers the WHOLE call and defaults to 60 seconds, so a run sized
+past it comes back as a timeout with worker_reuse unknown -- not as a result,
+and not as a smaller run.
 
 REPRODUCING A RUN
 Every result carries seed (decimal TEXT, because a cl-spec seed can exceed

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -65,6 +65,14 @@ tag names a keyword. A tag no loaded code mentions is reported as
 no-such-keyword rather than as an empty result -- 'nothing carries this tag'
 and 'this tag does not exist here' are different answers.
 
+WHAT THIS CL-SPEC COULD LOOK AT
+specs_listable, properties_listable and function_specs_listable say whether
+the loaded cl-spec can enumerate each half at all, and tag_filterable whether
+it can filter by tag. False is NOT 'this project has none': it is 'this
+revision cannot answer'. The matching counts entry is then null, never 0 --
+0 would say the registry holds none, which is a fact nothing here established.
+A kind whose halves are all unlistable is refused outright instead.
+
 Examples:
   (no arguments) -- everything registered
   kind='properties', package='my-app'
@@ -252,7 +260,10 @@ verification_gaps names what the run could not establish. Values:
   related-properties-unknown  whether any property is registered about the
                               symbol could not be read at all.
   no-properties-selected      the selection was empty. Nothing ran.
-A non-verdict result status (timeout, not-run, *-error) appears here as itself.
+A result status that is not a verdict appears here as itself: skipped,
+pending, timeout, not-run, generator-error, backend-error, not-registered,
+undefined-function, unsupported, internal-error. Only passed, failed and error
+are verdicts and none of them is a gap.
 
 counts has a field for the five common statuses plus other, and by_status,
 which covers every status that occurred; selected always equals their sum. A
@@ -289,6 +300,13 @@ calls the function, then checks :returns and :post. results[].contract carries:
   has_precondition false when the contract has no :pre at all, so nothing
                    could be refused and rejected 0 is not a shortfall. Null
                    when the definition could not be read.
+  rejected_contradicted
+                   true when refusals were reported for a contract with no
+                   :pre. Two readers disagreeing, so neither figure is usable.
+  rejected_usable  the one field to branch on: false whenever the refusal
+                   count may not be subtracted with, for any of the reasons
+                   above. effective_trials is null exactly when this is false,
+                   and verified is false with it.
   failure_reason   which half broke: return-spec, postcondition, precondition,
                    condition. Absent has two meanings, told apart by
                    failure_reason_readable: true means cl-spec could not

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -218,6 +218,10 @@ Per property, results[].status:
   generator-error no value could be generated. Nothing was checked.
   backend-error   cl-spec signalled something else. Nothing was checked.
   not-registered  the name resolved but nothing is registered under it.
+  undefined-function
+                  the contract is registered but the function it names is not
+                  defined in this image. Write it, or load its system.
+  unsupported     the loaded cl-spec cannot run this. Nothing was checked.
   internal-error  this adapter failed. NOT a statement about the property.
 
 For the whole call, status:

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -253,7 +253,21 @@ calls the function, then checks :returns and :post. results[].contract carries:
   effective_trials trials minus rejected -- what the function was ACTUALLY
                    called with. A passing run whose effective_trials is 0
                    checked nothing; cl-spec reports that as skipped, not
-                   passed.
+                   passed. NULL means the figure could not be derived, NOT
+                   zero calls: read rejected_measured and rejected_overcounted
+                   to see which.
+  rejected_measured
+                   false when this cl-spec exports no reader for the refused
+                   count. rejected is then null and the trial count above is
+                   an upper bound on what was checked.
+  rejected_overcounted
+                   true when cl-spec reported more refusals than trials, which
+                   its counter can do when the function signals. The
+                   difference is withheld rather than published as a negative
+                   or clamped to a zero that would read as never called.
+  has_precondition false when the contract has no :pre at all, so nothing
+                   could be refused and rejected 0 is not a shortfall. Null
+                   when the definition could not be read.
   failure_reason   which half broke: return-spec, postcondition, precondition,
                    condition. Absent has two meanings, told apart by
                    failure_reason_readable: true means cl-spec could not

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -251,11 +251,14 @@ A contract check generates arguments from :args, drops the ones :pre refuses,
 calls the function, then checks :returns and :post. results[].contract carries:
   rejected         generated argument lists :pre refused
   effective_trials trials minus rejected -- what the function was ACTUALLY
-                   called with. A passing run whose effective_trials is 0
-                   checked nothing; cl-spec reports that as skipped, not
-                   passed. NULL means the figure could not be derived, NOT
-                   zero calls: read rejected_measured and rejected_overcounted
-                   to see which.
+                   called with. NULL means the figure could not be derived,
+                   NOT zero calls: read rejected_measured and
+                   rejected_overcounted to see which. Do NOT read a passed
+                   verdict as proof the function ran: verified is false
+                   whenever this is 0 or null, and verification_gaps carries
+                   zero-trials or effective-trials-unknown, because cl-spec's
+                   own skipped-not-passed rule is computed from the same
+                   count and does not hold when that count is wrong.
   rejected_measured
                    false when this cl-spec exports no reader for the refused
                    count. rejected is then null and the trial count above is

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -219,8 +219,9 @@ Per property, results[].status:
   backend-error   cl-spec signalled something else. Nothing was checked.
   not-registered  the name resolved but nothing is registered under it.
   undefined-function
-                  the contract is registered but the function it names is not
-                  defined in this image. Write it, or load its system.
+                  a function the run needed is not defined in this image --
+                  the one a contract names, or one its property body calls.
+                  Write it, or load its system. NOT an adapter fault.
   unsupported     the loaded cl-spec cannot run this. Nothing was checked.
   internal-error  this adapter failed. NOT a statement about the property.
 

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -257,6 +257,12 @@ calls the function, then checks :returns and :post. results[].contract carries:
 Because rejections are counted here, verification_gaps does not claim they are
 unmeasured for a contract run.
 
+A contract has no :trials table for profile to select from, so its budget is
+the backend default unless you pass trials. Raise it when effective_trials
+comes back small: a :pre that refuses most of what is generated leaves the
+interesting inputs unreached, and cl-spec does not yet reflect a precondition
+into the generator (its specification 19).
+
 REPRODUCING A RUN
 Every result carries seed (decimal TEXT, because a cl-spec seed can exceed
 what JSON holds exactly as a number), profile, and definition_digest.  Re-run
@@ -311,6 +317,10 @@ symbol's function spec; the response names it when one exists.")
     :description
     "One registered function spec to run against its function. Exclusive with
 property and symbol.")
+   (trials :type :integer
+    :description
+    "Trial count for a contract run. Contract runs only: a property takes its
+count from its own :trials table, selected by profile.")
    (package :type :string
     :description "Package for an unqualified name (default: COMMON-LISP-USER)")
    (profile :type :string
@@ -331,6 +341,7 @@ property and symbol.")
   (let ((params (make-ht "property" property
                          "symbol" symbol
                          "function" function
+                         "trials" trials
                          "package" package
                          "profile" profile
                          "seed" seed

--- a/tests/fixtures/spec-fixture-contracts.lisp
+++ b/tests/fixtures/spec-fixture-contracts.lisp
@@ -1,0 +1,40 @@
+;;;; tests/fixtures/spec-fixture-contracts.lisp
+;;;;
+;;;; The function-spec half of tests/fixtures/spec-fixture.lisp, in a file of
+;;;; its own so that a cl-spec without DEFSPEC-FUNCTION costs these four
+;;;; definitions and nothing else.
+;;;;
+;;;; A (WHEN (function-specs-supported-p) ...) guard in the main file could not
+;;;; do that.  LOAD reads a whole top-level form before evaluating it, so
+;;;; CL-SPEC:DEFSPEC-FUNCTION is resolved by the reader -- against a revision
+;;;; that does not export the symbol, the guard has not run yet and the reader
+;;;; error takes the entire fixture down, CLAMP and the properties with it.
+;;;; A second file is only read when it is loaded.
+;;;;
+;;;; Loaded by the main fixture, never by ASDF: nothing depends on it.
+
+(in-package #:cl-mcp/tests/fixtures/spec-fixture)
+
+(cl-spec:defspec-function clamp
+  "CLAMP returns a value inside the interval it was given."
+  (:args (value small-int) (low small-int) (high small-int))
+  (:pre (<= low high))
+  (:returns small-int)
+  (:post (and (<= low result) (<= result high))))
+
+(cl-spec:defspec-function widen
+  "WIDEN stays inside SMALL-INT, which it does not."
+  (:args (value small-int))
+  (:returns small-int)
+  (:post (> result value)))
+
+(cl-spec:defspec-function never-callable
+  "A contract whose precondition no generated value can satisfy."
+  (:args (value small-int))
+  (:pre (> value 1000))
+  (:returns small-int))
+
+(cl-spec:defspec-function magnitude
+  "The magnitude is never negative, and has no upper bound worth naming."
+  (:args (value small-int))
+  (:returns (range integer 0 *)))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -14,6 +14,7 @@
 (defpackage #:cl-mcp/tests/fixtures/spec-fixture
   (:use #:cl)
   (:export #:clamp
+           #:function-specs-supported-p
            #:magnitude
            #:widen
            #:never-callable
@@ -78,12 +79,6 @@ exactly what loading an edited file produces."
     (= (clamp (clamp value 10 90) 10 90)
        (clamp value 10 90))))
 
-(cl-spec:defspec-function clamp
-  "CLAMP returns a value inside the interval it was given."
-  (:args (value small-int) (low small-int) (high small-int))
-  (:pre (<= low high))
-  (:returns small-int)
-  (:post (and (<= low result) (<= result high))))
 
 (defun widen (value)
   "Return VALUE moved one step away from zero.
@@ -92,27 +87,51 @@ Written to break its own contract at the top of SMALL-INT's range, so a test
 can see a contract failure that is not a property failure."
   (1+ value))
 
-(cl-spec:defspec-function widen
-  "WIDEN stays inside SMALL-INT, which it does not."
-  (:args (value small-int))
-  (:returns small-int)
-  (:post (> result value)))
 
 (defun never-callable (value)
   "Return VALUE. Its contract's :PRE admits nothing, so nothing ever calls it."
   value)
 
-(cl-spec:defspec-function never-callable
-  "A contract whose precondition no generated value can satisfy."
-  (:args (value small-int))
-  (:pre (> value 1000))
-  (:returns small-int))
 
 (defun magnitude (value)
   "Return the absolute value of VALUE."
   (abs value))
 
-(cl-spec:defspec-function magnitude
-  "The magnitude is never negative, and has no upper bound worth naming."
-  (:args (value small-int))
-  (:returns (range integer 0 *)))
+(defun function-specs-supported-p ()
+  "Return true when the loaded cl-spec implements function specs.
+
+FUNCTION-SPEC-DATA is the discriminator, not CHECK-FUNCTION: a cl-spec that
+predates function specs still has CHECK-FUNCTION fbound, as a stub that
+signals NOT-IMPLEMENTED, so FBOUNDP alone answers the wrong question."
+  (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
+    (and data (fboundp data) t)))
+
+;; Guarded because this file is LOADed, not compiled: against a cl-spec whose
+;; DEFSPEC-FUNCTION is still a stub, one signalling form aborts the load and
+;; every test in the file fails -- including the three that have nothing to do
+;; with contracts.  cl-mcp does not depend on cl-spec and must stay green
+;; against whichever revision happens to be installed.
+(when (function-specs-supported-p)
+  (cl-spec:defspec-function clamp
+    "CLAMP returns a value inside the interval it was given."
+    (:args (value small-int) (low small-int) (high small-int))
+    (:pre (<= low high))
+    (:returns small-int)
+    (:post (and (<= low result) (<= result high))))
+
+  (cl-spec:defspec-function widen
+    "WIDEN stays inside SMALL-INT, which it does not."
+    (:args (value small-int))
+    (:returns small-int)
+    (:post (> result value)))
+
+  (cl-spec:defspec-function never-callable
+    "A contract whose precondition no generated value can satisfy."
+    (:args (value small-int))
+    (:pre (> value 1000))
+    (:returns small-int))
+
+  (cl-spec:defspec-function magnitude
+    "The magnitude is never negative, and has no upper bound worth naming."
+    (:args (value small-int))
+    (:returns (range integer 0 *))))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -23,7 +23,6 @@
            #:clamp-is-idempotent
            #:clamp-is-wrong-on-purpose
            #:register-corrected-property
-           #:function-specs-supported-p
            #:contracts-registered-p))
 
 (in-package #:cl-mcp/tests/fixtures/spec-fixture)
@@ -133,6 +132,13 @@ signals at run time on a revision that exports it."
 ;; tests down that the split was written to protect.  Reported rather than
 ;; swallowed, and CONTRACTS-REGISTERED-P tells a test which happened.
 (when (function-specs-supported-p)
+  ;; Cleared first.  This file is loaded once per registry, and a flag left
+  ;; standing from an earlier load describes a registry that is no longer the
+  ;; one in effect: a second load whose contract half signalled would keep
+  ;; answering "registered" while the fresh registry holds none, and the
+  ;; contract tests would run against it and report the failures as adapter
+  ;; bugs.
+  (setf *contracts-registered* nil)
   (handler-case
       (progn
         (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -14,6 +14,8 @@
 (defpackage #:cl-mcp/tests/fixtures/spec-fixture
   (:use #:cl)
   (:export #:clamp
+           #:widen
+           #:never-callable
            #:small-int
            #:clamp-is-within-bounds
            #:clamp-is-idempotent
@@ -74,3 +76,33 @@ exactly what loading an edited file produces."
     (:kind :invariant)
     (= (clamp (clamp value 10 90) 10 90)
        (clamp value 10 90))))
+
+(cl-spec:defspec-function clamp
+  "CLAMP returns a value inside the interval it was given."
+  (:args (value small-int) (low small-int) (high small-int))
+  (:pre (<= low high))
+  (:returns small-int)
+  (:post (and (<= low result) (<= result high))))
+
+(defun widen (value)
+  "Return VALUE moved one step away from zero.
+
+Written to break its own contract at the top of SMALL-INT's range, so a test
+can see a contract failure that is not a property failure."
+  (1+ value))
+
+(cl-spec:defspec-function widen
+  "WIDEN stays inside SMALL-INT, which it does not."
+  (:args (value small-int))
+  (:returns small-int)
+  (:post (> result value)))
+
+(defun never-callable (value)
+  "Return VALUE. Its contract's :PRE admits nothing, so nothing ever calls it."
+  value)
+
+(cl-spec:defspec-function never-callable
+  "A contract whose precondition no generated value can satisfy."
+  (:args (value small-int))
+  (:pre (> value 1000))
+  (:returns small-int))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -14,6 +14,7 @@
 (defpackage #:cl-mcp/tests/fixtures/spec-fixture
   (:use #:cl)
   (:export #:clamp
+           #:magnitude
            #:widen
            #:never-callable
            #:small-int
@@ -106,3 +107,12 @@ can see a contract failure that is not a property failure."
   (:args (value small-int))
   (:pre (> value 1000))
   (:returns small-int))
+
+(defun magnitude (value)
+  "Return the absolute value of VALUE."
+  (abs value))
+
+(cl-spec:defspec-function magnitude
+  "The magnitude is never negative, and has no upper bound worth naming."
+  (:args (value small-int))
+  (:returns (range integer 0 *)))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -107,17 +107,31 @@ signals NOT-IMPLEMENTED, so FBOUNDP alone answers the wrong question."
   (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
     (and data (fboundp data) t)))
 
-(defvar *contracts-registered* nil
-  "True once the contract half of this fixture loaded without signalling.")
+(defvar *contracts-registered-in* '()
+  "Every registry the contract half of this fixture has loaded into.
 
-(defun contracts-registered-p ()
-  "Return true when this fixture's function specs are in the registry.
+A list rather than one value: this file is loaded once per registry and the
+loads interleave with the tests that read the answer, so recording only the
+latest let a private load clobber the shared registry's entry -- and the
+contract tests then skipped against a registry that holds them.")
+
+(defun contracts-registered-p (&optional (registry (symbol-value
+                                                    (find-symbol "*REGISTRY*"
+                                                                 "CL-SPEC"))))
+  "Return true when this fixture's function specs are in REGISTRY.
 
 What a test should ask before running contract coverage.  FUNCTION-SPECS-
 SUPPORTED-P says the loaded cl-spec has the API; this says the definitions
 actually made it in, which is not the same answer when DEFSPEC-FUNCTION
-signals at run time on a revision that exports it."
-  (and *contracts-registered* t))
+signals at run time on a revision that exports it.
+
+Keyed on the registry, not on a boolean.  This file is loaded once per
+registry and one test loads a private copy of it: a flag that only said
+\"yes\" answered for whichever load ran last, so a private load that failed
+could skip the contract tests against a shared registry that holds them, or a
+private load that succeeded could send them at one that does not.  Recording
+one registry rather than all of them has the same fault one step in."
+  (and registry (member registry *contracts-registered-in*) t))
 
 ;; Loaded rather than guarded in place.  This file is LOADed, not compiled,
 ;; and LOAD reads each top-level form before evaluating it -- so a
@@ -132,18 +146,16 @@ signals at run time on a revision that exports it."
 ;; tests down that the split was written to protect.  Reported rather than
 ;; swallowed, and CONTRACTS-REGISTERED-P tells a test which happened.
 (when (function-specs-supported-p)
-  ;; Cleared first.  This file is loaded once per registry, and a flag left
-  ;; standing from an earlier load describes a registry that is no longer the
-  ;; one in effect: a second load whose contract half signalled would keep
-  ;; answering "registered" while the fresh registry holds none, and the
-  ;; contract tests would run against it and report the failures as adapter
-  ;; bugs.
-  (setf *contracts-registered* nil)
+  ;; The registry is recorded, not a boolean.  This file is loaded once per
+  ;; registry and one test loads a private copy: a flag that only said "yes"
+  ;; described whichever load ran last, and the contract tests read it while a
+  ;; different registry was installed.
   (handler-case
       (progn
         (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"
                                (asdf:system-source-directory "cl-mcp")))
-        (setf *contracts-registered* t))
+        (pushnew (symbol-value (find-symbol "*REGISTRY*" "CL-SPEC"))
+                 *contracts-registered-in*))
     (error (condition)
       (format *error-output*
               "~&;; spec-fixture: contracts NOT registered: ~A~%" condition))))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -93,7 +93,6 @@ whose failure is rare makes the test that reads it a coin toss."
   "Return VALUE. Its contract's :PRE admits nothing, so nothing ever calls it."
   value)
 
-
 (defun magnitude (value)
   "Return the absolute value of VALUE."
   (abs value))
@@ -107,32 +106,12 @@ signals NOT-IMPLEMENTED, so FBOUNDP alone answers the wrong question."
   (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
     (and data (fboundp data) t)))
 
-;; Guarded because this file is LOADed, not compiled: against a cl-spec whose
-;; DEFSPEC-FUNCTION is still a stub, one signalling form aborts the load and
-;; every test in the file fails -- including the three that have nothing to do
-;; with contracts.  cl-mcp does not depend on cl-spec and must stay green
-;; against whichever revision happens to be installed.
+;; Loaded rather than guarded in place.  This file is LOADed, not compiled,
+;; and LOAD reads each top-level form before evaluating it -- so a
+;; CL-SPEC:DEFSPEC-FUNCTION form written here is resolved by the reader
+;; whatever a guard around it says, and against a revision that does not
+;; export the symbol the reader error takes the whole fixture down, CLAMP and
+;; the properties with it.  Only a separate file is left unread.
 (when (function-specs-supported-p)
-  (cl-spec:defspec-function clamp
-    "CLAMP returns a value inside the interval it was given."
-    (:args (value small-int) (low small-int) (high small-int))
-    (:pre (<= low high))
-    (:returns small-int)
-    (:post (and (<= low result) (<= result high))))
-
-  (cl-spec:defspec-function widen
-    "WIDEN stays inside SMALL-INT, which it does not."
-    (:args (value small-int))
-    (:returns small-int)
-    (:post (> result value)))
-
-  (cl-spec:defspec-function never-callable
-    "A contract whose precondition no generated value can satisfy."
-    (:args (value small-int))
-    (:pre (> value 1000))
-    (:returns small-int))
-
-  (cl-spec:defspec-function magnitude
-    "The magnitude is never negative, and has no upper bound worth naming."
-    (:args (value small-int))
-    (:returns (range integer 0 *))))
+  (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"
+                         (asdf:system-source-directory "cl-mcp"))))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -107,13 +107,18 @@ signals NOT-IMPLEMENTED, so FBOUNDP alone answers the wrong question."
   (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
     (and data (fboundp data) t)))
 
-(defvar *contracts-registered-in* '()
+(defvar *contracts-registered-in*
+  (make-hash-table :test #'eq :weakness :key)
   "Every registry the contract half of this fixture has loaded into.
 
-A list rather than one value: this file is loaded once per registry and the
+A set rather than one value: this file is loaded once per registry and the
 loads interleave with the tests that read the answer, so recording only the
 latest let a private load clobber the shared registry's entry -- and the
-contract tests then skipped against a registry that holds them.")
+contract tests then skipped against a registry that holds them.
+
+Weak on the key, because one test builds a throwaway registry per run and this
+defvar outlives the suite in a worker image: a strong set would retain every
+registry, with all its entries, for the life of the process.")
 
 (defun contracts-registered-p (&optional (registry (symbol-value
                                                     (find-symbol "*REGISTRY*"
@@ -131,7 +136,7 @@ registry and one test loads a private copy of it: a flag that only said
 could skip the contract tests against a shared registry that holds them, or a
 private load that succeeded could send them at one that does not.  Recording
 one registry rather than all of them has the same fault one step in."
-  (and registry (member registry *contracts-registered-in*) t))
+  (and registry (gethash registry *contracts-registered-in*) t))
 
 ;; Loaded rather than guarded in place.  This file is LOADed, not compiled,
 ;; and LOAD reads each top-level form before evaluating it -- so a
@@ -154,8 +159,9 @@ one registry rather than all of them has the same fault one step in."
       (progn
         (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"
                                (asdf:system-source-directory "cl-mcp")))
-        (pushnew (symbol-value (find-symbol "*REGISTRY*" "CL-SPEC"))
-                 *contracts-registered-in*))
+        (setf (gethash (symbol-value (find-symbol "*REGISTRY*" "CL-SPEC"))
+                       *contracts-registered-in*)
+              t))
     (error (condition)
       (format *error-output*
               "~&;; spec-fixture: contracts NOT registered: ~A~%" condition))))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -22,7 +22,9 @@
            #:clamp-is-within-bounds
            #:clamp-is-idempotent
            #:clamp-is-wrong-on-purpose
-           #:register-corrected-property))
+           #:register-corrected-property
+           #:function-specs-supported-p
+           #:contracts-registered-p))
 
 (in-package #:cl-mcp/tests/fixtures/spec-fixture)
 
@@ -106,12 +108,36 @@ signals NOT-IMPLEMENTED, so FBOUNDP alone answers the wrong question."
   (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
     (and data (fboundp data) t)))
 
+(defvar *contracts-registered* nil
+  "True once the contract half of this fixture loaded without signalling.")
+
+(defun contracts-registered-p ()
+  "Return true when this fixture's function specs are in the registry.
+
+What a test should ask before running contract coverage.  FUNCTION-SPECS-
+SUPPORTED-P says the loaded cl-spec has the API; this says the definitions
+actually made it in, which is not the same answer when DEFSPEC-FUNCTION
+signals at run time on a revision that exports it."
+  (and *contracts-registered* t))
+
 ;; Loaded rather than guarded in place.  This file is LOADed, not compiled,
 ;; and LOAD reads each top-level form before evaluating it -- so a
 ;; CL-SPEC:DEFSPEC-FUNCTION form written here is resolved by the reader
 ;; whatever a guard around it says, and against a revision that does not
 ;; export the symbol the reader error takes the whole fixture down, CLAMP and
 ;; the properties with it.  Only a separate file is left unread.
+;;
+;; HANDLER-CASE for the other half of the same promise: a revision that reads
+;; the file and then signals while registering -- a normalization change, a
+;; duplicate registration -- would otherwise take the same three unrelated
+;; tests down that the split was written to protect.  Reported rather than
+;; swallowed, and CONTRACTS-REGISTERED-P tells a test which happened.
 (when (function-specs-supported-p)
-  (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"
-                         (asdf:system-source-directory "cl-mcp"))))
+  (handler-case
+      (progn
+        (load (merge-pathnames "tests/fixtures/spec-fixture-contracts.lisp"
+                               (asdf:system-source-directory "cl-mcp")))
+        (setf *contracts-registered* t))
+    (error (condition)
+      (format *error-output*
+              "~&;; spec-fixture: contracts NOT registered: ~A~%" condition))))

--- a/tests/fixtures/spec-fixture.lisp
+++ b/tests/fixtures/spec-fixture.lisp
@@ -79,14 +79,15 @@ exactly what loading an edited file produces."
     (= (clamp (clamp value 10 90) 10 90)
        (clamp value 10 90))))
 
-
 (defun widen (value)
-  "Return VALUE moved one step away from zero.
+  "Return VALUE moved halfway up SMALL-INT's range, leaving it at the top.
 
-Written to break its own contract at the top of SMALL-INT's range, so a test
-can see a contract failure that is not a property failure."
-  (1+ value))
-
+Written to break its :RETURNS over most of that range rather than at one end
+of it.  (1+ value) broke it only at 100, one of the 101 values check-it draws
+uniformly, so the test that reads the failure passed 300 trials and still came
+up empty about once in twenty runs -- measured at 4 misses in 60.  A fixture
+whose failure is rare makes the test that reads it a coin toss."
+  (+ value 50))
 
 (defun never-callable (value)
   "Return VALUE. Its contract's :PRE admits nothing, so nothing ever calls it."

--- a/tests/spec-adapter-core-test.lisp
+++ b/tests/spec-adapter-core-test.lisp
@@ -300,6 +300,40 @@ Same name, different home package: the pair a resolver must not confuse."
           (ok (string= d1 (definition-digest (funcall api-for spec-v1)
                                              'prop nil))))))))
 
+(deftest definition-digest-follows-a-return-spec
+  (testing "widening the spec a contract returns changes its digest"
+    ;; A contract's own data holds a reference node naming the spec, so a
+    ;; :RETURNS whose spec was widened leaves every byte of the contract
+    ;; identical.  Walked from :ARGUMENTS alone, the digest did not move and a
+    ;; replay against the wider output domain came back "faithful".
+    (let* ((contract (list :name 'widen
+                           :arguments (list (list :variable 'value
+                                                  :spec (list :kind :reference
+                                                              :target 'in-int)))
+                           :returns (list :name nil :kind :reference
+                                          :target 'out-int)))
+           (api-for (lambda (out-max)
+                      (make-cl-spec-api
+                       :functions
+                       (list :property-data
+                             (lambda (name &key registry)
+                               (declare (ignore name registry)) contract)
+                             :spec-data
+                             (lambda (name &key registry)
+                               (declare (ignore registry))
+                               (if (eq name 'out-int)
+                                   (list :name name :kind :range :min 0
+                                         :max out-max)
+                                   (list :name name :kind :range :min 0
+                                         :max 100))))))))
+      (let ((narrow (definition-digest (funcall api-for 100) 'widen nil))
+            (wide (definition-digest (funcall api-for 999) 'widen nil)))
+        (ok (stringp narrow))
+        (ok (not (string= narrow wide)))
+        (testing "and the same return spec still digests the same twice"
+          (ok (string= narrow (definition-digest (funcall api-for 100)
+                                                 'widen nil))))))))
+
 (deftest definition-digest-tolerates-unresolved-reference
   (testing "a reference to a spec that is not registered does not signal"
     (let ((api (make-cl-spec-api

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -557,6 +557,40 @@ thread sees the value the caller captured rather than the global one.")
       (ok (eq :invalid-arguments (getf report :status)))
       (ok (search "single" (string-downcase (getf report :message)))))))
 
+(deftest check-report-refuses-a-setting-the-run-cannot-honour
+  (testing "profile with function= is refused, not reported unused"
+    ;; cl-spec's CHECK-FUNCTION takes no profile and a contract has no :TRIALS
+    ;; table for one to select from, so publishing the caller's profile would
+    ;; name a setting the run never used -- the mirror of the trials refusal.
+    (let ((report (check-report (%stub-api) :ok
+                                :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD"
+                                :profile "thorough")))
+      (ok (eq :invalid-arguments (getf report :status)))
+      (ok (search "profile" (string-downcase (getf report :message))))))
+  (testing "trials with symbol= is refused the same way"
+    (let ((report (check-report (%stub-api) :ok
+                                :symbol "CL-MCP-SPEC-REPORT-FIXTURE:ADD"
+                                :trials 100)))
+      (ok (eq :invalid-arguments (getf report :status)))
+      (ok (search "trials" (string-downcase (getf report :message))))))
+  (testing "and neither waits on cl-spec to be loaded first"
+    ;; An argument that is wrong is wrong whatever cl-spec is doing; answering
+    ;; "cl-spec is not loaded" sends the caller to fix the wrong thing, then
+    ;; hands them the real complaint on the next call.
+    (let ((report (check-report nil :not-loaded :symbol "CL:CAR" :trials 100)))
+      (ok (eq :invalid-arguments (getf report :status)))
+      (ok (search "trials" (string-downcase (getf report :message))))))
+  (testing "while a profile on a property selection is honoured"
+    (let ((report (check-report
+                   (%api-with-run (lambda (&rest ignored)
+                                    (declare (ignore ignored))
+                                    (%result-stub)))
+                   :ok
+                   :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"
+                   :profile "thorough")))
+      (ok (eq :completed (getf report :status)))
+      (ok (eq :thorough (getf report :profile))))))
+
 (deftest check-report-digest-mismatch-is-loud
   (testing "an unexpected definition is reported as an unfaithful replay"
     (let ((report (check-report

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -627,6 +627,52 @@ listing functions are not -- the shape the blanket listing guard refused."
       (ok (eq :completed (getf report :status)))
       (ok (eq :thorough (getf report :profile))))))
 
+(deftest check-report-does-not-blame-itself-for-a-missing-function
+  (testing "a contract whose function is not defined says which fact that is"
+    ;; cl-spec's FUNCTION-SPEC-TARGET signals CL:UNDEFINED-FUNCTION on purpose,
+    ;; so that a project can adopt cl-spec one function at a time.  Read as
+    ;; :INTERNAL-ERROR -- documented as "this adapter failed" -- it told the
+    ;; caller cl-mcp was broken when they had simply not written the function.
+    (let* ((report (check-report
+                    (%api-with-run
+                     (lambda (&rest ignored)
+                       (declare (ignore ignored))
+                       (error 'undefined-function :name 'no-such-function)))
+                    :ok
+                    :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"))
+           (result (first (getf report :results))))
+      (ok (eq :undefined-function (getf result :status)))
+      (ok (not (eq :internal-error (getf result :status))))
+      (testing "and the call did not reach a verdict"
+        (ok (eq :incomplete (getf report :status)))
+        (ok (not (getf report :verified)))))))
+
+(deftest check-report-lists-an-unrun-contract-as-a-gap
+  (testing "the contract an :about selection left alone reaches the gap list"
+    ;; The headline says it; verification_gaps is the machine-readable half of
+    ;; the same statement, and a consumer branching on verified plus this list
+    ;; read full coverage for a function whose contract never ran.
+    (let* ((api (%api-with-run (lambda (&rest ignored)
+                                 (declare (ignore ignored))
+                                 (%result-stub))
+                               :semantic-data
+                               (lambda (symbol &key registry)
+                                 (declare (ignore registry))
+                                 (list :symbol symbol
+                                       :package (package-name
+                                                 (symbol-package symbol))
+                                       :spec nil :property nil
+                                       :function-spec (%sym "ADD")
+                                       :properties-about
+                                       (list (%sym "ADD-COMMUTES"))))))
+           (report (check-report api :ok
+                                 :symbol "CL-MCP-SPEC-REPORT-FIXTURE:ADD")))
+      (ok (member :contract-not-run (getf report :verification-gaps)))
+      (testing "and it is named in the selection as data, not only in prose"
+        (ok (string= "ADD" (getf (getf (getf report :selection)
+                                       :contract-not-run)
+                                 :name)))))))
+
 (deftest check-report-digest-mismatch-is-loud
   (testing "an unexpected definition is reported as an unfaithful replay"
     (let ((report (check-report

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -709,7 +709,35 @@ listing functions are not -- the shape the blanket listing guard refused."
         (ok (null (getf contract :effective-trials))))
       (ok (not (getf report :verified)))
       (ok (member :rejection-counts-unmeasured
-                  (getf report :verification-gaps))))))
+                  (getf report :verification-gaps)))
+      (testing "and the gap says the count is unknown, not that it was zero"
+        ;; zero-trials is documented as a budget that resolved to nothing.
+        ;; This run executed trials; only the correction is missing.
+        (ok (member :effective-trials-unknown
+                    (getf report :verification-gaps)))
+        (ok (not (member :zero-trials (getf report :verification-gaps)))))))
+  (testing "and a cl-spec with no refused-input reader verifies nothing either"
+    ;; The raw trial count is not a fallback: a :PRE that admits nothing still
+    ;; generates its full budget, so counting those would let a contract the
+    ;; function never saw report itself evaluated.
+    (let ((report (check-report
+                   (%api-with-run
+                    (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                    :check-function
+                    (lambda (&rest ignored)
+                      (declare (ignore ignored))
+                      (%result-stub :status :passed :trials 100))
+                    :function-spec-data
+                    (lambda (name &key registry)
+                      (declare (ignore registry))
+                      (list :name name :arguments nil
+                            :preconditions '((> value 1000)))))
+                   :ok
+                   :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD")))
+      (let ((contract (getf (first (getf report :results)) :contract)))
+        (ok (not (getf contract :rejected-measured)))
+        (ok (null (getf contract :effective-trials))))
+      (ok (not (getf report :verified))))))
 
 (deftest check-report-lists-an-unrun-contract-as-a-gap
   (testing "the contract an :about selection left alone reaches the gap list"
@@ -762,7 +790,34 @@ listing functions are not -- the shape the blanket listing guard refused."
         (ok (string= "ADD-COMMUTES" (getf (first left) :name))))
       (testing "and says so in a note rather than only in the coverage prose"
         (ok (find-if (lambda (note) (search "NOT covered" note))
-                     (getf (getf report :selection) :notes)))))))
+                     (getf (getf report :selection) :notes))))))
+  (testing "a lookup that failed is not an empty list of related properties"
+    ;; "nothing else is registered" and "this could not be read" are the
+    ;; distinction every other flag in this module carries.
+    (let ((report (check-report
+                   (%api-with-run
+                    (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                    :check-function
+                    (lambda (&rest ignored)
+                      (declare (ignore ignored))
+                      (%result-stub :status :passed))
+                    :check-rejected (lambda (result) (declare (ignore result)) 0)
+                    :semantic-data
+                    (lambda (symbol &key registry)
+                      (declare (ignore symbol registry))
+                      (error 'fixture-unknown-name))
+                    :function-spec-data
+                    (lambda (name &key registry)
+                      (declare (ignore registry))
+                      (list :name name :arguments nil :preconditions nil)))
+                   :ok
+                   :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD")))
+      (ok (null (getf (getf report :selection) :properties-not-run)))
+      (ok (not (getf (getf report :selection) :properties-not-run-read)))
+      (ok (member :related-properties-unknown
+                  (getf report :verification-gaps)))
+      (ok (not (member :properties-not-run
+                       (getf report :verification-gaps)))))))
 
 (deftest check-report-digest-mismatch-is-loud
   (testing "an unexpected definition is reported as an unfaithful replay"

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -375,6 +375,28 @@ thread sees the value the caller captured rather than the global one.")
                   (declare (ignore registry))
                   (when (eq tag :math) (list (%sym "ADD-COMMUTES"))))))))
 
+(defun %contract-listing-api ()
+  "Return a stub API that can enumerate contracts and nothing else.
+
+Stands for a cl-spec whose function-spec half is present while the older
+listing functions are not -- the shape the blanket listing guard refused."
+  (%stub-api :list-function-specs
+             (lambda (&optional registry)
+               (declare (ignore registry))
+               (list (%sym "ADD")))
+             :function-spec-data
+             (lambda (name &key registry)
+               (declare (ignore registry))
+               (list :name name
+                     :documentation "ADD stays inside SMALL-INT."
+                     :arguments (list (list :variable (%sym "A")
+                                            :spec (list :kind :reference
+                                                        :target (%sym "SMALL-INT"))))
+                     :returns (list :kind :reference
+                                    :target (%sym "SMALL-INT"))
+                     :preconditions nil
+                     :postconditions nil))))
+
 (deftest list-report-enumerates-what-is-registered
   (testing "both kinds come back with the property's discovery fields"
     (let ((report (list-report (%listing-api) :ok :kind "both")))
@@ -446,6 +468,20 @@ thread sees the value the caller captured rather than the global one.")
     (let ((report (list-report (%stub-api) :ok :kind "both")))
       (ok (eq :unsupported (getf report :status)))
       (ok (search "list-specs" (getf report :message))))))
+
+(deftest list-report-gates-on-what-the-kind-needs
+  (testing "a contract listing does not wait on the property listing API"
+    ;; kind=function-specs reads neither LIST-SPECS nor LIST-PROPERTIES, and
+    ;; the blanket guard predating it refused a listing it could produce --
+    ;; while reporting function_specs_listable true three keys later.
+    (let ((report (list-report (%contract-listing-api) :ok
+                               :kind "function-specs")))
+      (ok (eq :ok (getf report :status)))
+      (ok (getf report :function-specs-listable))
+      (ok (= 1 (length (getf report :function-specs))))))
+  (testing "while both still needs both"
+    (let ((report (list-report (%contract-listing-api) :ok :kind "both")))
+      (ok (eq :unsupported (getf report :status))))))
 
 (deftest list-report-rejects-an-unknown-kind
   (testing "kind is constrained"

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -479,9 +479,24 @@ listing functions are not -- the shape the blanket listing guard refused."
       (ok (eq :ok (getf report :status)))
       (ok (getf report :function-specs-listable))
       (ok (= 1 (length (getf report :function-specs))))))
-  (testing "while both still needs both"
+  (testing "and the default kind lists the half it can rather than refusing"
+    ;; "both" is what a caller gets with no arguments.  Failing it outright on
+    ;; a revision that can still enumerate contracts gave back the same
+    ;; "nothing can be enumerated" answer this gate exists to stop giving.
     (let ((report (list-report (%contract-listing-api) :ok :kind "both")))
-      (ok (eq :unsupported (getf report :status))))))
+      (ok (eq :ok (getf report :status)))
+      (ok (= 1 (length (getf report :function-specs))))
+      (testing "naming the halves it could not look at"
+        (ok (not (getf report :specs-listable)))
+        (ok (not (getf report :properties-listable)))
+        (testing "whose counts are null, not zero"
+          (ok (null (getf (getf report :counts) :specs)))
+          (ok (null (getf (getf report :counts) :properties)))
+          (ok (eql 1 (getf (getf report :counts) :function-specs)))))))
+  (testing "while a kind with no reachable half is still unsupported"
+    (let ((report (list-report (%contract-listing-api) :ok :kind "properties")))
+      (ok (eq :unsupported (getf report :status)))
+      (ok (search "list-properties" (getf report :message))))))
 
 (deftest list-report-rejects-an-unknown-kind
   (testing "kind is constrained"
@@ -628,11 +643,35 @@ listing functions are not -- the shape the blanket listing guard refused."
       (ok (eq :thorough (getf report :profile))))))
 
 (deftest check-report-does-not-blame-itself-for-a-missing-function
+  ;; cl-spec's FUNCTION-SPEC-TARGET signals CL:UNDEFINED-FUNCTION on purpose,
+  ;; so that a project can adopt cl-spec one function at a time.  Read as
+  ;; :INTERNAL-ERROR -- documented as "this adapter failed" -- it told the
+  ;; caller cl-mcp was broken when they had simply not written the function.
   (testing "a contract whose function is not defined says which fact that is"
-    ;; cl-spec's FUNCTION-SPEC-TARGET signals CL:UNDEFINED-FUNCTION on purpose,
-    ;; so that a project can adopt cl-spec one function at a time.  Read as
-    ;; :INTERNAL-ERROR -- documented as "this adapter failed" -- it told the
-    ;; caller cl-mcp was broken when they had simply not written the function.
+    ;; Driven through function=, the path that actually raises it: a property
+    ;; selection reaches the same clause by a different route and would leave
+    ;; the contract path untested.
+    (let* ((report (check-report
+                    (%api-with-run
+                     (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                     :check-function
+                     (lambda (&rest ignored)
+                       (declare (ignore ignored))
+                       (error 'undefined-function :name (%sym "ADD")))
+                     :function-spec-data
+                     (lambda (name &key registry)
+                       (declare (ignore registry))
+                       (list :name name :arguments nil :preconditions nil)))
+                    :ok
+                    :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD"))
+           (result (first (getf report :results))))
+      (ok (eq :contract (getf result :kind)))
+      (ok (eq :undefined-function (getf result :status)))
+      (ok (not (eq :internal-error (getf result :status))))
+      (testing "and the call did not reach a verdict"
+        (ok (eq :incomplete (getf report :status)))
+        (ok (not (getf report :verified))))))
+  (testing "a property body calling an undefined function reads the same way"
     (let* ((report (check-report
                     (%api-with-run
                      (lambda (&rest ignored)
@@ -641,11 +680,7 @@ listing functions are not -- the shape the blanket listing guard refused."
                     :ok
                     :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"))
            (result (first (getf report :results))))
-      (ok (eq :undefined-function (getf result :status)))
-      (ok (not (eq :internal-error (getf result :status))))
-      (testing "and the call did not reach a verdict"
-        (ok (eq :incomplete (getf report :status)))
-        (ok (not (getf report :verified)))))))
+      (ok (eq :undefined-function (getf result :status))))))
 
 (deftest check-report-lists-an-unrun-contract-as-a-gap
   (testing "the contract an :about selection left alone reaches the gap list"

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -762,7 +762,10 @@ listing functions are not -- the shape the blanket listing guard refused."
                     :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD"))
            (result (first (getf report :results))))
       (ok (not (eq :internal-error (getf result :status))))
-      (ok (eq :unmeasured (getf (getf result :contract) :rejection-status)))
+      ;; :TRIALS-UNCOUNTED, not :UNMEASURED: the refusal count was read and
+      ;; the trial count was not, and the two are different sentences.
+      (ok (eq :trials-uncounted
+              (getf (getf result :contract) :rejection-status)))
       (ok (null (getf (getf result :contract) :effective-trials)))
       (ok (not (getf report :verified)))))
   (testing "and a projection that came back NIL is not a readable contract"
@@ -792,9 +795,20 @@ listing functions are not -- the shape the blanket listing guard refused."
     ;; The headline says it; verification_gaps is the machine-readable half of
     ;; the same statement, and a consumer branching on verified plus this list
     ;; read full coverage for a function whose contract never ran.
+    ;; The stub has the contract API: this response tells the caller to run
+    ;; the contract, and it now names one only when this cl-spec could.
     (let* ((api (%api-with-run (lambda (&rest ignored)
                                  (declare (ignore ignored))
                                  (%result-stub))
+                               :check-function
+                               (lambda (&rest ignored)
+                                 (declare (ignore ignored))
+                                 (%result-stub))
+                               :function-spec-data
+                               (lambda (name &key registry)
+                                 (declare (ignore registry))
+                                 (list :name name :arguments nil
+                                       :preconditions nil))
                                :semantic-data
                                (lambda (symbol &key registry)
                                  (declare (ignore registry))

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -739,6 +739,54 @@ listing functions are not -- the shape the blanket listing guard refused."
         (ok (null (getf contract :effective-trials))))
       (ok (not (getf report :verified))))))
 
+(deftest check-report-survives-a-result-with-no-trial-count
+  (testing "a NIL trial count is reported, not subtracted"
+    ;; cl-spec writes (- (or (property-result-trials result) 0) rejected) in
+    ;; its own checker, so the count can be NIL.  Reached with no :pre, the
+    ;; adapter subtracted from it and the TYPE-ERROR came back to the caller
+    ;; as internal-error -- "this adapter failed" -- for a run cl-spec had
+    ;; completed.
+    (let* ((report (check-report
+                    (%api-with-run
+                     (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                     :check-function
+                     (lambda (&rest ignored)
+                       (declare (ignore ignored))
+                       (%result-stub :status :passed :trials nil))
+                     :check-rejected (lambda (result) (declare (ignore result)) 0)
+                     :function-spec-data
+                     (lambda (name &key registry)
+                       (declare (ignore registry))
+                       (list :name name :arguments nil :preconditions nil)))
+                    :ok
+                    :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD"))
+           (result (first (getf report :results))))
+      (ok (not (eq :internal-error (getf result :status))))
+      (ok (eq :unmeasured (getf (getf result :contract) :rejection-status)))
+      (ok (null (getf (getf result :contract) :effective-trials)))
+      (ok (not (getf report :verified)))))
+  (testing "and a projection that came back NIL is not a readable contract"
+    ;; Read as a real answer it produced four positive claims -- no :pre,
+    ;; every input passed, a usable count, an effective trial count -- and a
+    ;; verified verdict resting on them.
+    (let* ((report (check-report
+                    (%api-with-run
+                     (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                     :check-function
+                     (lambda (&rest ignored)
+                       (declare (ignore ignored))
+                       (%result-stub :status :passed :trials 100))
+                     :check-rejected (lambda (result) (declare (ignore result)) 0)
+                     :function-spec-data
+                     (lambda (name &key registry)
+                       (declare (ignore name registry))
+                       nil))
+                    :ok
+                    :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD"))
+           (result (first (getf report :results))))
+      (ok (eq :unknown (getf (getf result :contract) :precondition-p)))
+      (ok (not (getf report :verified))))))
+
 (deftest check-report-lists-an-unrun-contract-as-a-gap
   (testing "the contract an :about selection left alone reaches the gap list"
     ;; The headline says it; verification_gaps is the machine-readable half of

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -682,6 +682,35 @@ listing functions are not -- the shape the blanket listing guard refused."
            (result (first (getf report :results))))
       (ok (eq :undefined-function (getf result :status))))))
 
+(deftest check-report-will-not-verify-an-uncountable-contract-run
+  (testing "more refusals than trials is not evidence, in either gate"
+    ;; %CONTRACT-PLIST withholds effective_trials for this case and the text
+    ;; says the call count cannot be derived.  %EVALUATED-P used to fall back
+    ;; to the raw trial count -- the number the rejection count exists to
+    ;; correct -- so verified came back true for a run the same response
+    ;; declared unmeasurable, and the gap list said nothing at all.
+    (let ((report (check-report
+                   (%api-with-run
+                    (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                    :check-function
+                    (lambda (&rest ignored)
+                      (declare (ignore ignored))
+                      (%result-stub :status :passed :trials 1))
+                    :check-rejected (lambda (result) (declare (ignore result)) 2)
+                    :function-spec-data
+                    (lambda (name &key registry)
+                      (declare (ignore registry))
+                      (list :name name :arguments nil
+                            :preconditions '((> value 0)))))
+                   :ok
+                   :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD")))
+      (let ((contract (getf (first (getf report :results)) :contract)))
+        (ok (getf contract :rejected-overcounted))
+        (ok (null (getf contract :effective-trials))))
+      (ok (not (getf report :verified)))
+      (ok (member :rejection-counts-unmeasured
+                  (getf report :verification-gaps))))))
+
 (deftest check-report-lists-an-unrun-contract-as-a-gap
   (testing "the contract an :about selection left alone reaches the gap list"
     ;; The headline says it; verification_gaps is the machine-readable half of
@@ -707,6 +736,33 @@ listing functions are not -- the shape the blanket listing guard refused."
         (ok (string= "ADD" (getf (getf (getf report :selection)
                                        :contract-not-run)
                                  :name)))))))
+
+(deftest check-report-lists-the-properties-a-contract-run-left-alone
+  (testing "function= names the properties it did not run, both ways"
+    ;; The mirror of :CONTRACT-NOT-RUN. A contract that holds is not a clean
+    ;; bill for a function whose properties were never run, and the argument
+    ;; for putting one direction in the gap list is the argument for the other.
+    (let ((report (check-report
+                   (%api-with-run
+                    (lambda (&rest ignored) (declare (ignore ignored)) nil)
+                    :check-function
+                    (lambda (&rest ignored)
+                      (declare (ignore ignored))
+                      (%result-stub :status :passed))
+                    :check-rejected (lambda (result) (declare (ignore result)) 0)
+                    :function-spec-data
+                    (lambda (name &key registry)
+                      (declare (ignore registry))
+                      (list :name name :arguments nil :preconditions nil)))
+                   :ok
+                   :function "CL-MCP-SPEC-REPORT-FIXTURE:ADD")))
+      (ok (member :properties-not-run (getf report :verification-gaps)))
+      (let ((left (getf (getf report :selection) :properties-not-run)))
+        (ok (= 1 (length left)))
+        (ok (string= "ADD-COMMUTES" (getf (first left) :name))))
+      (testing "and says so in a note rather than only in the coverage prose"
+        (ok (find-if (lambda (note) (search "NOT covered" note))
+                     (getf (getf report :selection) :notes)))))))
 
 (deftest check-report-digest-mismatch-is-loud
   (testing "an unexpected definition is reported as an unfaithful replay"

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -32,17 +32,37 @@ cl-spec-facing behaviour is covered by tests/spec-adapter-report-test.lisp
 with stub API handles; this file needs the real system."
   "Printed instead of running, so an absent cl-spec is visible rather than silent.")
 
+(defun %backend-installed-p ()
+  "Return true when CL-SPEC is present with a generator backend installed.
+
+The backend, not the package: cl-spec loads without one, and introspection
+works while nothing can be executed.  This file runs properties, so the
+package alone is not the question it needs answered."
+  (let ((package (find-package "CL-SPEC")))
+    (when package
+      (let ((backend (find-symbol "*GENERATOR-BACKEND*" "CL-SPEC")))
+        (and backend (boundp backend) (symbol-value backend) t)))))
+
 (defun %cl-spec-available-p ()
-  "Return true when cl-spec/check-it can be loaded into this image."
+  "Return true when cl-spec/check-it is usable in this image.
+
+The load is attempted whenever the backend is missing, not only when the
+CL-SPEC package is absent.  Gated on the package, an image that had loaded
+plain cl-spec -- no backend -- never reached the load, every test in this file
+skipped, and the suite reported itself green: the file's own coverage depended
+on which system happened to be quickloaded first, and a claim that these tests
+ran was a claim about load order rather than about the code.
+
+Called once per test and cheap after the first: ASDF answers a loaded system
+without recompiling, and the answer here is the backend, which either got
+installed or did not."
   (handler-case
       (progn
-        (unless (find-package "CL-SPEC")
+        (unless (%backend-installed-p)
           (let ((*standard-output* (make-broadcast-stream))
                 (*error-output* (make-broadcast-stream)))
             (asdf:load-system "cl-spec/check-it")))
-        (and (find-package "CL-SPEC")
-             (symbol-value (find-symbol "*GENERATOR-BACKEND*" "CL-SPEC"))
-             t))
+        (%backend-installed-p))
     (error () nil)))
 
 (defparameter +no-contracts-reason+
@@ -55,21 +75,21 @@ covered by tests/spec-adapter-report-test.lisp."
 (defun %contracts-available-p ()
   "Return true when the fixture registered its contracts in this image.
 
-Asks the fixture's own predicate rather than carrying a second copy of it.
-The two decide the same thing -- whether this cl-spec implements function
-specs -- and the fixture is the half that acts on the answer, so a copy here
-that drifted would skip the tests while the contracts loaded, or run them
-while the file left them out, and the skip reason would say the opposite of
-what the registry holds.
+Asks the fixture rather than carrying a second copy of the discriminator, and
+asks it the question these tests need answered: not whether this cl-spec has
+the function-spec API, but whether the definitions are in the registry.  The
+two differ when DEFSPEC-FUNCTION exists and signals -- the fixture reports
+that and keeps its other half -- and a predicate that only checked the API
+would then run contract tests against an empty registry and blame the adapter.
 
 Loading the fixture first is safe whatever the answer: the contract half lives
 in a file of its own precisely so that an older cl-spec leaves it unread."
   (and (%cl-spec-available-p)
        (progn
          (%ensure-fixture)
-         (let ((supported (find-symbol "FUNCTION-SPECS-SUPPORTED-P"
-                                       "CL-MCP/TESTS/FIXTURES/SPEC-FIXTURE")))
-           (and supported (fboundp supported) (funcall supported) t)))))
+         (let ((registered (find-symbol "CONTRACTS-REGISTERED-P"
+                                        "CL-MCP/TESTS/FIXTURES/SPEC-FIXTURE")))
+           (and registered (fboundp registered) (funcall registered) t)))))
 
 (defun %registry-symbol ()
   "Return the CL-SPEC:*REGISTRY* symbol."

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -53,14 +53,23 @@ covered by tests/spec-adapter-report-test.lisp."
   "Printed instead of running the contract tests against a cl-spec that has none.")
 
 (defun %contracts-available-p ()
-  "Return true when the loaded cl-spec implements function specs.
+  "Return true when the fixture registered its contracts in this image.
 
-FUNCTION-SPEC-DATA is the discriminator, not CHECK-FUNCTION: a cl-spec that
-predates function specs still has CHECK-FUNCTION fbound, as a stub that
-signals NOT-IMPLEMENTED."
+Asks the fixture's own predicate rather than carrying a second copy of it.
+The two decide the same thing -- whether this cl-spec implements function
+specs -- and the fixture is the half that acts on the answer, so a copy here
+that drifted would skip the tests while the contracts loaded, or run them
+while the file left them out, and the skip reason would say the opposite of
+what the registry holds.
+
+Loading the fixture first is safe whatever the answer: the contract half lives
+in a file of its own precisely so that an older cl-spec leaves it unread."
   (and (%cl-spec-available-p)
-       (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
-         (and data (fboundp data) t))))
+       (progn
+         (%ensure-fixture)
+         (let ((supported (find-symbol "FUNCTION-SPECS-SUPPORTED-P"
+                                       "CL-MCP/TESTS/FIXTURES/SPEC-FIXTURE")))
+           (and supported (fboundp supported) (funcall supported) t)))))
 
 (defun %registry-symbol ()
   "Return the CL-SPEC:*REGISTRY* symbol."

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -32,6 +32,9 @@ cl-spec-facing behaviour is covered by tests/spec-adapter-report-test.lisp
 with stub API handles; this file needs the real system."
   "Printed instead of running, so an absent cl-spec is visible rather than silent.")
 
+(defvar *backend-load-attempted* nil
+  "Set once the cl-spec/check-it load has been tried in this image.")
+
 (defun %backend-installed-p ()
   "Return true when CL-SPEC is present with a generator backend installed.
 
@@ -56,14 +59,23 @@ ran was a claim about load order rather than about the code.
 Called once per test and cheap after the first: ASDF answers a loaded system
 without recompiling, and the answer here is the backend, which either got
 installed or did not."
-  (handler-case
-      (progn
-        (unless (%backend-installed-p)
-          (let ((*standard-output* (make-broadcast-stream))
-                (*error-output* (make-broadcast-stream)))
-            (asdf:load-system "cl-spec/check-it")))
-        (%backend-installed-p))
-    (error () nil)))
+  (case *backend-load-attempted*
+    ((:done) (%backend-installed-p))
+    (t
+     (handler-case
+         (progn
+           (unless (%backend-installed-p)
+             (let ((*standard-output* (make-broadcast-stream))
+                   (*error-output* (make-broadcast-stream)))
+               (asdf:load-system "cl-spec/check-it")))
+           (setf *backend-load-attempted* :done)
+           (%backend-installed-p))
+       (error ()
+         ;; Remembered, so a machine without cl-spec/check-it pays one failed
+         ;; ASDF resolution rather than one per test.  The success path is
+         ;; cheap on its own; this is the path the rewrite was for.
+         (setf *backend-load-attempted* :done)
+         nil)))))
 
 (defparameter +no-contracts-reason+
   "the cl-spec in this image predates function specs: it exports no

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -99,9 +99,16 @@ in a file of its own precisely so that an older cl-spec leaves it unread."
   (and (%cl-spec-available-p)
        (progn
          (%ensure-fixture)
+         ;; Asked about the shared registry by name.  These tests read the
+         ;; answer outside WITH-FIXTURE-REGISTRY, where the installed registry
+         ;; is the global one, and another test loads a private copy of the
+         ;; fixture -- so the question has to name which registry it is about.
          (let ((registered (find-symbol "CONTRACTS-REGISTERED-P"
                                         "CL-MCP/TESTS/FIXTURES/SPEC-FIXTURE")))
-           (and registered (fboundp registered) (funcall registered) t)))))
+           (and registered
+                (fboundp registered)
+                (funcall registered *fixture-registry*)
+                t)))))
 
 (defun %registry-symbol ()
   "Return the CL-SPEC:*REGISTRY* symbol."

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -45,6 +45,23 @@ with stub API handles; this file needs the real system."
              t))
     (error () nil)))
 
+(defparameter +no-contracts-reason+
+  "the cl-spec in this image predates function specs: it exports no
+function-spec-data, so there is no contract to describe or run. The adapter's
+own answer to that -- an unsupported status naming the missing API -- is
+covered by tests/spec-adapter-report-test.lisp."
+  "Printed instead of running the contract tests against a cl-spec that has none.")
+
+(defun %contracts-available-p ()
+  "Return true when the loaded cl-spec implements function specs.
+
+FUNCTION-SPEC-DATA is the discriminator, not CHECK-FUNCTION: a cl-spec that
+predates function specs still has CHECK-FUNCTION fbound, as a stub that
+signals NOT-IMPLEMENTED."
+  (and (%cl-spec-available-p)
+       (let ((data (find-symbol "FUNCTION-SPEC-DATA" "CL-SPEC")))
+         (and data (fboundp data) t))))
+
 (defun %registry-symbol ()
   "Return the CL-SPEC:*REGISTRY* symbol."
   (find-symbol "*REGISTRY*" "CL-SPEC"))
@@ -234,8 +251,8 @@ reached the caller."
                                     (gethash "definition_digest" after-result))))))))))))
 
 (deftest cl-spec-adapter-reads-a-contract
-  (if (not (%cl-spec-available-p))
-      (skip +skip-reason+)
+  (if (not (%contracts-available-p))
+      (skip (if (%cl-spec-available-p) +no-contracts-reason+ +skip-reason+))
       (progn
         (%ensure-fixture)
         (with-fixture-registry
@@ -273,8 +290,8 @@ reached the caller."
                 (ok (search "RESULT" text)))))))))
 
 (deftest cl-spec-adapter-runs-a-contract
-  (if (not (%cl-spec-available-p))
-      (skip +skip-reason+)
+  (if (not (%contracts-available-p))
+      (skip (if (%cl-spec-available-p) +no-contracts-reason+ +skip-reason+))
       (progn
         (%ensure-fixture)
         (with-fixture-registry

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -328,11 +328,20 @@ reached the caller."
               (ok (eql 0 (gethash "effective_trials" (gethash "contract" result))))))
 
           (testing "an :about selection does not quietly run the contract"
-            (let ((response (spec-check-response
-                             (make-ht "symbol" (%fixture-name "CLAMP")))))
+            (let* ((response (spec-check-response
+                              (make-ht "symbol" (%fixture-name "CLAMP"))))
+                   (text (%text response))
+                   (headline (subseq text 0 (or (position #\Newline text)
+                                                (length text)))))
               (ok (every (lambda (result) (string= "property" (gethash "kind" result)))
                          (gethash "results" response)))
-              (ok (search "was NOT run" (%text response)))))
+              (testing "and the first line says so, where a reader who stops will see it"
+                (ok (search "properties only" headline))
+                (ok (search "NOT run" headline))
+                (ok (string= "CLAMP"
+                             (gethash "name"
+                                      (gethash "contract_not_run"
+                                               (gethash "selection" response))))))))
 
           (testing "trials without a contract is refused rather than ignored"
             (let ((response (spec-check-response

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -16,7 +16,8 @@
   (:import-from #:cl-mcp/src/tools/spec-entry
                 #:spec-symbol-response
                 #:spec-describe-response
-                #:spec-check-response)
+                #:spec-check-response
+                #:spec-list-response)
   (:import-from #:cl-mcp/src/tools/helpers
                 #:make-ht))
 
@@ -82,6 +83,17 @@ two paths agreeing whichever one a test exercises."
 (defun %first-result (response)
   "Return the first per-property result of a spec-check RESPONSE."
   (aref (gethash "results" response) 0))
+
+(defun %text (response)
+  "Return the text an MCP client would show for RESPONSE.
+
+Asserted on rather than only the payload: a client that renders content[].text
+sees this and nothing else, so a fact that reaches the payload alone has not
+reached the caller."
+  (let ((content (gethash "content" response)))
+    (if (and content (plusp (length content)))
+        (gethash "text" (aref content 0))
+        "")))
 
 (deftest cl-spec-adapter-discovers-and-describes
   (if (not (%cl-spec-available-p))
@@ -212,3 +224,110 @@ two paths agreeing whichever one a test exercises."
                 (testing "and the digest moved, so an old seed is not faithful"
                   (ok (not (string= before-digest
                                     (gethash "definition_digest" after-result))))))))))))
+
+(deftest cl-spec-adapter-reads-a-contract
+  (if (not (%cl-spec-available-p))
+      (skip +skip-reason+)
+      (progn
+        (%ensure-fixture)
+        (with-fixture-registry
+          (testing "spec-symbol says a contract exists and how to reach it"
+            (let ((response (spec-symbol-response
+                             (make-ht "symbol" (%fixture-name "CLAMP")))))
+              (ok (string= "CLAMP"
+                           (gethash "name"
+                                    (gethash "function_spec"
+                                             (gethash "registry" response)))))
+              (ok (search "spec-describe kind=function-spec" (%text response)))))
+
+          (testing "spec-describe projects which inputs it takes and what it returns"
+            (let* ((response (spec-describe-response
+                              (make-ht "kind" "function-spec"
+                                       "name" (%fixture-name "CLAMP"))))
+                   (text (%text response)))
+              (ok (string= "ok" (gethash "status" response)))
+              (ok (= 3 (length (gethash "arguments" response))))
+              (ok (gethash "returns" response))
+              (ok (search "SMALL-INT" text))
+              (testing "and the :pre and :post forms are shown, not only stored"
+                (ok (search ":pre" text))
+                (ok (search ":post" text))
+                (ok (search "RESULT" text)))))))))
+
+(deftest cl-spec-adapter-runs-a-contract
+  (if (not (%cl-spec-available-p))
+      (skip +skip-reason+)
+      (progn
+        (%ensure-fixture)
+        (with-fixture-registry
+          (testing "a contract that holds is verified, with its rejections counted"
+            (let* ((response (spec-check-response
+                              (make-ht "function" (%fixture-name "CLAMP")
+                                       "trials" 200)))
+                   (result (%first-result response))
+                   (contract (gethash "contract" result)))
+              (ok (string= "completed" (gethash "status" response)))
+              (ok (eq t (gethash "verified" response)))
+              (ok (string= "contract" (gethash "kind" result)))
+              (ok (= 200 (gethash "budget" (gethash "trials" result))))
+              (ok (string= "requested" (gethash "budget_source"
+                                                (gethash "trials" result))))
+              (testing "the run says how many inputs :pre refused"
+                (ok (eq t (gethash "rejected_measured" contract)))
+                (ok (integerp (gethash "rejected" contract)))
+                (ok (plusp (gethash "rejected" contract)))
+                (ok (= (gethash "effective_trials" contract)
+                       (- (gethash "executed" (gethash "trials" result))
+                          (gethash "rejected" contract)))))
+              (testing "and does not claim rejections are unmeasured"
+                (ok (not (find "rejection-counts-unmeasured"
+                               (gethash "verification_gaps" response)
+                               :test #'string=))))))
+
+          (testing "a contract that is broken names which half broke"
+            (let* ((response (spec-check-response
+                              (make-ht "function" (%fixture-name "WIDEN")
+                                       "trials" 300)))
+                   (result (%first-result response))
+                   (contract (gethash "contract" result)))
+              (ok (eq yason:false (gethash "verified" response)))
+              (ok (string= "failed" (gethash "status" result)))
+              (ok (plusp (length (gethash "counterexample" result))))
+              (ok (string= "return-spec" (gethash "failure_reason" contract)))
+              (testing "with cl-spec's account of the value that missed its spec"
+                (ok (stringp (gethash "explanation" contract))))))
+
+          (testing "a contract nothing could call is skipped, never verified"
+            ;; The zero-count success: every generated input refused, so the
+            ;; function was never called and there is nothing to have verified.
+            (let* ((response (spec-check-response
+                              (make-ht "function" (%fixture-name "NEVER-CALLABLE")
+                                       "trials" 30)))
+                   (result (%first-result response)))
+              (ok (eq yason:false (gethash "verified" response)))
+              (ok (string= "skipped" (gethash "status" result)))
+              (ok (= 30 (gethash "rejected" (gethash "contract" result))))
+              (ok (eql 0 (gethash "effective_trials" (gethash "contract" result))))))
+
+          (testing "an :about selection does not quietly run the contract"
+            (let ((response (spec-check-response
+                             (make-ht "symbol" (%fixture-name "CLAMP")))))
+              (ok (every (lambda (result) (string= "property" (gethash "kind" result)))
+                         (gethash "results" response)))
+              (ok (search "was NOT run" (%text response)))))
+
+          (testing "trials without a contract is refused rather than ignored"
+            (let ((response (spec-check-response
+                             (make-ht "symbol" (%fixture-name "CLAMP")
+                                      "trials" 10))))
+              (ok (string= "invalid-arguments" (gethash "status" response)))
+              (ok (search "function=" (%text response)))))
+
+          (testing "spec-list enumerates contracts as their own kind"
+            (let* ((response (spec-list-response (make-ht "kind" "function-specs")))
+                   (text (%text response)))
+              (ok (string= "ok" (gethash "status" response)))
+              (ok (eq t (gethash "function_specs_listable" response)))
+              (ok (= 3 (gethash "function_specs" (gethash "counts" response))))
+              (ok (search "function specs:" text))
+              (ok (search "CLAMP" text))))))))

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -49,24 +49,28 @@ with stub API handles; this file needs the real system."
   "Return the CL-SPEC:*REGISTRY* symbol."
   (find-symbol "*REGISTRY*" "CL-SPEC"))
 
-(defun %ensure-fixture ()
-  "Load the fixture into a registry of its own, once.
+(defun %load-fixture ()
+  "Load the fixture into a registry of its own and return that registry.
 
 The global registry is swapped rather than rebound: the run thread a deadline
 spawns does not inherit dynamic bindings, and the adapter reads the registry
 on the calling thread precisely so it can hand it across.  Swapping keeps the
 two paths agreeing whichever one a test exercises."
+  (let* ((registry-symbol (%registry-symbol))
+         (make (find-symbol "MAKE-HASH-TABLE-REGISTRY" "CL-SPEC"))
+         (previous (symbol-value registry-symbol))
+         (fresh (funcall make)))
+    (setf (symbol-value registry-symbol) fresh)
+    (unwind-protect
+         (load (merge-pathnames "tests/fixtures/spec-fixture.lisp"
+                                (asdf:system-source-directory "cl-mcp")))
+      (setf (symbol-value registry-symbol) previous))
+    fresh))
+
+(defun %ensure-fixture ()
+  "Load the shared fixture registry, once."
   (unless *fixture-registry*
-    (let* ((registry-symbol (%registry-symbol))
-           (make (find-symbol "MAKE-HASH-TABLE-REGISTRY" "CL-SPEC"))
-           (previous (symbol-value registry-symbol))
-           (fresh (funcall make)))
-      (setf (symbol-value registry-symbol) fresh)
-      (unwind-protect
-           (load (merge-pathnames "tests/fixtures/spec-fixture.lisp"
-                                  (asdf:system-source-directory "cl-mcp")))
-        (setf (symbol-value registry-symbol) previous))
-      (setf *fixture-registry* fresh))))
+    (setf *fixture-registry* (%load-fixture))))
 
 (defmacro with-fixture-registry (&body body)
   "Run BODY with the fixture's registry installed as CL-SPEC:*REGISTRY*."
@@ -201,8 +205,12 @@ reached the caller."
 (deftest cl-spec-adapter-sees-a-redefinition
   (if (not (%cl-spec-available-p))
       (skip +skip-reason+)
-      (progn
-        (%ensure-fixture)
+      ;; A registry of its own, not the shared one.  This test replaces one of
+      ;; the fixture's properties with a corrected version, and the shared
+      ;; registry would carry that replacement into whichever test ran next --
+      ;; which is what happens when the suite is run twice in one image: the
+      ;; property written to fail passes, and four other tests fail with it.
+      (let ((*fixture-registry* (%load-fixture)))
         (with-fixture-registry
           (testing "re-registering a property changes its digest and its verdict"
             (let* ((before (spec-check-response

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -248,6 +248,16 @@ reached the caller."
                                              (gethash "registry" response)))))
               (ok (search "spec-describe kind=function-spec" (%text response)))))
 
+          (testing "an open range end reads as the * the author wrote"
+            ;; cl-spec spells it :UNBOUNDED internally. Printing the keyword
+            ;; puts an IR detail in front of a reader who wrote * and will
+            ;; write * again.
+            (let ((text (%text (spec-describe-response
+                                (make-ht "kind" "function-spec"
+                                         "name" (%fixture-name "MAGNITUDE"))))))
+              (ok (search "[0, *]" text))
+              (ok (not (search "UNBOUNDED" text)))))
+
           (testing "spec-describe projects which inputs it takes and what it returns"
             (let* ((response (spec-describe-response
                               (make-ht "kind" "function-spec"
@@ -366,6 +376,11 @@ reached the caller."
                    (text (%text response)))
               (ok (string= "ok" (gethash "status" response)))
               (ok (eq t (gethash "function_specs_listable" response)))
-              (ok (= 3 (gethash "function_specs" (gethash "counts" response))))
+              ;; The count is what the registry holds, not a magic number:
+              ;; asserted against the listing beside it so adding a fixture
+              ;; contract does not make this a puzzle to re-derive.
+              (ok (<= 4 (gethash "function_specs" (gethash "counts" response))))
+              (ok (= (length (gethash "function_specs" response))
+                     (gethash "function_specs" (gethash "counts" response))))
               (ok (search "function specs:" text))
               (ok (search "CLAMP" text))))))))

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -353,8 +353,13 @@ reached the caller."
               (ok (eq t (gethash "verified" response)))
               (ok (string= "contract" (gethash "kind" result)))
               (ok (= 200 (gethash "budget" (gethash "trials" result))))
-              (ok (string= "requested" (gethash "budget_source"
-                                                (gethash "trials" result))))
+              (testing "and the budget comes off cl-spec's own result"
+                ;; Not the adapter's reconstruction: check-function records
+                ;; the budget the run was given, so the derivation note does
+                ;; not apply to a contract run.
+                (ok (string= "cl-spec result"
+                             (gethash "budget_source"
+                                      (gethash "trials" result)))))
               (testing "the run says how many inputs :pre refused"
                 (ok (eq t (gethash "rejected_measured" contract)))
                 (ok (integerp (gethash "rejected" contract)))

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -323,6 +323,36 @@ reached the caller."
               (ok (string= "invalid-arguments" (gethash "status" response)))
               (ok (search "function=" (%text response)))))
 
+          (testing "the replay line for a contract is a call that would work"
+            ;; Printed as spec-check property=<name>, following it verbatim
+            ;; asks for a property that does not exist -- and without the
+            ;; budget, a failure found at 300 trials need not reappear at the
+            ;; backend default.
+            (let* ((response (spec-check-response
+                              (make-ht "function" (%fixture-name "WIDEN")
+                                       "trials" 300)))
+                   (text (%text response)))
+              (ok (search "Replay: spec-check function=" text))
+              (ok (not (search "Replay: spec-check property=" text)))
+              (ok (search "trials=300" text))))
+
+          (testing "the selection line calls a contract a contract"
+            (let ((text (%text (spec-check-response
+                                (make-ht "function" (%fixture-name "CLAMP")
+                                         "trials" 20)))))
+              (ok (search "Selected 1 contract" text))
+              (ok (not (search "Selected 1 property" text)))))
+
+          (testing "a symbol whose only registration is a contract still says so"
+            ;; The caller asked about the symbol and got "nothing ran". If the
+            ;; contract is not named here they have no reason to look further.
+            (let* ((response (spec-check-response
+                              (make-ht "symbol" (%fixture-name "NEVER-CALLABLE"))))
+                   (text (%text response)))
+              (ok (string= "no-properties" (gethash "status" response)))
+              (ok (search "function spec is registered" text))
+              (ok (search "function=" text))))
+
           (testing "spec-list enumerates contracts as their own kind"
             (let* ((response (spec-list-response (make-ht "kind" "function-specs")))
                    (text (%text response)))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -45,7 +45,10 @@
   "Return a completed contract check report whose single result failed."
   (list :status :completed
         :verified nil
-        :selection (list :mode "function" :count 1
+        ;; "contract", the mode %SELECT-NAMED actually emits for a function
+        ;; selection -- %SELECTION-NOUN keys on it, and "function" here sent
+        ;; every test built on this fixture down the property branch.
+        :selection (list :mode "contract" :count 1
                          :selected (list (%symbol-data "PROBE" "WIDEN"))
                          :source "explicit function argument"
                          :coverage "Only the contract named.")
@@ -62,7 +65,10 @@
                                     :failure-reason failure-reason
                                     :failure-reason-readable
                                     failure-reason-readable)
-                    :seed "7" :profile :normal
+                    ;; No :PROFILE: a contract run has none, and production
+                    ;; now leaves the key out rather than publishing the
+                    ;; :NORMAL that leaks off cl-spec's synthetic property.
+                    :seed "7"
                     :counterexample nil
                     :counterexample-status :present
                     :shrunk-counterexample nil
@@ -744,7 +750,7 @@
     ;; function was called -1 times".
     (let* ((response (build-spec-check-response
                       (%contract-check-report :rejected 2
-                                              :effective-trials 0
+                                              :effective-trials nil
                                               :rejected-overcounted t
                                               :failure-reason :condition
                                               :failure-reason-readable t)))
@@ -753,7 +759,15 @@
       (ok (eq t (gethash "rejected_overcounted" contract)))
       (ok (search "more refusals than trials" text))
       (ok (not (search "-1" text)))
-      (ok (not (search "called 0 time" text)))))
+      (ok (not (search "called 0 time" text)))
+      (testing "and the JSON withholds the figure rather than saying zero"
+        ;; 0 is itself the claim the text refuses to make.
+        (ok (null (gethash "effective_trials" contract))))
+      (testing "while the line calls a contract a contract"
+        (ok (search "Selected 1 contract" text))
+        (ok (not (search "Selected 1 property" text))))
+      (testing "and prints no profile, which a contract run does not have"
+        (ok (not (search "profile:" text))))))
   (testing "and an ordinary count still reads as one"
     (let ((text (first-text
                  (build-spec-check-response

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -42,7 +42,8 @@
 (defun %contract-check-report (&key failure-reason failure-reason-readable
                                     rejected-overcounted (rejected 3)
                                     (effective-trials 27)
-                                    (precondition-p t))
+                                    (precondition-p t)
+                                    (rejection-status :usable))
   "Return a completed contract check report whose single result failed."
   (list :status :completed
         :verified nil
@@ -60,6 +61,7 @@
                     :trials (list :executed 30 :budget 30
                                   :budget-source "requested")
                     :contract (list :rejected rejected
+                                    :rejection-status rejection-status
                                     :precondition-p precondition-p
                                     :rejected-measured t
                                     :rejected-overcounted rejected-overcounted
@@ -833,6 +835,7 @@
     (let* ((response (build-spec-check-response
                       (%contract-check-report :rejected 2
                                               :effective-trials nil
+                                              :rejection-status :overcounted
                                               :rejected-overcounted t
                                               :failure-reason :condition
                                               :failure-reason-readable t)))
@@ -866,6 +869,7 @@
     ;; trials on the strength of a number that cannot mean anything.
     (let* ((response (build-spec-check-response
                       (%contract-check-report :precondition-p nil
+                                              :rejection-status :no-precondition
                                               :rejected 0
                                               :effective-trials 30
                                               :failure-reason :postcondition

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -39,6 +39,36 @@
   (list :package package :name name
         :qualified (format nil "~A::~A" package name)))
 
+(defun %contract-check-report (&key failure-reason failure-reason-readable)
+  "Return a completed contract check report whose single result failed."
+  (list :status :completed
+        :verified nil
+        :selection (list :mode "function" :count 1
+                         :selected (list (%symbol-data "PROBE" "WIDEN"))
+                         :source "explicit function argument"
+                         :coverage "Only the contract named.")
+        :results
+        (list (list :property (%symbol-data "PROBE" "WIDEN")
+                    :kind :contract
+                    :status :failed
+                    :trials (list :executed 30 :budget 30
+                                  :budget-source "requested")
+                    :contract (list :rejected 3
+                                    :rejected-measured t
+                                    :effective-trials 27
+                                    :failure-reason failure-reason
+                                    :failure-reason-readable
+                                    failure-reason-readable)
+                    :seed "7" :profile :normal
+                    :counterexample nil
+                    :counterexample-status :present
+                    :shrunk-counterexample nil
+                    :shrink-status :present
+                    :definition-match :not-checked))
+        :counts (list :selected 1 :passed 0 :failed 1
+                      :errored 0 :timed-out 0 :not-run 0)
+        :environment *environment*))
+
 (deftest not-loaded-response-says-what-to-load
   (testing "the cl-spec-not-loaded answer is actionable in the text itself"
     (let* ((response (build-spec-symbol-response
@@ -629,3 +659,50 @@
            (counts (gethash "counts" response)))
       (ok (null (gethash "specs" counts)))
       (ok (eql 0 (gethash "properties" counts))))))
+
+(deftest check-response-unsupported-reaches-the-text
+  (testing "a contract cl-spec cannot run says so where a client can see it"
+    ;; The report carries a message and no selection, results or counts.  Read
+    ;; as a report of a run it renders "Selected NIL properties via NIL" and
+    ;; the one thing the caller needs -- why nothing could be executed --
+    ;; never reaches content[].text.
+    (let* ((response (build-spec-check-response
+                      (list :status :unsupported
+                            :verified nil
+                            :message
+                            (concatenate 'string
+                                         "the cl-spec loaded here does not "
+                                         "export check-function, so a "
+                                         "contract cannot be executed.")
+                            :environment *environment*)))
+           (text (first-text response)))
+      (ok (string= "unsupported" (gethash "status" response)))
+      (ok (eq yason:false (gethash "verified" response)))
+      (ok (search "check-function" text))
+      (ok (not (search "Selected" text))))))
+
+(deftest check-response-does-not-invent-non-determinism
+  (testing "an unreadable failure reason is not a finding about the function"
+    ;; NIL reaches the renderer from two opposite places: cl-spec saying the
+    ;; counterexample would not reproduce, and this adapter never having had a
+    ;; reader to ask.  Printing the first for both accuses the caller's code.
+    (let ((text (first-text
+                 (build-spec-check-response
+                  (%contract-check-report :failure-reason nil
+                                          :failure-reason-readable nil)))))
+      (ok (search "could not be read" text))
+      (ok (not (search "not deterministic" text)))))
+  (testing "but cl-spec's own silence still is one"
+    (let ((text (first-text
+                 (build-spec-check-response
+                  (%contract-check-report :failure-reason nil
+                                          :failure-reason-readable t)))))
+      (ok (search "not deterministic" text))))
+  (testing "and a reason that was read is printed as itself"
+    (let* ((response (build-spec-check-response
+                      (%contract-check-report :failure-reason :return-spec
+                                              :failure-reason-readable t)))
+           (contract (gethash "contract" (aref (gethash "results" response) 0))))
+      (ok (search "broken half: return-spec" (first-text response)))
+      (ok (string= "return-spec" (gethash "failure_reason" contract)))
+      (ok (eq t (gethash "failure_reason_readable" contract))))))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -696,6 +696,34 @@
       (ok (null (gethash "specs" counts)))
       (ok (eql 0 (gethash "properties" counts))))))
 
+(deftest list-response-says-whether-the-tag-narrowed-anything
+  (flet ((header (kind)
+           (first-text
+            (build-spec-list-response
+             (list :status :ok :kind kind
+                   :specs (list (%symbol-data "PROBE" "SMALL-INT"))
+                   :properties nil :function-specs nil
+                   :specs-listable t :properties-listable t
+                   :function-specs-listable t
+                   :counts (list :specs 1)
+                   :filters (list :tag "critical" :tag-resolved t)
+                   :coverage "everything registered here"
+                   :environment *environment*)))))
+    (testing "a kind that lists no properties says the tag was not applied"
+      ;; "1 spec  tagged critical" asserts a filter that narrowed nothing:
+      ;; LIST-REPORT never offers the tag to the spec or contract listings.
+      (let ((text (header "specs")))
+        (ok (search "was NOT applied" text))
+        (ok (not (search "tagged critical" text)))))
+    (testing "a properties listing says it plainly"
+      (let ((text (header "properties")))
+        (ok (search "tagged critical" text))
+        (ok (not (search "was NOT applied" text)))
+        (ok (not (search "(properties only)" text)))))
+    (testing "and a mixed listing says which half it narrowed"
+      (let ((text (header "both")))
+        (ok (search "tagged critical (properties only)" text))))))
+
 (deftest check-response-unsupported-reaches-the-text
   (testing "a contract cl-spec cannot run says so where a client can see it"
     ;; The report carries a message and no selection, results or counts.  Read

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -41,14 +41,15 @@
 
 (defun %contract-check-report (&key failure-reason failure-reason-readable
                                     rejected-overcounted (rejected 3)
-                                    (effective-trials 27))
+                                    (effective-trials 27)
+                                    (precondition-p t))
   "Return a completed contract check report whose single result failed."
   (list :status :completed
         :verified nil
         ;; "contract", the mode %SELECT-NAMED actually emits for a function
         ;; selection -- %SELECTION-NOUN keys on it, and "function" here sent
         ;; every test built on this fixture down the property branch.
-        :selection (list :mode "contract" :count 1
+        :selection (list :mode "contract" :kind :contract :count 1
                          :selected (list (%symbol-data "PROBE" "WIDEN"))
                          :source "explicit function argument"
                          :coverage "Only the contract named.")
@@ -59,6 +60,7 @@
                     :trials (list :executed 30 :budget 30
                                   :budget-source "requested")
                     :contract (list :rejected rejected
+                                    :precondition-p precondition-p
                                     :rejected-measured t
                                     :rejected-overcounted rejected-overcounted
                                     :effective-trials effective-trials
@@ -775,3 +777,28 @@
                                           :failure-reason-readable t)))))
       (ok (search "called 27 times" text))
       (ok (not (search "more refusals than trials" text))))))
+
+(deftest check-response-does-not-invent-a-precondition
+  (testing "a contract with no :pre is not described as refusing inputs"
+    ;; "0 of them refused by :pre" tells the reader a precondition exists.
+    ;; On a contract written with :args, :returns and :post and no :pre, that
+    ;; is a clause the author never wrote -- and the tool then advises raising
+    ;; trials on the strength of a number that cannot mean anything.
+    (let* ((response (build-spec-check-response
+                      (%contract-check-report :precondition-p nil
+                                              :rejected 0
+                                              :effective-trials 30
+                                              :failure-reason :postcondition
+                                              :failure-reason-readable t)))
+           (contract (gethash "contract" (aref (gethash "results" response) 0)))
+           (text (first-text response)))
+      (ok (eq yason:false (gethash "has_precondition" contract)))
+      (ok (search "no :pre" text))
+      (ok (not (search "refused by :pre" text)))))
+  (testing "while one that has a :pre still reports its refusals"
+    (let ((text (first-text
+                 (build-spec-check-response
+                  (%contract-check-report :failure-reason :return-spec
+                                          :failure-reason-readable t)))))
+      (ok (search "refused by :pre" text))
+      (ok (not (search "no :pre" text))))))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -741,7 +741,7 @@
       (ok (eql 0 (gethash "properties" counts))))))
 
 (deftest list-response-says-whether-the-tag-narrowed-anything
-  (flet ((header (kind)
+  (flet ((header (kind &key (tag-filterable t))
            (first-text
             (build-spec-list-response
              (list :status :ok :kind kind
@@ -749,6 +749,7 @@
                    :properties nil :function-specs nil
                    :specs-listable t :properties-listable t
                    :function-specs-listable t
+                   :tag-filterable tag-filterable
                    :counts (list :specs 1)
                    :filters (list :tag "critical" :tag-resolved t)
                    :coverage "everything registered here"
@@ -766,7 +767,14 @@
         (ok (not (search "(properties only)" text)))))
     (testing "and a mixed listing says which half it narrowed"
       (let ((text (header "both")))
-        (ok (search "tagged critical (properties only)" text))))))
+        (ok (search "tagged critical (properties only)" text))))
+    (testing "while a cl-spec that cannot filter by tag says that instead"
+      ;; Keyed on properties_listable, this printed "tagged critical" over a
+      ;; listing the tag never touched -- read as "no property carries it".
+      (let ((text (header "properties" :tag-filterable nil)))
+        (ok (search "was NOT applied" text))
+        (ok (search "properties-with-tag" text))
+        (ok (not (search "tagged critical" text)))))))
 
 (deftest check-response-unsupported-reaches-the-text
   (testing "a contract cl-spec cannot run says so where a client can see it"

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -658,6 +658,50 @@
       (ok (search "62 more characters" text))
       (ok (search "17 more characters" text)))))
 
+(deftest describe-response-renders-an-argument-spec-in-full
+  (testing "an argument's own bounds, values and class reach the text"
+    ;; The arguments block used to print the node's kind and recurse into its
+    ;; children, so everything that says what the input actually admits was
+    ;; dropped -- the half spec-describe kind=function-spec exists for.
+    (let* ((response (build-spec-describe-response
+                      (list :status :ok :kind "function-spec"
+                            :name (%symbol-data "PROBE" "BUCKET")
+                            :documentation nil
+                            :arguments
+                            (list (list :variable (%symbol-data "PROBE" "V")
+                                        :spec (list :kind :range :min "0"
+                                                    :max "100"
+                                                    :base-type "INTEGER"))
+                                  (list :variable (%symbol-data "PROBE" "LO")
+                                        :spec (list :kind :member
+                                                    :values "(1 2 3)"))
+                                  (list :variable (%symbol-data "PROBE" "ACC")
+                                        :spec
+                                        (list :kind :class
+                                              :class-name
+                                              (%symbol-data "PROBE" "ACCOUNT"))))
+                            :returns nil
+                            :source-form "(DEFSPEC-FUNCTION" :source-form-complete t
+                            :environment *environment*)))
+           (text (first-text response)))
+      (ok (search "V : range [0, 100]  base: INTEGER" text))
+      (ok (search "LO : member  values: (1 2 3)" text))
+      (testing "and a class prints its name, not SYMBOL-DATA's plist"
+        (ok (search "ACC : class PROBE::ACCOUNT" text))
+        (ok (not (search "QUALIFIED" text))))))
+  (testing "a contract with no :pre claims nothing about its completeness"
+    (let ((response (build-spec-describe-response
+                     (list :status :ok :kind "function-spec"
+                           :name (%symbol-data "PROBE" "WIDEN")
+                           :documentation nil :arguments nil :returns nil
+                           :preconditions nil
+                           :preconditions-complete :not-applicable
+                           :source-form "(DEFSPEC-FUNCTION"
+                           :source-form-complete t
+                           :environment *environment*))))
+      (ok (null (gethash "preconditions" response)))
+      (ok (null (gethash "preconditions_complete" response))))))
+
 (deftest list-response-omits-a-kind-that-was-not-requested
   (testing "the header names only what was counted"
     (flet ((text-for (kind specs properties)

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -753,7 +753,15 @@
                    :function-specs-listable t
                    :tag-filterable tag-filterable
                    :counts (list :specs 1)
-                   :filters (list :tag "critical" :tag-resolved t)
+                   ;; TAG-APPLIED as LIST-REPORT computes it: the kind lists
+                   ;; properties, this cl-spec can enumerate them, and it can
+                   ;; filter by tag.
+                   :filters (list :tag "critical" :tag-resolved t
+                                  :tag-applied
+                                  (and (member kind '("properties" "both")
+                                               :test #'equal)
+                                       tag-filterable
+                                       t))
                    :coverage "everything registered here"
                    :environment *environment*)))))
     (testing "a kind that lists no properties says the tag was not applied"

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -39,7 +39,9 @@
   (list :package package :name name
         :qualified (format nil "~A::~A" package name)))
 
-(defun %contract-check-report (&key failure-reason failure-reason-readable)
+(defun %contract-check-report (&key failure-reason failure-reason-readable
+                                    rejected-overcounted (rejected 3)
+                                    (effective-trials 27))
   "Return a completed contract check report whose single result failed."
   (list :status :completed
         :verified nil
@@ -53,9 +55,10 @@
                     :status :failed
                     :trials (list :executed 30 :budget 30
                                   :budget-source "requested")
-                    :contract (list :rejected 3
+                    :contract (list :rejected rejected
                                     :rejected-measured t
-                                    :effective-trials 27
+                                    :rejected-overcounted rejected-overcounted
+                                    :effective-trials effective-trials
                                     :failure-reason failure-reason
                                     :failure-reason-readable
                                     failure-reason-readable)
@@ -622,6 +625,31 @@
       (ok (search "truncated" text))
       (ok (search "31" text)))))
 
+(deftest describe-response-marks-a-cut-precondition
+  (testing "a truncated :pre or :post says so, like the body does"
+    ;; A silently cut :PRE is worse than a cut body: a reader takes the clause
+    ;; for the whole condition and concludes the contract admits inputs it
+    ;; refuses.
+    (let* ((response (build-spec-describe-response
+                      (list :status :ok :kind "function-spec"
+                            :name (%symbol-data "PROBE" "TRANSFER")
+                            :documentation nil :arguments nil :returns nil
+                            :preconditions "(AND (PLUSP AMOUNT)"
+                            :preconditions-complete nil
+                            :preconditions-omitted-chars 62
+                            :postconditions "(> RESULT"
+                            :postconditions-complete nil
+                            :postconditions-omitted-chars 17
+                            :source-form "(DEFSPEC-FUNCTION" :source-form-complete t
+                            :definition-digest "a41f9c2b7d0e5518"
+                            :environment *environment*)))
+           (text (first-text response)))
+      (ok (eq yason:false (gethash "preconditions_complete" response)))
+      (ok (= 62 (gethash "preconditions_omitted_chars" response)))
+      (ok (= 17 (gethash "postconditions_omitted_chars" response)))
+      (ok (search "62 more characters" text))
+      (ok (search "17 more characters" text)))))
+
 (deftest list-response-omits-a-kind-that-was-not-requested
   (testing "the header names only what was counted"
     (flet ((text-for (kind specs properties)
@@ -706,3 +734,30 @@
       (ok (search "broken half: return-spec" (first-text response)))
       (ok (string= "return-spec" (gethash "failure_reason" contract)))
       (ok (eq t (gethash "failure_reason_readable" contract))))))
+
+(deftest check-response-never-reports-a-negative-call-count
+  (testing "more refusals than trials is said, not subtracted"
+    ;; cl-spec stops counting refusals at the first failure it recognizes, but
+    ;; a target that SIGNALS unwinds past that point with the counter running
+    ;; and shrinking keeps feeding it.  Measured at 3 runs in 8 against such a
+    ;; contract -- one of them 1 trial and 2 rejections, which printed as "the
+    ;; function was called -1 times".
+    (let* ((response (build-spec-check-response
+                      (%contract-check-report :rejected 2
+                                              :effective-trials 0
+                                              :rejected-overcounted t
+                                              :failure-reason :condition
+                                              :failure-reason-readable t)))
+           (contract (gethash "contract" (aref (gethash "results" response) 0)))
+           (text (first-text response)))
+      (ok (eq t (gethash "rejected_overcounted" contract)))
+      (ok (search "more refusals than trials" text))
+      (ok (not (search "-1" text)))
+      (ok (not (search "called 0 time" text)))))
+  (testing "and an ordinary count still reads as one"
+    (let ((text (first-text
+                 (build-spec-check-response
+                  (%contract-check-report :failure-reason :return-spec
+                                          :failure-reason-readable t)))))
+      (ok (search "called 27 times" text))
+      (ok (not (search "more refusals than trials" text))))))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -227,6 +227,63 @@
         (ok (search "NOT VERIFIED" text))
         (ok (not (search "FAILED" text)))))))
 
+(deftest check-response-headline-says-when-a-contract-was-not-run
+  (testing "a passing :about selection that left a contract unrun says so up front"
+    ;; Without this the first line of a run over a broken function reads
+    ;; "✓ VERIFIED": the properties do hold, and the note saying the contract
+    ;; was never executed sits several lines below a reader who has already
+    ;; stopped.
+    (let* ((response (build-spec-check-response
+                      (list :status :completed
+                            :verified t
+                            :selection (list :mode "about" :count 1
+                                             :selected (list (%symbol-data "PROBE" "GOOD"))
+                                             :contract-not-run (%symbol-data "PROBE" "CLAMP")
+                                             :source "cl-spec:semantic-data -> :properties-about"
+                                             :coverage "Direct (:about ...) registrations only.")
+                            :results
+                            (list (list :property (%symbol-data "PROBE" "GOOD")
+                                        :status :passed
+                                        :trials (list :executed 100 :budget 100
+                                                      :budget-source "backend-default")
+                                        :seed "111" :profile :normal
+                                        :definition-match :not-checked))
+                            :counts (list :selected 1 :passed 1 :failed 0
+                                          :errored 0 :timed-out 0 :not-run 0)
+                            :environment *environment*)))
+           (text (first-text response))
+           (headline (subseq text 0 (or (position #\Newline text) (length text)))))
+      (ok (search "VERIFIED" headline))
+      (ok (search "properties only" headline))
+      (ok (search "NOT run" headline))
+      (testing "and a consumer reading the payload gets the name, not prose"
+        (ok (string= "PROBE::CLAMP"
+                     (gethash "qualified"
+                              (gethash "contract_not_run"
+                                       (gethash "selection" response))))))))
+  (testing "a selection with no contract behind it keeps the bare headline"
+    (let* ((response (build-spec-check-response
+                      (list :status :completed
+                            :verified t
+                            :selection (list :mode "about" :count 1
+                                             :selected (list (%symbol-data "PROBE" "GOOD"))
+                                             :source "cl-spec:semantic-data -> :properties-about"
+                                             :coverage "Direct (:about ...) registrations only.")
+                            :results
+                            (list (list :property (%symbol-data "PROBE" "GOOD")
+                                        :status :passed
+                                        :trials (list :executed 100 :budget 100
+                                                      :budget-source "backend-default")
+                                        :seed "111" :profile :normal
+                                        :definition-match :not-checked))
+                            :counts (list :selected 1 :passed 1 :failed 0
+                                          :errored 0 :timed-out 0 :not-run 0)
+                            :environment *environment*)))
+           (text (first-text response))
+           (headline (subseq text 0 (or (position #\Newline text) (length text)))))
+      (ok (search "VERIFIED" headline))
+      (ok (not (search "properties only" headline))))))
+
 (deftest check-response-replays-the-failure-not-the-first-run
   (testing "the replay line names the property that did not pass"
     (let* ((response (build-spec-check-response

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -216,6 +216,14 @@ are what a test about the message has to look at."
       (multiple-value-bind (value message) (funcall read-arg params "trials" nil)
         (ok (null value))
         (ok (null message)))
+      (testing "and a budget past the ceiling is refused with the reason"
+        ;; The ceiling bounds what a leaked deadline thread is left doing in
+        ;; the worker, so it has to be reachable through the entry point the
+        ;; worker handler calls, not only through the schema.
+        (let ((response (%call "spec-check"
+                               "{\"function\":\"cl:car\",\"trials\":5000000}")))
+          (ok (search "at most" (%text response)))
+          (ok (search "1,000,000" (%text response)))))
       (testing "and a value that is there still has to be positive"
         (setf (gethash "trials" params) 0)
         (multiple-value-bind (value message)

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -17,7 +17,8 @@
   (:import-from #:cl-mcp/src/tools/spec-entry #:parse-seed-string)
   (:import-from #:cl-mcp/src/spec-adapter-report
                 #:+result-statuses+
-                #:+call-statuses+)
+                #:+call-statuses+
+                #:+verification-gap-values+)
   (:import-from #:cl-mcp/src/tools/registry
                 #:*enabled-tool-groups*
                 #:disabled-tool-group)
@@ -265,7 +266,15 @@ are what a test about the message has to look at."
         (dolist (status +call-statuses+)
           (ok (search (string-downcase (symbol-name status)) description)
               (format nil "spec-check description must name the ~(~A~) call status"
-                      status)))))))
+                      status))))
+      (testing "and every verification gap it can report"
+        ;; The gap set grew four times in one branch while the description
+        ;; explained two of the values.  Checked from the code's own list for
+        ;; the same reason the statuses are.
+        (dolist (gap +verification-gap-values+)
+          (ok (search (string-downcase (symbol-name gap)) description)
+              (format nil "spec-check description must name the ~(~A~) gap"
+                      gap)))))))
 
 (deftest spec-check-description-states-the-current-rules
   (testing "verified's third condition and the four-valued match are stated"

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -278,10 +278,18 @@ are what a test about the message has to look at."
             (format nil "spec-check description must name the ~(~A~) status"
                     status)))
       (testing "and the whole-call statuses too"
-        (dolist (status +call-statuses+)
-          (ok (search (string-downcase (symbol-name status)) description)
-              (format nil "spec-check description must name the ~(~A~) call status"
-                      status))))
+        ;; Searched inside the whole-call section, not the whole string: a
+        ;; status documented only under results[].status satisfied a search
+        ;; over the description and the guard reported coverage it did not
+        ;; have -- which is how undefined-function reached +CALL-STATUSES+
+        ;; without ever being defined for a caller reading about a call.
+        (let* ((start (search "For the whole call, status:" description))
+               (section (subseq description (or start 0))))
+          (ok start "the description must have a whole-call status section")
+          (dolist (status +call-statuses+)
+            (ok (search (string-downcase (symbol-name status)) section)
+                (format nil "the whole-call section must name ~(~A~)"
+                        status)))))
       (testing "and every verification gap it can report"
         ;; The gap set grew four times in one branch while the description
         ;; explained two of the values.  Checked from the code's own list for

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -192,6 +192,29 @@ are what a test about the message has to look at."
       (ok (search "max_chars" (%text response)))
       (ok (search "positive" (string-downcase (%text response)))))))
 
+(deftest spec-check-refuses-a-non-positive-trials
+  (testing "a negative trial count is refused before anything runs"
+    ;; The schema's :INTEGER admits 0 and negatives, and cl-spec runs
+    ;; (loop for trial from 1 to -5) without complaint: zero trials, which the
+    ;; response then asserts as "-5 executed of -5 budget (requested)".
+    (let ((response (%call "spec-check" "{\"function\":\"cl:car\",\"trials\":-5}")))
+      (ok (search "trials" (%text response)))
+      (ok (search "positive" (string-downcase (%text response))))))
+  (testing "and so is zero"
+    (let ((response (%call "spec-check" "{\"function\":\"cl:car\",\"trials\":0}")))
+      (ok (search "positive" (string-downcase (%text response))))))
+  (testing "while an absent trials stays absent rather than becoming a budget"
+    ;; The default is NIL, not a number: a contract with no trials= must fall
+    ;; through to the backend's own count, and a property must reach its
+    ;; :TRIALS table.
+    (%ensure-tools)
+    (let* ((params (make-hash-table :test #'equal))
+           (response (progn (setf (gethash "property" params) "cl:car")
+                            (funcall (find-symbol "SPEC-CHECK-RESPONSE"
+                                                  "CL-MCP/SRC/TOOLS/SPEC-ENTRY")
+                                     params))))
+      (ok (not (string= "invalid-arguments" (gethash "status" response)))))))
+
 (deftest read-tools-accept-a-timeout
   (testing "spec-symbol and spec-describe take timeout_seconds"
     (%ensure-tools)

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -140,11 +140,19 @@ are what a test about the message has to look at."
       (ok (search "property" (%text result)))
       (ok (search "spec" (%text result))))))
 
-(deftest spec-check-refuses-both-targets
+(deftest spec-check-refuses-more-than-one-target
   (testing "property and symbol together is refused with a usable message"
     (let ((result (%call "spec-check"
                          "{\"property\":\"cl:car\",\"symbol\":\"cl:cdr\"}")))
-      (ok (search "both" (string-downcase (%text result)))))))
+      (ok (search "exactly one" (string-downcase (%text result))))))
+  (testing "so is a function alongside one of them"
+    (let ((result (%call "spec-check"
+                         "{\"function\":\"cl:car\",\"symbol\":\"cl:cdr\"}")))
+      (ok (search "exactly one" (string-downcase (%text result))))))
+  (testing "and naming none of the three says all three"
+    (let ((result (%call "spec-check" "{}")))
+      (ok (search "property, symbol or function"
+                  (string-downcase (%text result)))))))
 
 (deftest spec-check-refuses-a-non-numeric-seed
   (testing "a seed that is not decimal digits is rejected before any run"

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -205,16 +205,23 @@ are what a test about the message has to look at."
     (let ((response (%call "spec-check" "{\"function\":\"cl:car\",\"trials\":0}")))
       (ok (search "positive" (string-downcase (%text response))))))
   (testing "while an absent trials stays absent rather than becoming a budget"
-    ;; The default is NIL, not a number: a contract with no trials= must fall
-    ;; through to the backend's own count, and a property must reach its
-    ;; :TRIALS table.
+    ;; Asserted on the value, not on a status that would be something else
+    ;; anyway.  A numeric default here would send cl-spec a budget the caller
+    ;; never asked for, and "the call was not refused" cannot see that: the
+    ;; status is cl-spec-not-loaded or not-registered either way.
     (%ensure-tools)
-    (let* ((params (make-hash-table :test #'equal))
-           (response (progn (setf (gethash "property" params) "cl:car")
-                            (funcall (find-symbol "SPEC-CHECK-RESPONSE"
-                                                  "CL-MCP/SRC/TOOLS/SPEC-ENTRY")
-                                     params))))
-      (ok (not (string= "invalid-arguments" (gethash "status" response)))))))
+    (let ((params (make-hash-table :test #'equal))
+          (read-arg (find-symbol "%POSITIVE-INTEGER-ARG"
+                                 "CL-MCP/SRC/TOOLS/SPEC-ENTRY")))
+      (multiple-value-bind (value message) (funcall read-arg params "trials" nil)
+        (ok (null value))
+        (ok (null message)))
+      (testing "and a value that is there still has to be positive"
+        (setf (gethash "trials" params) 0)
+        (multiple-value-bind (value message)
+            (funcall read-arg params "trials" nil)
+          (ok (null value))
+          (ok (search "positive" message)))))))
 
 (deftest read-tools-accept-a-timeout
   (testing "spec-symbol and spec-describe take timeout_seconds"


### PR DESCRIPTION
Follow-up to #151, on the same branch. cl-spec has since implemented
`defspec-function`, `check-function` and `function-spec-data`; the adapter that
merged answered "function specs are unsupported", which was true of the older
revision and is now misleading. These eight commits teach the four tools about
contracts, and fix what driving the loop end to end turned up.

## Function specs reach the tools

- **`spec-describe kind=function-spec`** projects the contract: the spec of each
  argument, the spec of the return value, and the `:pre` / `:post` forms. Nothing
  exposed this before — properties say what relations must hold, not what the
  signature admits. The unsupported message stays for a cl-spec that cannot
  project one, reworded to be about the loaded revision rather than about whether
  a contract exists.
- **`spec-check function=`** is a third target beside `property=` and `symbol=`.
  It is deliberately not folded into `symbol=`: an `:about` selection covers
  properties only, and quietly widening what runs would make the reported
  coverage wrong.
- **`spec-list kind=function-specs`**, included in `both`, with
  `function_specs_listable` so a cl-spec that cannot enumerate them is not read
  as a project that has none.

## What a contract run reports that a property run cannot

- `rejected` and `effective_trials`. cl-spec's checker refuses inputs its `:PRE`
  does not admit, and a trial count that includes them overstates the work. On
  the demo defect: 100 trials, 83 refused, 17 real calls — which read as a
  hundred trials' worth of evidence until the response said otherwise. `verified`
  now reads the effective count.
- `verification_gaps` drops `rejection-counts-unmeasured` on a contract run,
  because the number is right there. Listing a gap whose answer is present trains
  a reader to ignore the list.
- `failure_reason` names which half broke, with cl-spec's `explain-data` for a
  return value that missed its spec.
- **`trials=`**, contract runs only. A property takes its budget from its own
  `:trials` table, so `profile` is the lever there; a contract has no table,
  which left the backend default as the only reachable budget — and the demo
  defect (a bucket index off by one at the closed right edge) survived every run
  the tool could ask for. At `trials=2000` it falls out in 18 trials, shrunk to
  `VALUE=-1 LOW=-2 HIGH=-1 COUNT=1`. Passing `trials=` with `property=` or
  `symbol=` is refused rather than ignored: `run-property` takes no override, so
  honouring it there would report a budget the run did not use.

## What the end-to-end run left broken in the reporting

- An `:about` selection over a symbol with a function spec runs the properties
  and not the contract. That was a note four lines below the verdict, so a
  broken function opened with a bare `✓ VERIFIED`. All three verdicts now carry
  the qualifier — `✓ VERIFIED (properties only — the function spec for X was NOT
  run)` — and the selection carries the name as data
  (`selection.contract_not_run`) so a JSON consumer need not parse the headline.
- The replay line printed `spec-check property=<name>` for a contract: following
  it verbatim asks for a property that does not exist, and it omitted the budget,
  so a failure found at `trials=2000` need not reappear. It now prints
  `function=<name> trials=<budget>`.
- `spec-check symbol=` on a symbol whose only registration is a contract said
  "NO PROPERTIES … nothing was executed" and dropped the note saying a contract
  *is* registered — the one case where the caller most needs it.
- "Selected 1 property via explicit function argument" called a contract a
  property.
- An open range end prints as `*`, not as cl-spec's `:UNBOUNDED`. Mapped in
  `%spec-tree` so the text and the JSON agree.
- `:pre` / `:post` text is cut at `max_chars` with the cut reported, like every
  other form this module prints.

## Tests

- Integration coverage against the real cl-spec for the contract path: a contract
  that holds with its rejections counted, one that breaks with the half named,
  one whose `:pre` admits nothing (skipped, never verified), an `:about`
  selection that leaves the contract alone and says so, `trials=` refused without
  a contract, and the listing.
- The fixture's contract definitions sit behind a capability check keyed on
  `function-spec-data` — `check-function` is fbound as a stub on older
  revisions, so `fboundp` answers the wrong question. Verified both ways by
  checking cl-spec out at main (3 passed, 2 skipped) and at its branch (all 6
  suites passing). The fixture is `load`ed rather than compiled, so one
  signalling form aborted the whole file and errored five tests, three of which
  predate this branch.
- The redefinition test now loads its own copy of the fixture. It rewrites the
  deliberately false property in the registry every other test in the file
  shares, and that registry is cached in a `defvar` — so a second run of the
  suite in the same image produced nine failures that said nothing about the
  code.

## Verification

| | |
|---|---|
| Full suite | 65 suites / ✓5234 / ×2 — the two `×` are the intentional `rove-red` scaffold `project-scaffold` asserts on (main: ✓5176 / ×2) |
| spec suites | all six ran, no skips: cl-spec resolved and the contract path exercised for real |
| `(asdf:compile-system :cl-mcp :force :all)` in a fresh image | `; caught` 29, unchanged from before the branch; no warning from any spec file |
| `mallet src/*.lisp src/*/*.lisp tests/*.lisp` | clean |

The `cl-spec` tool group stays opt-in and off by default, and cl-mcp still has no
dependency on cl-spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvpFGW43e6ETyA7yaTxE2d
