### PR TITLE
spec-adapter: preserve versioned cl-spec metadata

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -681,6 +681,20 @@ structured counterexample. cl-mcp does not depend on cl-spec: these tools
 resolve it at call time and report `cl-spec-not-loaded` when it is absent, and
 `unsupported` when the loaded revision lacks the API an operation needs.
 
+With cl-spec's versioned Lisp API, `spec-describe` and completed per-result
+`spec-check` records include `core_schema`. Its integer `schema_version` is
+independent of the adapter's existing string `schema_version`. It carries
+`record_kind`, `entity_kind`, `definition_digest`, `definition_digest_complete`,
+`definition_digest_covers`, and `capabilities` (generation, shrinking,
+instrumentation). An absent or unsupported core schema is `null`.
+The digest covers declarations and registered spec/generator dependencies,
+including whole-argument generators; it excludes target/helper implementations,
+captured/external state and backend settings. Check results use metadata captured
+by cl-spec before execution. Incomplete or unsupported versioned digests remain
+unknown when compared. Only older cl-spec records without a schema version use
+the legacy adapter digest. Capability `available` means generator/shrinker
+construction is supported; it does not guarantee successful draws or reductions.
+
 - `spec-list` — what is registered at all. The entry point when you do not yet
   know a name: the other three all take one you already have. Returns names,
   and for each property its kind, tags, `(:about ...)` targets and docstring —

--- a/src/spec-adapter-core.lisp
+++ b/src/spec-adapter-core.lisp
@@ -43,7 +43,7 @@
            #:printed-for-digest
            #:printed-for-display
            #:print-form-bounded
-           #:definition-digest))
+           #:core-schema-data #:definition-digest))
 
 (in-package #:cl-mcp/src/spec-adapter-core)
 
@@ -89,7 +89,8 @@ the symbol.  Empty on a stub API, where PROGV then binds nothing."
 and fbound for the adapter to report itself usable.")
 
 (defparameter +optional-functions+
-  '((:list-specs . "LIST-SPECS")
+  '((:result-data . "RESULT-DATA")
+     (:list-specs . "LIST-SPECS")
     (:list-properties . "LIST-PROPERTIES")
     (:list-function-specs . "LIST-FUNCTION-SPECS")
     (:properties-with-tag . "PROPERTIES-WITH-TAG")
@@ -629,6 +630,14 @@ followed *PRINT-CASE*, which a digest must not."
                  "|"
                  (symbol-name symbol))))
 
+(defun core-schema-data (data)
+  "Return recognized core metadata, independent of the adapter's JSON schema.
+Absent or unsupported core versions return NIL; they are never inferred."
+  (when (eql 1 (getf data :schema-version))
+    (loop for key in '(:schema-version :record-kind :entity-kind :definition-digest
+                      :definition-digest-complete :definition-digest-covers :capabilities)
+          append (list key (getf data key)))))
+
 (defun definition-digest (api property-name registry
                           &key (property nil property-p)
                                (data-key :property-data))
@@ -674,6 +683,15 @@ than skipped, so the digest still changes if it is defined later."
             (pending '())
             (seen (make-hash-table :test #'eq))
             (specs '()))
+        ;; A versioned core record owns its digest, including incompleteness.
+        ;; Never turn an unknown schema or missing dependency into a legacy match.
+        (when (get-properties property '(:schema-version))
+          (return-from definition-digest
+            (if (and (eql 1 (getf property :schema-version))
+                     (getf property :definition-digest-complete)
+                     (stringp (getf property :definition-digest)))
+                (values (getf property :definition-digest) t)
+                (values nil nil))))
         (dolist (argument (getf property :arguments))
           (setf pending (%collect-spec-references (getf argument :spec) pending)))
         ;; :RETURNS as well, for a function spec.  The contract's own data

--- a/src/spec-adapter-report.lisp
+++ b/src/spec-adapter-report.lisp
@@ -25,7 +25,7 @@
                 #:find-keyword
                 #:symbol-data
                 #:externalize-value
-                #:definition-digest
+                #:core-schema-data #:definition-digest
                 #:printed-for-display
                 #:print-form-bounded)
   (:import-from #:cl-mcp/src/object-registry
@@ -900,7 +900,8 @@ answers."
           ;; place offering one for expect_definition_digest without saying so.
           (multiple-value-bind (digest complete)
               (definition-digest api name registry :property data)
-            (list :status :ok
+            (list :core-schema (core-schema-data data)
+                  :status :ok
                   :kind "function-spec"
                   :name (symbol-data name)
                   :documentation (getf data :documentation)
@@ -934,7 +935,8 @@ answers."
         (%print-bounded-form (getf data :body) max-chars)
       (multiple-value-bind (source source-complete source-omitted)
           (%print-bounded-form (getf data :source-form) max-chars)
-        (list :status :ok
+        (list :core-schema (core-schema-data data)
+              :status :ok
               :kind "property"
               :name (symbol-data name)
               :property-kind (getf data :kind)
@@ -967,7 +969,8 @@ answers."
   (let ((data (funcall (api-fn api :spec-data) name :registry registry)))
     (multiple-value-bind (source complete omitted)
         (%print-bounded-form (getf data :source-form) max-chars)
-      (list :status :ok
+      (list :core-schema (core-schema-data data)
+            :status :ok
             :kind "spec"
             :name (symbol-data name)
             :spec (%spec-tree data)
@@ -1801,7 +1804,15 @@ legitimately empty, and cl-spec reports it as NIL -- exactly what a run that
 never reached a verdict also reports.  Reading one as the other is how a
 consumer ends up believing a timeout produced a counterexample with no
 arguments, or that a failure was somehow argument-free."
-  (let* ((status (funcall (api-fn api :result-status) result))
+  (let* ((core-data (when (api-has-p api :result-data)
+                      (funcall (api-fn api :result-data) result)))
+         (core-schema (core-schema-data core-data))
+         (digest (if core-data
+                     (multiple-value-bind (value complete)
+                         (definition-digest api name nil :property core-data)
+                       (list :value value :complete complete :covers (getf digest :covers)))
+                     digest))
+         (status (funcall (api-fn api :result-status) result))
          (counterexample (funcall (api-fn api :result-counterexample) result))
          (shrunk (funcall (api-fn api :result-shrunk-counterexample) result))
          (condition (funcall (api-fn api :result-condition) result))
@@ -1810,7 +1821,8 @@ arguments, or that a failure was somehow argument-free."
          (zero-argument-property (eql 0 argument-count))
          (executed (funcall (api-fn api :result-trials) result))
          (verdict (member status '(:failed :error))))
-    (list :property (symbol-data name)
+    (list :core-schema core-schema
+          :property (symbol-data name)
           :kind kind
           :contract (when (eq kind :contract)
                       (%contract-plist api result executed max-value-chars

--- a/src/tools/spec-response-builders.lisp
+++ b/src/tools/spec-response-builders.lisp
@@ -486,6 +486,22 @@ preconditions_complete.  Absent has to reach the consumer as null."
       (unless (eq :not-applicable (getf report key))
         (json-bool (getf report key))))))
 
+(defun %core-schema-ht (data)
+  "Render the supported Lisp core schema independently of MCP's envelope version."
+  (when data
+    (let ((capabilities (getf data :capabilities)))
+      (make-ht "schema_version" (getf data :schema-version)
+               "record_kind" (%keyword-string (getf data :record-kind))
+               "entity_kind" (%keyword-string (getf data :entity-kind))
+               "definition_digest" (getf data :definition-digest)
+               "definition_digest_complete" (json-bool (getf data :definition-digest-complete))
+               "definition_digest_covers" (%keyword-string (getf data :definition-digest-covers))
+               "capabilities"
+               (make-ht "generation" (%keyword-string (getf capabilities :generation))
+                        "shrinking" (%keyword-string (getf capabilities :shrinking))
+                        "instrumentation" (%keyword-string
+                                           (getf capabilities :instrumentation)))))))
+
 (defun build-spec-describe-response (report)
   "Return the MCP response for a DESCRIBE-REPORT plist."
   (case (getf report :status)
@@ -530,6 +546,7 @@ preconditions_complete.  Absent has to reach the consumer as null."
               "source_form_complete" (%optional-bool report :source-form-complete)
               "source_form_omitted_chars" (getf report :source-form-omitted-chars)
               "source_location" (%source-location-ht (getf report :source-location))
+              "core_schema" (%core-schema-ht (getf report :core-schema))
               "definition_digest" (getf report :definition-digest)
               "definition_digest_complete" (%optional-bool
                                             report :definition-digest-complete)
@@ -651,6 +668,7 @@ not be read."
            "elapsed" (getf result :elapsed)
            "timeout_seconds" (getf result :timeout-seconds)
            "thread_leaked" (json-bool (getf result :thread-leaked))
+           "core_schema" (%core-schema-ht (getf result :core-schema))
            "definition_digest" (getf result :definition-digest)
            "definition_digest_covers" (%keyword-string
                                        (getf result :definition-digest-covers))

--- a/tests/spec-adapter-core-test.lisp
+++ b/tests/spec-adapter-core-test.lisp
@@ -28,6 +28,22 @@
 
 (in-package #:cl-mcp/tests/spec-adapter-core-test)
 
+(deftest core-digests-take-precedence-without-legacy-fallback
+  (let ((api (make-cl-spec-api)))
+    (multiple-value-bind (digest complete)
+        (definition-digest api 'sample nil
+                           :property '(:schema-version 1 :definition-digest "core"
+                                       :definition-digest-complete t))
+      (ok (equal "core" digest))
+      (ok complete))
+    (dolist (data '((:schema-version 1 :definition-digest nil :definition-digest-complete nil)
+                    (:schema-version 99 :definition-digest "future"
+                     :definition-digest-complete t)))
+      (multiple-value-bind (digest complete)
+          (definition-digest api 'sample nil :property data)
+        (ok (null digest))
+        (ok (null complete))))))
+
 (defun %ensure-fixture-packages ()
   "Create two packages that both export a symbol named FOO.
 Same name, different home package: the pair a resolver must not confuse."

--- a/tests/spec-adapter-report-test.lisp
+++ b/tests/spec-adapter-report-test.lisp
@@ -24,6 +24,28 @@
 
 (in-package #:cl-mcp/tests/spec-adapter-report-test)
 
+(deftest result-digest-uses-captured-core-metadata
+  (let* ((data '(:schema-version 1 :record-kind :result :entity-kind :property
+                 :definition-digest "captured" :definition-digest-complete t))
+         (api (make-cl-spec-api
+               :functions
+               (list :result-data (constantly data)
+                     :result-status (constantly :passed)
+                     :result-counterexample (constantly nil)
+                     :result-shrunk-counterexample (constantly nil)
+                     :result-condition (constantly nil)
+                     :result-seed (constantly 42)
+                     :result-trials (constantly 1)
+                     :result-profile (constantly :normal)
+                     :result-elapsed (constantly 0))))
+         (report (cl-mcp/src/spec-adapter-report::%result-plist
+                  api nil 'sample :property nil
+                  '(:value "before-run" :complete t :covers :property)
+                  "captured" 100 nil)))
+    (ok (equal "captured" (getf report :definition-digest)))
+    (ok (eq :true (getf report :definition-match)))
+    (ok (eq :result (getf (getf report :core-schema) :record-kind)))))
+
 (define-condition fixture-unknown-name (error)
   ()
   (:report (lambda (condition stream)

--- a/tests/spec-integration-test.lisp
+++ b/tests/spec-integration-test.lisp
@@ -164,6 +164,60 @@ reached the caller."
         (gethash "text" (aref content 0))
         "")))
 
+(deftest real-function-core-schema-survives-check
+  (if (or (not (%contracts-available-p))
+          (not (find-symbol "SCHEMA-INFO" "CL-SPEC")))
+      (skip "This integration check needs the versioned Function Spec schema.")
+      (with-fixture-registry
+        (let* ((name (%fixture-name "WIDEN"))
+               (description (spec-describe-response
+                             (make-ht "kind" "function-spec" "name" name)))
+               (definition (gethash "core_schema" description))
+               (checked (spec-check-response
+                         (make-ht "function" name "seed" "42" "trials" 1)))
+               (result (%first-result checked))
+               (metadata (gethash "core_schema" result)))
+          (ok (hash-table-p definition))
+          (ok (hash-table-p metadata))
+          (when (and definition metadata)
+            (ok (equal "function-spec" (gethash "entity_kind" metadata)))
+            (ok (equal "result" (gethash "record_kind" metadata)))
+            (ok (equal (gethash "definition_digest" definition)
+                       (gethash "definition_digest" metadata))))
+          (ok (equal (gethash "definition_digest" description)
+                     (gethash "definition_digest" result)))))))
+
+(deftest real-core-schema-survives-describe-and-check
+  (if (or (not (%cl-spec-available-p))
+          (not (find-symbol "SCHEMA-INFO" "CL-SPEC")))
+      (skip "This integration check needs cl-spec's versioned core schema.")
+      (progn
+        (%ensure-fixture)
+        (with-fixture-registry
+          (let* ((name (%fixture-name "CLAMP-IS-IDEMPOTENT"))
+                 (description (spec-describe-response
+                               (make-ht "kind" "property" "name" name)))
+                 (definition (gethash "core_schema" description))
+                 (checked (spec-check-response (make-ht "property" name "seed" "42")))
+                 (result (%first-result checked))
+                 (metadata (gethash "core_schema" result)))
+            (ok (hash-table-p definition))
+            (ok (hash-table-p metadata))
+            (when (and definition metadata)
+              (ok (equal "definition" (gethash "record_kind" definition)))
+              (ok (equal "result" (gethash "record_kind" metadata)))
+              (ok (equal "property" (gethash "entity_kind" metadata)))
+              (ok (equal (gethash "definition_digest" definition)
+                         (gethash "definition_digest" metadata))))
+            (ok (equal (gethash "definition_digest" description)
+                       (gethash "definition_digest" result))))
+          (let* ((description (spec-describe-response
+                               (make-ht "kind" "spec" "name" (%fixture-name "SMALL-INT"))))
+                 (metadata (gethash "core_schema" description)))
+            (ok (hash-table-p metadata))
+            (when metadata
+              (ok (equal "spec" (gethash "entity_kind" metadata)))))))))
+
 (deftest cl-spec-adapter-discovers-and-describes
   (if (not (%cl-spec-available-p))
       (skip +skip-reason+)

--- a/tests/spec-response-builders-test.lisp
+++ b/tests/spec-response-builders-test.lisp
@@ -20,6 +20,23 @@
 
 (in-package #:cl-mcp/tests/spec-response-builders-test)
 
+(deftest core-schema-is-distinct-from-mcp-schema
+  (let* ((metadata '(:schema-version 1 :record-kind :definition :entity-kind :spec
+                     :definition-digest "core" :definition-digest-complete t
+                     :definition-digest-covers :declaration-and-registered-dependencies
+                     :capabilities (:generation :available :shrinking :none
+                                    :instrumentation :unavailable)))
+         (response (build-spec-describe-response
+                    (list :status :ok :kind "spec" :core-schema metadata)))
+         (core (gethash "core_schema" response)))
+    (ok (equal "1" (gethash "schema_version" response)))
+    (ok (hash-table-p core))
+    (when core
+      (ok (eql 1 (gethash "schema_version" core)))
+      (ok (equal "spec" (gethash "entity_kind" core)))
+      (ok (equal "core" (gethash "definition_digest" core)))
+      (ok (equal "none" (gethash "shrinking" (gethash "capabilities" core)))))))
+
 (defun first-text (response)
   "Pull the text of the first content part out of RESPONSE, or NIL."
   (let ((content (gethash "content" response)))


### PR DESCRIPTION
The adapter now preserves cl-spec's versioned definition and result metadata through `spec-describe` and `spec-check`. Check results prefer the digest captured by cl-spec before execution, rather than replacing it with a separately read definition.

Adds a nested `core_schema` object while retaining the existing MCP JSON schema version and legacy fields. Supported core digests are authoritative; incomplete or unsupported versioned records remain incomparable. Records from older cl-spec versions still use the legacy adapter digest. There is no new hard dependency on cl-spec.

Companion core PR: https://github.com/masatoi/cl-spec/pull/4 (core specification §38.1). This adapter is compatible with older cl-spec; the new metadata becomes available when the core change is loaded.

Validation:
- `rove cl-mcp.asd`: exit 0, all 63 suite groups passed.
- Adapter core/report/response-builder/integration suites: 23/48/29/7 passed, 107 total.
- Real integration covers both property and Function Spec metadata through describe/check JSON responses.
- `mallet` on changed Lisp files and `git diff --check`: passed.
