### PR TITLE
fix(cl-spec): three the end-to-end run against cl-spec found

### DIFF
--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -2338,9 +2338,18 @@ anything holds."
                   ;; is to have reproduced the earlier run.
                   :reproduction-faithful
                   (cond ((null expect-definition-digest) :not-checked)
-                        ((find :unknown results
-                               :key (lambda (result)
-                                      (getf result :definition-match)))
+                        ;; :NOT-CHECKED beside a digest that WAS asked for is
+                        ;; a run that never reached the comparison -- a
+                        ;; timeout, an exhausted budget, a run that signalled.
+                        ;; It belongs with the unreadable digest and not with
+                        ;; the fall-through: taken for a disagreement, a
+                        ;; contract whose target is not even defined reported
+                        ;; that the caller's definitions had moved, about a
+                        ;; digest nothing had looked at.
+                        ((find-if (lambda (result)
+                                    (member (getf result :definition-match)
+                                            '(:unknown :not-checked)))
+                                  results)
                          :unknown)
                         ((every (lambda (result)
                                   (eq :true (getf result :definition-match)))

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -771,7 +771,17 @@ so the function was called ~A time~:P"
       (let ((reason (getf contract :failure-reason)))
         (cond
           (reason
-           (format stream "~&    broken half: ~A" (%keyword-string reason)))
+           (format stream "~&    broken half: ~A" (%keyword-string reason))
+           ;; CONTRACT-ERROR is not a half of what was claimed about the
+           ;; function, the way CONDITION, POSTCONDITION and RETURN-SPEC are:
+           ;; it is the contract's own code signalling while it checked the
+           ;; answer.  In the same column and the same words as the others it
+           ;; reads as one more way the function broke -- and so does the
+           ;; condition under it, which is a TYPE-ERROR out of a :post form.
+           (when (eq :contract-error reason)
+             (format stream "~&      The contract's own code signalled while ~
+it checked the answer. The condition below is a finding about the :pre, ~
+:returns or :post form, NOT about the function.")))
           ((not (member (getf result :status) '(:failed :error))) nil)
           ((getf contract :failure-reason-readable)
            (format stream "~&    broken half: not determined -- re-running the ~
@@ -912,35 +922,53 @@ that has a function spec ran the properties and not the contract, and the bare
 word would be read as a clean bill for the function -- which is exactly what a
 run over a broken function whose properties happen to hold produces.  The
 qualifier goes on all three verdicts: what was covered does not depend on how
-it came out."
-  (let ((verdict (cond ((getf report :verified) "✓ VERIFIED")
-                       ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
-                       (t "⚠ NOT VERIFIED")))
-        (contract (getf (getf report :selection) :contract-not-run))
-        (properties (append (getf (getf report :selection) :properties-not-run)
-                            (let ((own (getf (getf report :selection)
-                                             :own-property-not-run)))
-                              (when own (list own))))))
-    (cond
-      (contract
-       (format nil "~A (properties only -- the function spec for ~A was NOT run)"
-               verdict (getf contract :qualified)))
-      ;; The mirror, and it needs saying for the same reason: a contract that
-      ;; holds is not a clean bill for a function whose properties were never
-      ;; run, and the headline is where a reader stops.
-      (properties
-       (format nil "~A (contract only -- ~D propert~:@P about this symbol ~
-~:*~[~;was~:;were~] NOT run)"
-               verdict (length properties)))
-      ;; And the case where coverage is least known needs it most: the
-      ;; lookup that would have said what else is registered failed, so the
-      ;; bare verdict would be the only line that did not admit it.
-      ((and (eq :contract (getf (getf report :selection) :kind))
-            (not (getf (getf report :selection) :properties-not-run-read)))
-       (format nil "~A (contract only -- what else is registered about this ~
-symbol could not be read)"
-               verdict))
-      (t verdict))))
+it came out.
+
+And a claim about which revision was covered.  EXPECT_DEFINITION_DIGEST is an
+assertion by the caller -- this is still the contract I saved -- so a run that
+disagrees with it has a verdict about definitions the caller was not asking
+about.  Carried beside the coverage qualifier rather than instead of it: the
+two answer different questions, and either one dropped leaves the headline
+claiming what the run did not establish."
+  (let* ((verdict (cond ((getf report :verified) "✓ VERIFIED")
+                        ((plusp (or (getf (getf report :counts) :failed) 0)) "✗ FAILED")
+                        (t "⚠ NOT VERIFIED")))
+         (selection (getf report :selection))
+         (contract (getf selection :contract-not-run))
+         (properties (append (getf selection :properties-not-run)
+                             (let ((own (getf selection :own-property-not-run)))
+                               (when own (list own)))))
+         (coverage
+           (cond
+             (contract
+              (format nil "properties only -- the function spec for ~A was NOT run"
+                      (getf contract :qualified)))
+             ;; The mirror, and it needs saying for the same reason: a contract
+             ;; that holds is not a clean bill for a function whose properties
+             ;; were never run, and the headline is where a reader stops.
+             (properties
+              (format nil "contract only -- ~D propert~:@P about this symbol ~
+~:*~[~;was~:;were~] NOT run"
+                      (length properties)))
+             ;; And the case where coverage is least known needs it most: the
+             ;; lookup that would have said what else is registered failed, so
+             ;; the bare verdict would be the only line that did not admit it.
+             ((and (eq :contract (getf selection :kind))
+                   (not (getf selection :properties-not-run-read)))
+              (format nil "contract only -- what else is registered about ~
+this symbol could not be read"))
+             (t nil)))
+         ;; :TRUE and :NOT-CHECKED add nothing -- one confirms the assertion,
+         ;; the other means none was made -- and a qualifier on every headline
+         ;; is a qualifier nobody reads.
+         (reproduction
+           (case (getf report :reproduction-faithful)
+             (:false (format nil "the definitions moved since the digest ~
+given -- this did NOT reproduce that run"))
+             (:unknown (format nil "whether the definitions still match the ~
+digest given could not be read"))
+             (t nil))))
+    (format nil "~A~@[ (~A)~]~@[ (~A)~]" verdict coverage reproduction)))
 
 (defun %format-check-text (report)
   "Render the spec-check report as the text an MCP client will show."

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -569,7 +569,11 @@ Four answers, and NIL is not one of them.  A report that carries no verdict at
 all -- a selection of zero, where nothing ran and no digest was requested --
 was being published as an unfaithful reproduction of a run that never
 happened, because \"unfaithful\" was the fallback for both an absent key and a
-real disagreement.  CHECK-REPORT now says :FALSE for the disagreement."
+real disagreement.  CHECK-REPORT now says :FALSE for the disagreement.
+
+:UNKNOWN carries two shortfalls: a digest that could not be read, and a run
+that never reached a comparison at all.  Neither is a disagreement, which is
+the whole point of keeping them out of :FALSE."
   (case value
     (:true "faithful")
     (:false "unfaithful")
@@ -965,8 +969,18 @@ this symbol could not be read"))
            (case (getf report :reproduction-faithful)
              (:false (format nil "the definitions moved since the digest ~
 given -- this did NOT reproduce that run"))
-             (:unknown (format nil "whether the definitions still match the ~
-digest given could not be read"))
+             ;; Two shortfalls under one word, and the results are what tell
+             ;; them apart.  A digest that could not be read was looked at; a
+             ;; timeout, an exhausted budget or a run that signalled never got
+             ;; that far, and "could not be read" would send the reader to a
+             ;; digest that was never the problem.
+             (:unknown
+              (if (find :unknown (getf report :results)
+                        :key (lambda (result) (getf result :definition-match)))
+                  (format nil "whether the definitions still match the digest ~
+given could not be read")
+                  (format nil "this run did not get far enough to compare the ~
+digest given")))
              (t nil))))
     (format nil "~A~@[ (~A)~]~@[ (~A)~]" verdict coverage reproduction)))
 

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -219,8 +219,12 @@ Per property, results[].status:
   failed          a counterexample was found; both the original and the shrunk
                   arguments are reported.
   error           the property body signalled.
-  skipped         defined by cl-spec; the current backend does not produce it.
-  pending         same. Reported as-is if it ever appears.
+  skipped         nothing was checked, and this is NOT a pass: a contract
+                  whose :pre refused every generated input, so the function
+                  was never called, or a run whose trial budget resolved to
+                  zero.
+  pending         defined by cl-spec; the current backend does not produce it.
+                  Reported as-is if it ever appears.
   timeout         the deadline expired. NOTHING was proved or disproved.
   not-run         the whole-call budget was spent before this property started.
   generator-error no value could be generated. Nothing was checked.

--- a/src/tools/spec-tools.lisp
+++ b/src/tools/spec-tools.lisp
@@ -367,8 +367,13 @@ reported faithful and is not a reproduction. Check the function yourself.
 
 definition_match is four-valued: match, mismatch, unknown (the digest could
 not be computed, or its input hit the print limit -- this is NOT a
-disagreement) and not-checked (no expect_definition_digest was given).
-reproduction_faithful says the same four things about the call as a whole.
+disagreement) and not-checked (no expect_definition_digest was given, OR this
+result never reached a comparison: a timeout, an exhausted budget, a run that
+signalled).  reproduction_faithful says the same four things about the call as
+a whole, with one difference forced by that second cause: not-checked there
+means only that no expect_definition_digest was given, and unknown covers both
+a digest that could not be read and a run where nothing compared one.  Neither
+is a disagreement; only mismatch says the definitions moved.
 A matching digest means the property and the specs it references are
 unchanged; it says nothing about the implementation, the backend, or the
 environment.

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -1031,3 +1031,31 @@ listing functions are not -- the shape the blanket listing guard refused."
                                   :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"
                                   :symbol "CL-MCP-SPEC-REPORT-FIXTURE:ADD")
                     :status))))))
+
+(deftest check-report-does-not-call-an-unexecuted-run-unfaithful
+  (testing "a run that never compared the digest did not find the definitions moved"
+    ;; A timeout, an exhausted budget and a signalling run all carry
+    ;; :DEFINITION-MATCH :NOT-CHECKED whether or not a digest was asked for.
+    ;; The fall-through read every one of them as a disagreement, so a caller
+    ;; who passed expect_definition_digest to a contract whose target is not
+    ;; defined was told its definitions had moved -- about a digest nothing
+    ;; had looked at.
+    (let ((report (check-report
+                   (%api-with-run (lambda (&rest ignored)
+                                    (declare (ignore ignored))
+                                    (error "the target is not defined")))
+                   :ok
+                   :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"
+                   :expect-definition-digest "0000000000000000")))
+      (ok (eq :not-checked (getf (first (getf report :results))
+                                 :definition-match)))
+      (ok (eq :unknown (getf report :reproduction-faithful)))))
+  (testing "and a real disagreement is still reported as one"
+    (let ((report (check-report
+                   (%api-with-run (lambda (&rest ignored)
+                                    (declare (ignore ignored))
+                                    (%result-stub)))
+                   :ok
+                   :property "CL-MCP-SPEC-REPORT-FIXTURE:ADD-COMMUTES"
+                   :expect-definition-digest "0000000000000000")))
+      (ok (eq :false (getf report :reproduction-faithful))))))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -894,3 +894,90 @@
                                           :failure-reason-readable t)))))
       (ok (search "refused by :pre" text))
       (ok (not (search "no :pre" text))))))
+
+(defun %digest-check-report (faithful &key properties-not-run)
+  "Return a passing contract report whose reproduction verdict is FAITHFUL.
+
+PROPERTIES-NOT-RUN adds a coverage gap, so a case can ask whether the two
+qualifiers displace one another."
+  (list :status :completed
+        :verified t
+        :selection (list* :mode "contract" :kind :contract :count 1
+                          :selected (list (%symbol-data "PROBE" "WIDEN"))
+                          :source "explicit function argument"
+                          :coverage "Only the contract named."
+                          :properties-not-run-read t
+                          (when properties-not-run
+                            (list :properties-not-run
+                                  (list (%symbol-data "PROBE" "WIDEN-IS-WIDE")))))
+        :results
+        (list (list :property (%symbol-data "PROBE" "WIDEN")
+                    :kind :contract
+                    :status :passed
+                    :trials (list :executed 30 :budget 30
+                                  :budget-source "requested")
+                    :seed "7"
+                    :counterexample-status :not-applicable
+                    :shrink-status :not-applicable
+                    :definition-match faithful))
+        :counts (list :selected 1 :passed 1 :failed 0
+                      :errored 0 :timed-out 0 :not-run 0
+                      :other 0 :by-status '((:passed . 1)))
+        :reproduction-faithful faithful
+        :environment *environment*))
+
+(defun %headline (report)
+  "Return the first line of the text REPORT renders to."
+  (let ((text (first-text (build-spec-check-response report))))
+    (subseq text 0 (or (position #\Newline text) (length text)))))
+
+(deftest check-response-headline-says-when-the-definitions-moved
+  (testing "a pass that did not reproduce the named run says so up front"
+    ;; EXPECT_DEFINITION_DIGEST is an assertion by the caller: this is still
+    ;; the contract I saved.  When it turns out false the run keeps its own
+    ;; verdict -- but a bare "✓ VERIFIED" on the first line is read as
+    ;; confirmation of the saved one, and the reproduction verdict sits
+    ;; several lines under a reader who has already stopped.  The same
+    ;; argument the coverage qualifiers are here for.
+    (let ((headline (%headline (%digest-check-report :false))))
+      (ok (search "VERIFIED" headline))
+      (ok (search "definitions moved" headline))))
+  (testing "a digest that could not be read is not taken for a match"
+    (let ((headline (%headline (%digest-check-report :unknown))))
+      (ok (search "VERIFIED" headline))
+      (ok (search "could not be read" headline))))
+  (testing "a match, and a run with no digest to check, keep the bare headline"
+    (dolist (value '(:true :not-checked))
+      (let ((headline (%headline (%digest-check-report value))))
+        (ok (search "VERIFIED" headline))
+        (ok (not (search "definitions" headline))))))
+  (testing "and it does not displace the coverage qualifier"
+    ;; Two different gaps.  One says what was covered, the other says which
+    ;; revision covered it, and dropping either to make room for the other
+    ;; leaves the headline making a claim the run did not support.
+    (let ((headline (%headline (%digest-check-report :false
+                                                     :properties-not-run t))))
+      (ok (search "contract only" headline))
+      (ok (search "definitions moved" headline)))))
+
+(deftest check-response-says-when-the-contract-itself-signalled
+  (testing "contract-error is a finding about the contract, not the function"
+    ;; CONDITION, POSTCONDITION and RETURN-SPEC all name a half of what was
+    ;; claimed about the function.  CONTRACT-ERROR names the contract's own
+    ;; code signalling, which is a different accusation -- and printed in the
+    ;; same column as the others, the bare word reads as one more way the
+    ;; function broke.
+    (let ((text (first-text (build-spec-check-response
+                             (%contract-check-report
+                              :failure-reason :contract-error
+                              :failure-reason-readable t)))))
+      (ok (search "broken half: contract-error" text))
+      (ok (search "contract's own code" text))
+      (ok (search "NOT about the function" text))))
+  (testing "and a half that really is about the function gets no such gloss"
+    (let ((text (first-text (build-spec-check-response
+                             (%contract-check-report
+                              :failure-reason :postcondition
+                              :failure-reason-readable t)))))
+      (ok (search "broken half: postcondition" text))
+      (ok (not (search "contract's own code" text))))))

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -895,11 +895,14 @@
       (ok (search "refused by :pre" text))
       (ok (not (search "no :pre" text))))))
 
-(defun %digest-check-report (faithful &key properties-not-run)
+(defun %digest-check-report (faithful &key properties-not-run (match faithful))
   "Return a passing contract report whose reproduction verdict is FAITHFUL.
 
 PROPERTIES-NOT-RUN adds a coverage gap, so a case can ask whether the two
-qualifiers displace one another."
+qualifiers displace one another.  MATCH is the result's own verdict, which is
+FAITHFUL except where the two differ: a call answers :UNKNOWN both for a digest
+that could not be read and for a run that never reached a comparison, and only
+the result says which."
   (list :status :completed
         :verified t
         :selection (list* :mode "contract" :kind :contract :count 1
@@ -919,7 +922,7 @@ qualifiers displace one another."
                     :seed "7"
                     :counterexample-status :not-applicable
                     :shrink-status :not-applicable
-                    :definition-match faithful))
+                    :definition-match match))
         :counts (list :selected 1 :passed 1 :failed 0
                       :errored 0 :timed-out 0 :not-run 0
                       :other 0 :by-status '((:passed . 1)))
@@ -946,6 +949,16 @@ qualifiers displace one another."
     (let ((headline (%headline (%digest-check-report :unknown))))
       (ok (search "VERIFIED" headline))
       (ok (search "could not be read" headline))))
+  (testing "and a run that never compared one is not called a disagreement"
+    ;; :UNKNOWN covers two different shortfalls.  A digest that could not be
+    ;; read was looked at; a timeout, an exhausted budget or a signalling run
+    ;; never got that far, and "could not be read" sends the reader to a
+    ;; digest that was never the problem.
+    (let ((headline (%headline (%digest-check-report :unknown
+                                                     :match :not-checked))))
+      (ok (search "VERIFIED" headline))
+      (ok (search "did not get far enough" headline))
+      (ok (not (search "could not be read" headline)))))
   (testing "a match, and a run with no digest to check, keep the bare headline"
     (dolist (value '(:true :not-checked))
       (let ((headline (%headline (%digest-check-report value))))

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -328,3 +328,35 @@ are what a test about the message has to look at."
     (ok (eq :cl-spec (disabled-tool-group "spec-list")))
     (with-cl-spec-group
       (ok (null (disabled-tool-group "spec-list"))))))
+
+(deftest spec-check-description-does-not-call-skipped-unreachable
+  (testing "a status the code emits is not documented as one that cannot occur"
+    ;; The description said the current backend does not produce SKIPPED.  It
+    ;; does: cl-spec's CHECK-FUNCTION returns it for a contract whose :pre
+    ;; refused every generated input, and RUN-PROPERTY for a budget that
+    ;; resolved to zero.  A model told the status cannot happen has no reading
+    ;; for it when it does, and the one reading it must not reach is "passed".
+    (%ensure-tools)
+    (let* ((*use-worker-pool* nil)
+           (*enabled-tool-groups* (list "CL-SPEC"))
+           (response (process-json-line
+                      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
+           (tools (gethash "tools" (gethash "result" (parse response))))
+           (description (loop for tool across tools
+                              when (string= "spec-check" (gethash "name" tool))
+                                return (gethash "description" tool)))
+           (start (search "  skipped " description))
+           (end (search "  pending " description)))
+      (ok start "the description must document the skipped status")
+      (ok (and end (> end start)) "and pending must follow it")
+      (let ((entry (subseq description start end)))
+        (ok (not (search "does not produce" entry)))
+        (ok (search "never called" entry))
+        (ok (search "NOT a pass" entry)))
+      (testing "and pending, which really is unreachable, still says so alone"
+        ;; Its entry read "same.", which is only true while the entry above
+        ;; it says what SKIPPED no longer says.
+        (let* ((pending-end (search "  timeout " description))
+               (entry (subseq description end pending-end)))
+          (ok (search "does not produce" entry))
+          (ok (not (search "same." entry))))))))

--- a/tests/spec-tools-test.lisp
+++ b/tests/spec-tools-test.lisp
@@ -360,3 +360,27 @@ are what a test about the message has to look at."
                (entry (subseq description end pending-end)))
           (ok (search "does not produce" entry))
           (ok (not (search "same." entry))))))))
+
+(deftest spec-check-description-says-when-a-digest-was-never-compared
+  (testing "not-checked and unknown are not documented as one cause each"
+    ;; not-checked has two causes -- no digest was asked for, and a run that
+    ;; never reached a comparison -- and the description named only the first.
+    ;; A caller reading it takes not-checked beside an expect_definition_digest
+    ;; it did pass for a contradiction, and takes the call's unknown for a
+    ;; digest that could not be read when nothing had looked at one.
+    (%ensure-tools)
+    (let* ((*use-worker-pool* nil)
+           (*enabled-tool-groups* (list "CL-SPEC"))
+           (response (process-json-line
+                      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
+           (tools (gethash "tools" (gethash "result" (parse response))))
+           (description (loop for tool across tools
+                              when (string= "spec-check" (gethash "name" tool))
+                                return (gethash "description" tool)))
+           (start (search "definition_match is" description))
+           (end (search "This regenerates the trial sequence" description))
+           (section (subseq description start end)))
+      (ok (search "never reached a comparison" section))
+      (ok (search "reproduction_faithful" section))
+      (testing "and the call-level unknown covers the same shortfall"
+        (ok (search "nothing compared" section))))))


### PR DESCRIPTION
Found by driving the merged adapter through every outcome `check-function` can report — one contract per outcome, against cl-spec's `function-specs` branch. Three of them came back reported in a way a reading model would get wrong.

## 1. `skipped` was documented as a status that cannot occur

`spec-check`'s description said:

> `skipped` — defined by cl-spec; the current backend does not produce it.

It does. cl-spec's `check-function` returns `:skipped` for a contract whose `:pre` refused every generated input, so the function was never called; `run-property` returns it for a budget that resolved to zero. Reproduced with a contract whose `:pre` is unsatisfiable:

```
[1] PROBE::UNSATISFIABLE  skipped
    trials: 200 executed of 200 budget (cl-spec result)
    contract: 200 of them refused by :pre, so the function was called 0 times
```

A status documented as unreachable has no reading when it arrives, and the reading it must not get is "passed" — which is what an unqualified word beside a 200-trial budget invites. `pending`, which really is unreachable, said "same." and now stands alone.

## 2. A headline said `✓ VERIFIED` for a run whose definitions had moved

`expect_definition_digest` is an assertion by the caller — *this is still the contract I saved*. The run's own verdict is not an answer to it, and `reproduction: unfaithful` was the answer, several lines below a reader who stopped at the first.

This is the argument the coverage qualifiers are already here for, so the verdict is carried the same way — beside them, never instead of them:

```
✓ VERIFIED (the definitions moved since the digest given -- this did NOT reproduce that run)
✓ VERIFIED (whether the definitions still match the digest given could not be read)
✓ VERIFIED (contract only -- 1 property about this symbol was NOT run) (the definitions moved since the digest given -- this did NOT reproduce that run)
✓ VERIFIED     <- :true and :not-checked keep the bare headline
```

`:unknown` is qualified too: a digest that could not be read, taken silently for a match, is the same failure in the other direction.

## 3. `broken half: contract-error` named the wrong culprit

`condition`, `postcondition` and `return-spec` each name a half of what was *claimed about the function*. `contract-error` names the contract's own code signalling — a different accusation, printed in the same column and the same words. The condition under it, a `TYPE-ERROR` out of a `:post` form, reads as the function's until something says otherwise.

```
    broken half: contract-error
      The contract's own code signalled while it checked the answer. The condition
      below is a finding about the :pre, :returns or :post form, NOT about the function.
```

## Verification

- Each fix has a test written first and watched fail: `does not produce` still present, no `definitions moved` in the headline, no `contract's own code` in the text.
- Two tests added to `tests/spec-response-builders-test.lisp`, one to `tests/spec-tools-test.lisp`.
- `(asdf:compile-system :cl-mcp :force :all)` in a fresh process — no warnings from either changed file.
- `rove cl-mcp.asd` — **All 63 tests passed**. (The `rove-red` failure inside the run is the deliberately failing scaffold `project-scaffold-test` generates.)
- `mallet` on all four changed files — no problems found.

No cl-spec change is needed for any of these; the adapter already passes `:contract-error` and `unbound-target` through correctly, which is what the end-to-end run was checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfxLmD4pFe3jfKjLsZubjh